### PR TITLE
fix: correct typo in SAN entries for production environment

### DIFF
--- a/terragrunt/env/production/env_vars.hcl
+++ b/terragrunt/env/production/env_vars.hcl
@@ -3,5 +3,5 @@ inputs = {
   env              = "production"
   cost_center_code = "ai-answers-prod"
   domain           = "ai-answers.alpha.canada.ca"
-  san              = ["*.ai-answers.alpha.canada.ca", "responses-ai.alpha.canada.ca"]
+  san              = ["*.ai-answers.alpha.canada.ca", "reponses-ia.alpha.canada.ca"]
 }


### PR DESCRIPTION
Made a typo in French URL, this fixes it.
