### PR TITLE
fix:single-word-name pattern removed

### DIFF
--- a/src/services/RedactionService.js
+++ b/src/services/RedactionService.js
@@ -328,11 +328,11 @@ class RedactionService {
         pattern: /(?<=\b(name:|nom:)\s+)([A-Za-z]+(?:\s+[A-Za-z]+)?)\b/gi,
         description: 'Name patterns in EN/FR'
       },
-      {
-        // Names in "name [Name]" format (missing "is" - common for non-English speakers)
-        pattern: /\b(?:name|nom)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b/gi,
-        description: 'Names in incomplete introduction phrases'
-      },
+      // REMOVED: Names in "name [Name]" format pattern - was too broad and caught legitimate questions about name changes
+      // {
+      //   pattern: /\b(?:name|nom)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b/gi,
+      //   description: 'Names in incomplete introduction phrases'
+      // },
       {
         // Names in signature patterns
         // pattern: /\b(?:Sincerely|Regards|Best|Cheers|Cordialement|Sincèrement|Amicalement)\s*,\s*\n*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b/gi,


### PR DESCRIPTION
Was catching the word 'name' anywhere in the sentence. 

# Summary | Résumé

Was fixing that 'my name is' wasn't being caught, but went overboard. Had to remove the pattern just catching the word 'name' because that word is used in many legit questions about name changes. 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
