### PR TITLE
Add Canada.ca search API integration

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -19,6 +19,8 @@ env:
   TF_VAR_azure_openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY}}
   TF_VAR_azure_openai_endpoint: ${{ secrets.AZURE_OPENAI_ENDPOINT}}
   TF_VAR_azure_openai_api_version: ${{ secrets.AZURE_OPENAI_API_VERSION}}
+  TF_VAR_canada_ca_search_uri: ${{ secrets.CANADA_CA_SEARCH_URI}}
+  TF_VAR_canada_ca_search_api_key: ${{ secrets.CANADA_CA_SEARCH_API_KEY}}
   TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -17,6 +17,8 @@ env:
   TF_VAR_azure_openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY}}
   TF_VAR_azure_openai_endpoint: ${{ secrets.AZURE_OPENAI_ENDPOINT}}
   TF_VAR_azure_openai_api_version: ${{ secrets.AZURE_OPENAI_API_VERSION}}
+  TF_VAR_canada_ca_search_uri: ${{ secrets.CANADA_CA_SEARCH_URI}}
+  TF_VAR_canada_ca_search_api_key: ${{ secrets.CANADA_CA_SEARCH_API_KEY}}
   TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 

--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -6,11 +6,11 @@ locals {
     },
     {
       "name"      = "CANADA_CA_SEARCH_URI"
-      "valueFrom" = var.canada_ca_search_uri
+      "valueFrom" = var.canada_ca_search_uri_arn
     },
     {
       "name"      = "CANADA_CA_SEARCH_API_KEY"
-      "valueFrom" = var.canada_ca_search_api_key
+      "valueFrom" = var.canada_ca_search_api_key_arn
     },
     {
       "name"      = "AZURE_OPENAI_API_KEY"

--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -9,7 +9,7 @@ locals {
       "valueFrom" = var.canada_ca_search_uri
     },
     {
-       "name"      = "CANADA_CA_SEARCH_API_KEY"
+      "name"      = "CANADA_CA_SEARCH_API_KEY"
       "valueFrom" = var.canada_ca_search_api_key
     },
     {

--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -5,6 +5,14 @@ locals {
       "valueFrom" = var.docdb_uri_arn
     },
     {
+      "name"      = "CANADA_CA_SEARCH_URI"
+      "valueFrom" = var.canada_ca_search_uri
+    },
+    {
+       "name"      = "CANADA_CA_SEARCH_API_KEY"
+      "valueFrom" = var.canada_ca_search_api_key
+    },
+    {
       "name"      = "AZURE_OPENAI_API_KEY"
       "valueFrom" = var.azure_openai_api_key_arn
     },

--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -90,3 +90,13 @@ variable "azure_openai_api_version_arn" {
   description = "ARN of the Azure OpenAI API version parameter"
   type        = string
 }
+
+variable "canada_ca_search_uri_arn" {
+  description = "ARN of the Canada.ca search URI parameter"
+  type        = string
+}
+
+variable "canada_ca_search_api_key_arn" {
+  description = "ARN of the Canada.ca search API key parameter"
+  type        = string
+}

--- a/terragrunt/aws/iam/iam.tf
+++ b/terragrunt/aws/iam/iam.tf
@@ -27,6 +27,8 @@ data "aws_iam_policy_document" "ai-answers-ssm-policy" {
       var.azure_openai_api_key_arn,
       var.azure_openai_endpoint_arn,
       var.azure_openai_api_version_arn,
+      var.canada_ca_search_uri_arn,
+      var.canada_ca_search_api_key_arn,
       var.docdb_uri_arn
     ]
   }

--- a/terragrunt/aws/iam/inputs.tf
+++ b/terragrunt/aws/iam/inputs.tf
@@ -13,6 +13,14 @@ variable "azure_openai_api_version_arn" {
   type        = string
 }
 
+variable "canada_ca_search_uri_arn" {
+  description = "The arn of the canada search uri parameter"
+  type        = string
+}
+variable "canada_ca_search_api_key_arn" {
+  description = "The arn of the canada search api parameter"
+  type        = string
+}
 variable "docdb_username_arn" {
   description = "The arn of the document db username parameter"
   type        = string

--- a/terragrunt/aws/ssm/inputs.tf
+++ b/terragrunt/aws/ssm/inputs.tf
@@ -28,3 +28,15 @@ variable "azure_openai_api_version" {
   type        = string
   default     = "2024-06-01"
 }
+
+variable "canada_ca_search_uri" {
+  description = "The URI of the Canada.ca search API"
+  sensitive   = true
+  type        = string
+}
+
+variable "canada_ca_search_api_key" {
+  description = "The API key of the Canada.ca search API"
+  sensitive   = true
+  type        = string
+}

--- a/terragrunt/aws/ssm/outputs.tf
+++ b/terragrunt/aws/ssm/outputs.tf
@@ -32,3 +32,13 @@ output "azure_openai_api_version_arn" {
   description = "ARN of the Azure OpenAI API version parameter"
   value       = aws_ssm_parameter.azure_openai_api_version.arn
 }
+
+output "canada_ca_search_uri_arn" {
+  description = "ARN of the Canada.ca search URI parameter"
+  value       = aws_ssm_parameter.canada_ca_search_uri.arn
+}
+
+output "canada_ca_search_api_key_arn" {
+  description = "ARN of the Canada.ca search API key parameter"
+  value       = aws_ssm_parameter.canada_ca_search_api_key.arn
+}

--- a/terragrunt/aws/ssm/ssm.tf
+++ b/terragrunt/aws/ssm/ssm.tf
@@ -37,3 +37,15 @@ resource "aws_ssm_parameter" "azure_openai_api_version" {
   type  = "SecureString"
   value = var.azure_openai_api_version
 }
+
+resource "aws_ssm_parameter" "canada_ca_search_uri" {
+  name  = "canada_ca_search_uri"
+  type  = "SecureString"
+  value = var.canada_ca_search_uri
+}
+
+resource "aws_ssm_parameter" "canada_ca_search_api_key" {
+  name  = "canada_ca_search_api_key"
+  type  = "SecureString"
+  value = var.canada_ca_search_api_key
+}

--- a/terragrunt/env/staging/ecs/terragrunt.hcl
+++ b/terragrunt/env/staging/ecs/terragrunt.hcl
@@ -69,6 +69,8 @@ dependency "ssm" {
     azure_openai_api_key_arn     = ""
     azure_openai_endpoint_arn    = ""
     azure_openai_api_version_arn = ""
+    canada_ca_search_uri_arn     = ""
+    canada_ca_search_api_key_arn = ""
   }
 }
 
@@ -87,6 +89,8 @@ inputs = {
   azure_openai_api_key_arn         = dependency.ssm.outputs.azure_openai_api_key_arn
   azure_openai_endpoint_arn        = dependency.ssm.outputs.azure_openai_endpoint_arn
   azure_openai_api_version_arn     = dependency.ssm.outputs.azure_openai_api_version_arn
+  canada_ca_search_uri_arn         = dependency.ssm.outputs.canada_ca_search_uri_arn
+  canada_ca_search_api_key_arn     = dependency.ssm.outputs.canada_ca_search_api_key_arn
 }
 
 include {

--- a/terragrunt/env/staging/iam/terragrunt.hcl
+++ b/terragrunt/env/staging/iam/terragrunt.hcl
@@ -16,6 +16,8 @@ dependency "ssm" {
     azure_openai_api_key_arn     = ""
     azure_openai_endpoint_arn    = ""
     azure_openai_api_version_arn = ""
+    canada_ca_search_api_key_arn = ""
+    canada_ca_search_uri_arn     = ""
   }
 }
 
@@ -35,6 +37,8 @@ inputs = {
   azure_openai_endpoint_arn    = dependency.ssm.outputs.azure_openai_endpoint_arn
   azure_openai_api_version_arn = dependency.ssm.outputs.azure_openai_api_version_arn
   docdb_uri_arn                = dependency.database.outputs.docdb_uri_arn
+  canada_ca_search_api_key_arn = dependency.ssm.outputs.canada_ca_search_api_key_arn
+  canada_ca_search_uri_arn     = dependency.ssm.outputs.canada_ca_search_uri_arn
 }
 
 include {


### PR DESCRIPTION
added support for the Canada.ca search API.  This includes defining the API key and URI variables, updating the IAM role to grant access to these parameters, and modifying the workflow files to include the new secrets.