### PR TITLE
Adding terraform code for iam roles, default tags and openai api key secret

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -1,4 +1,4 @@
-name: "Terraform apply staging"
+name: 'Terraform apply staging'
 
 on:
   workflow_dispatch:
@@ -6,9 +6,9 @@ on:
     branches:
       - main
     paths:
-      - "terragrunt/**"
-      - "!terragrunt/env/staging/**"
-      - ".github/workflows/tf_apply_staging.yml"
+      - 'terragrunt/**'
+      - '!terragrunt/env/staging/**'
+      - '.github/workflows/tf_apply_staging.yml'
 
 env:
   AWS_REGION: ca-central-1
@@ -16,6 +16,7 @@ env:
   TERRAGRUNT_VERSION: 0.72.3
   TF_VAR_docdb_username: ${{ secrets.DOCDB_USERNAME}}
   TF_VAR_docdb_password: ${{ secrets.DOCDB_PASSWORD}}
+  TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY}}
 
 permissions:
   id-token: write
@@ -60,4 +61,8 @@ jobs:
 
       - name: Apply database
         working-directory: terragrunt/env/staging/database
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply iam
+        working-directory: terragrunt/env/staging/iam
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -1,12 +1,12 @@
-name: "Terraform plan staging"
+name: 'Terraform plan staging'
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "terragrunt/**"
-      - "!terragrunt/env/staging/**"
-      - ".github/workflows/tf_plan_staging.yml"
+      - 'terragrunt/**'
+      - '!terragrunt/env/staging/**'
+      - '.github/workflows/tf_plan_staging.yml'
 
 env:
   AWS_REGION: ca-central-1
@@ -14,6 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.72.3
   TF_VAR_docdb_username: ${{ secrets.DOCDB_USERNAME}}
   TF_VAR_docdb_password: ${{ secrets.DOCDB_PASSWORD}}
+  TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY}}
 
 permissions:
   id-token: write
@@ -34,6 +35,7 @@ jobs:
           - module: network
           - module: hosted_zone
           - module: database
+          - module: iam
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,7 +55,7 @@ jobs:
         uses: cds-snc/terraform-plan@v3.2.2
         with:
           comment-delete: true
-          comment-title: "Staging: ${{ matrix.module }}"
+          comment-title: 'Staging: ${{ matrix.module }}'
           directory: ./terragrunt/env/staging/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true

--- a/terragrunt/aws/iam/iam.tf
+++ b/terragrunt/aws/iam/iam.tf
@@ -1,0 +1,57 @@
+# IAM Role definitions
+
+# Policy for ECS task role
+data "aws_iam_policy_document" "ai-answers-ecs-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ai-answers-ssm-policy" {
+  statement {
+    sid    = "AllowSSMParameterAccess"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath"
+    ]
+    resources = [
+      var.docdb_password_arn,
+      var.docdb_username_arn,
+      var.openai_api_key_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ai-answers-ssm-policy" {
+  name        = "ai-answers-ssm-policy"
+  description = "Policy for AI Answers to access SSM parameters"
+  policy      = data.aws_iam_policy_document.ai-answers-ssm-policy.json
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_iam_role" "ai-answers-ecs-role" {
+  name               = "ai-answers-ecs-role"
+  assume_role_policy = data.aws_iam_policy_document.ai-answers-ecs-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "ai-answers-ecs-policy" {
+  role       = aws_iam_role.ai-answers-ecs-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_policy_attachment" "ai-answers-ssm-policy" {
+  name       = "ai-answers-ssm-policy"
+  policy_arn = aws_iam_policy.ai-answers-ssm-policy.arn
+  roles      = [aws_iam_role.ai-answers-ecs-role.name]
+}

--- a/terragrunt/aws/iam/inputs.tf
+++ b/terragrunt/aws/iam/inputs.tf
@@ -1,0 +1,14 @@
+variable "openai_api_key_arn" {
+  description = "The arn of the openai api key parameter"
+  type        = string
+}
+
+variable "docdb_username_arn" {
+  description = "The arn of the document db username parameter"
+  type        = string
+}
+
+variable "docdb_password_arn" {
+  description = "The arn of the document db password parameter"
+  type        = string
+}

--- a/terragrunt/aws/iam/outputs.tf
+++ b/terragrunt/aws/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "iam_role_ai-answers-ecs-role_arn" {
+  description = "The ARN of the IAM role for the AI Answers ECS task"
+  value       = aws_iam_role.ai-answers-ecs-role.arn
+}

--- a/terragrunt/aws/ssm/inputs.tf
+++ b/terragrunt/aws/ssm/inputs.tf
@@ -9,3 +9,9 @@ variable "docdb_password" {
   sensitive   = true
   type        = string
 }
+
+variable "openai_api_key" {
+  description = "The openai api key"
+  sensitive   = true
+  type        = string
+}

--- a/terragrunt/aws/ssm/outputs.tf
+++ b/terragrunt/aws/ssm/outputs.tf
@@ -17,3 +17,8 @@ output "docdb_username_name" {
   description = "The document db username"
   value       = aws_ssm_parameter.docdb_username.name
 }
+
+output "openai_api_key_arn" {
+  description = "Arm of he openai api key parameter"
+  value       = aws_ssm_parameter.openai_api_key.arn
+}

--- a/terragrunt/aws/ssm/ssm.tf
+++ b/terragrunt/aws/ssm/ssm.tf
@@ -19,3 +19,9 @@ resource "aws_ssm_parameter" "docdb_password" {
     Terraform  = true
   }
 }
+
+resource "aws_ssm_parameter" "openai_api_key" {
+  name  = "openai_api_key"
+  type  = "SecureString"
+  value = var.openai_api_key
+}

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -37,3 +37,8 @@ variable "billing_tag_value" {
   description = "The value we use to track billing"
   type        = string
 }
+
+variable "default_tags" {
+  description = "The default tags we apply to all resources"
+  type        = map(string)
+}

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -10,10 +10,18 @@ terraform {
 provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]
+  # add default tags to all resources at creation or update
+  default_tags {
+    tags = var.default_tags
+  }
 }
 
 provider "aws" {
   alias               = "us-east-1"
   region              = "us-east-1"
   allowed_account_ids = [var.account_id]
+  # add default tags to all resources at creation or update
+  default_tags {
+    tags = var.default_tags
+  }
 }

