### PR TITLE
Adding hosted zone name to the outputs

### DIFF
--- a/terragrunt/aws/hosted_zone/outputs.tf
+++ b/terragrunt/aws/hosted_zone/outputs.tf
@@ -2,3 +2,8 @@ output "hosted_zone_id" {
   description = "Route53 hosted zone ID that will hold our DNS records"
   value       = aws_route53_zone.ai_answers.zone_id
 }
+
+output "hosted_zone_name" {
+  description = "Route53 hosted zone name that will hold our DNS records"
+  value       = aws_route53_zone.ai_answers.name
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the hosted zone name as an output since it will be used by the load balancer. 
