### PR TITLE
fix: configure environment-specific CPU and memory resources

### DIFF
--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -26,13 +26,13 @@ variable "ecr_repository_url" {
 variable "fargate_cpu" {
   description = "Fargate CPU units"
   type        = number
-  default     = 2048 # Increased from 256 (4x) for performance testing
+  default     = 256
 }
 
 variable "fargate_memory" {
   description = "Fargate Memory units"
   type        = number
-  default     = 8192 # Increased from 512 (4x) for performance testing
+  default     = 2048
 }
 
 variable "iam_role_ai-answers-ecs-role_arn" {

--- a/terragrunt/env/production/ecs/terragrunt.hcl
+++ b/terragrunt/env/production/ecs/terragrunt.hcl
@@ -101,6 +101,8 @@ inputs = {
   jwt_secret_key_arn               = dependency.ssm.outputs.jwt_secret_key_arn
   google_api_key_arn               = dependency.ssm.outputs.google_api_key_arn
   google_search_engine_id_arn      = dependency.ssm.outputs.google_search_engine_id_arn
+  fargate_cpu                      = 2048  # Override default for production
+  fargate_memory                   = 8000  # Override default for production
 }
 
 include {


### PR DESCRIPTION
- Maintain staging with 256 CPU and 2048 memory (default values)
- Increase production to 2048 CPU and 8000 memory for better performance
