### PR TITLE
Adding the security group id as output for the DocumentDB 

### DIFF
--- a/terragrunt/aws/database/outputs.tf
+++ b/terragrunt/aws/database/outputs.tf
@@ -9,6 +9,6 @@ output "aws_docdb_cluster_arn" {
 }
 
 output "aws_docdb_security_group_id" {
-  description = "The security group id"
+  description = "The security group id of the document db database"
   value       = aws_security_group.ai-answers-docdb-sg.id
 }

--- a/terragrunt/aws/database/outputs.tf
+++ b/terragrunt/aws/database/outputs.tf
@@ -7,3 +7,8 @@ output "aws_docdb_cluster_arn" {
   description = "The document db cluster arn"
   value       = aws_docdb_cluster.ai-answers-docdb-cluster.arn
 }
+
+output "aws_docdb_security_group_id" {
+  description = "The security group id"
+  value       = aws_security_group.ai-answers-docdb-sg.id
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the security Group ID for the DocumentDB database as output. It is needed for ECS. 
