### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         id: sre-app-token
         with:
-          app-id: ${{ secrets.SRE_BOT_RW_APP_ID }}
-          private-key: ${{ secrets.SRE_BOT_RW_PRIVATE_KEY }}
+          app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:


### PR DESCRIPTION
# Summary
Update the release please workflow to use a new, dedicated GitHub app for releases.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707