### PR TITLE
fix:add-emoji-stripping-to-redactionService

### DIFF
--- a/src/services/RedactionService.js
+++ b/src/services/RedactionService.js
@@ -416,6 +416,11 @@ class RedactionService {
       });
     });
 
+    // Strip emojis from the redacted text
+    // Simple emoji regex that covers most common emojis
+    const emojiRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{FE00}-\u{FE0F}]|[\u{1F3FB}-\u{1F3FF}]/gu;
+    redactedText = redactedText.replace(emojiRegex, '').trim();
+
     return { redactedText, redactedItems };
   }
 }


### PR DESCRIPTION


# Summary | Résumé

> strip emojis from questions - waste of input tokens and confusing to see flags for evaluators. Users will see emojis have been stripped. happens in RedactionService after any redactions. 
---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