--- a/terragrunt/env/root.hcl
+++ b/terragrunt/env/root.hcl
@@ -13,6 +13,10 @@ inputs = {
   billing_code              = "${local.vars.inputs.cost_center_code}"
   billing_tag_value         = "${local.vars.inputs.cost_center_code}"
   cbs_satellite_bucket_name = "cbs-satellite-${local.vars.inputs.account_id}"
+  default_tags              = {
+    CostCentre = "${local.vars.inputs.cost_center_code}"
+    Terraform  = true
+  }
 }
 
 generate "provider" {

--- a/terragrunt/env/staging/iam/.terraform.lock.hcl
+++ b/terragrunt/env/staging/iam/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.86.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:dVxrQ67Ikqv/1/rfopK/wvCdETlUbQ6ZFuNOH+vEWqs=",
+    "zh:1587c6a0199dc33d066c13e1628bc0dd966d7d6740cb2007b636524a3ec99430",
+    "zh:15af46cc5bb43a37c24438cb3a36d44209a89d923ea4d4d631b56b1a89717b26",
+    "zh:166902101ac1cc8ec4f53e3bdcbab2eac7eb448b1c428c2e622adbf9ce1a679c",
+    "zh:284d116ac9d4a4de74cd1f52486f00e10bc400d9654f92a8990ea0093c43ff78",
+    "zh:4135e928f20d456172c8ab4ae3d4d8e411b6feddc94aaa1347c92469d52f1e61",
+    "zh:72b317d17182c3e0ee72f2851d25565d369cb6ee803b12adc9b6c6d3dbfca8d7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9dd0e80964e215ff658b708be72ccda8a20f63af7eaebdd6f11eb0461633bb03",
+    "zh:a18e502c16b7b6b216b888eab9a5c66b1ed103847fce6985850e4fc9e364a3e8",
+    "zh:c239f12648d7f7bbadbf5db0b57aaa9429abe70b574975b581784b4f17b7ed79",
+    "zh:c5164ca8254b9973ee985a3841a4b1f776844c7dcbc112ab3a88a0096e7e2198",
+    "zh:d93ac58092c3fffc5ddc688b39721fbfacc353e8965001060a5a1ce934d97246",
+    "zh:e877f1be2ebe67a2d163b7488f47cff4c95aca9c541ddfa25ad16c6ecc98f6a8",
+    "zh:eb71af6dfdd2b5670b5b957397a576d6053587c75750c17acc105fb44ed806eb",
+    "zh:ff6aa4f88f8e789375391bc8c886c636fb3e4a45a3fd7dc291bca17c2b8d4184",
+  ]
+}

--- a/terragrunt/env/staging/iam/terragrunt.hcl
+++ b/terragrunt/env/staging/iam/terragrunt.hcl
@@ -1,0 +1,28 @@
+terraform {
+  source = "../../../aws//iam"
+}
+
+dependencies {
+  paths = ["../ssm"]
+}
+
+dependency "ssm" {
+  config_path                             = "../ssm"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs                            = {
+                                            docdb_username_arn = ""
+                                            docdb_password_arn = ""
+                                            openai_api_key_arn = ""
+                                          }
+}
+
+inputs = {
+  docdb_password_arn    = dependency.ssm.outputs.docdb_password_arn
+  docdb_username_arn    = dependency.ssm.outputs.docdb_username_arn
+  openai_api_key_arn    = dependency.ssm.outputs.openai_api_key_arn
+} 
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}


### PR DESCRIPTION
# Summary | Résumé

The following changes were done:
- Added terraform code for IAM roles for ECS 
- Gave permission of the ECS task to read the secrets
- Added default tags to input tags when resources are created or updated
- Added a new ssm parameter for the openai API key. 
