### PR TITLE
Create 2 availability zones for VPC as this is requirement for DocumentDB

### DIFF
--- a/terragrunt/aws/network/vpc.tf
+++ b/terragrunt/aws/network/vpc.tf
@@ -8,6 +8,9 @@ module "ai_answers_vpc" {
   name              = var.product_name
   billing_tag_value = var.billing_tag_value
 
+  # Enable 2 aviablity zones for subnets as this is requirement for the DocumentDB database
+  availability_zones = 2
+
   # Enables VPC flow logs and blocks ssh and rdp traffic
   enable_flow_log = true
   block_ssh       = true


### PR DESCRIPTION

# Summary | Résumé

The documentDB database needs to have at least 2 subnets and at least 2 availability zones. This change would accomplish this. 
