### PR TITLE
fix: update Dockerfile to install only production dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Copy package files and install dependencies
 COPY package.json package-lock.json ./
-RUN npm install
+RUN npm install --production
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
# Summary | Résumé

Remove SRE notice by not installing dev dependencies

---

This needs to be done to not install the dev dependencies from packages.json
mongodb-memory-server will not be installed and attempt to download binaries.


# Test instructions | Instructions pour tester la modification



---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
