### PR TITLE
Fix send referring url to search agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ temp.jsonl
 
 # Ignore memory files
 copilot/remember.md
+CLAUDE.md

--- a/agents/prompts/searchAgentPrompt.js
+++ b/agents/prompts/searchAgentPrompt.js
@@ -15,9 +15,14 @@ Step 2. TRANSLATE QUESTION AND REDACT PII
 Step 3. CRAFT SEARCH QUERY
 - GOOGLE_SEARCH_QUERY: craft the <translatedQuestion> into a search query compatible with Google Canada search on Government of Canada domains. 
 - if <originalLang> is fr, craft the search query from <translatedQuestion> in French, otherwise craft the search query in English.
-- Use keywords, shorten as needed  and apply good search query design. 
-Do not include redacted PII types (eg. "I'm COUNTRY passport holder. Do I need a visa" search query would be "find out if need visa", or "Je suis NAME, Je dois faire une demande RPC" search query would be "faire une demande RPC" ). 
--Context: the query results will be used to help the next agent answer the user's question in Canada's official languages of English or French.
+- Use keywords, shorten as needed and apply good search query design.
+- CONTEXT FROM REFERRING URL: If a referring URL is provided, use it to add context to the search query. For example:
+  * If user is on a passport page and mentions "my application", include "passport" in the search query
+  * If user is on a tax page and mentions "my return", include "tax return" in the search query
+  * If user is on a benefits page and mentions "my payment", include the specific benefit type in the search query
+- Do not include redacted PII types (eg. "I'm COUNTRY passport holder. Do I need a visa" search query would be "find out if need visa", or "Je suis NAME, Je dois faire une demande RPC" search query would be "faire une demande RPC" ). 
+- Never include a site: or domain: in the search query. They are added in the next step of the search query process. 
+- Context: the query results will be used to help the next agent answer the user's question in Canada's official languages of English or French.
 - OUTPUT the crafted search query wrapped in <query> tags. This step is complete after <query> is output.
 
 `;

--- a/api/search/search-context.js
+++ b/api/search/search-context.js
@@ -14,12 +14,12 @@ async function performSearch(query, lang, searchService = 'canadaca', chatId = '
 
 export default async function handler(req, res) {
     if (req.method === 'POST') {
-        const { message, chatId = 'system', searchService = 'canadaca', agentType = 'openai' } = req.body;
-        ServerLoggingService.info('Received request to search.', chatId, { message, searchService });
+        const { message, chatId = 'system', searchService = 'canadaca', agentType = 'openai', referringUrl = '' } = req.body;
+        ServerLoggingService.info('Received request to search.', chatId, { message, searchService, referringUrl });
 
         try {
-            // Call SearchAgentService to get the search query and originalLang
-            const agentResult = await invokeSearchAgent(agentType, { chatId, question: message });
+            // Call SearchAgentService to get the search query and originalLang, passing referring URL for context
+            const agentResult = await invokeSearchAgent(agentType, { chatId, question: message, referringUrl });
             const searchQuery = agentResult.query;
             const originalLang = agentResult.originalLang || '';
             // Determine lang

--- a/services/SearchAgentService.js
+++ b/services/SearchAgentService.js
@@ -3,7 +3,7 @@ import { PROMPT } from '../agents/prompts/searchAgentPrompt.js';
 
 const invokeSearchAgent = async (agentType, request) => {
     try {
-        const { chatId, question } = request;
+        const { chatId, question, referringUrl = '' } = request;
         const searchAgent = await createSearchAgent(agentType, chatId);
 
         const messages = [
@@ -13,12 +13,14 @@ const invokeSearchAgent = async (agentType, request) => {
             }
         ];
 
-
-
-        // Add the current message
+        // Add the current message with referring URL context if provided
+        const messageWithContext = referringUrl 
+            ? `${question}\n<referring-url>${referringUrl}</referring-url>`
+            : question;
+            
         messages.push({
             role: "user",
-            content: question,
+            content: messageWithContext,
         });
 
         const answer = await searchAgent.invoke({

--- a/src/services/ContextService.js
+++ b/src/services/ContextService.js
@@ -79,7 +79,7 @@ const ContextService = {
     }
   },
 
-  contextSearch: async (message, searchProvider, lang = 'en', chatId = 'system', agentType = 'openai') => {
+  contextSearch: async (message, searchProvider, lang = 'en', chatId = 'system', agentType = 'openai', referringUrl = '') => {
     try {
       const searchResponse = await fetch(getApiUrl('search-context'), {
         method: 'POST',
@@ -92,6 +92,7 @@ const ContextService = {
           searchService: searchProvider,
           chatId,
           agentType,
+          referringUrl,
         }),
       });
 
@@ -128,7 +129,8 @@ const ContextService = {
         searchProvider,
         lang,
         chatId,
-        aiProvider
+        aiProvider,
+        referringUrl
       );
       await LoggingService.info(
         chatId,

--- a/src/services/contextSystemPrompt.js
+++ b/src/services/contextSystemPrompt.js
@@ -81,7 +81,7 @@ ${departmentsString}
 
 4. If multiple organizations could be responsible:
    - Select the organization that most likely directly administers and delivers web content for the program/service
-   - OR if applicable, set the bilingual abbreviation key to CDS-SNC and select one of these cross-department canada.ca urls as the departmentUrl in the matching page-language (CDS-SNC is responsible for these cross-department services):
+   - OR if no organization is mentioned or fits the criteria, and the question is about one of the cross-department services below, set the bilingual abbreviation key to CDS-SNC and select one of these cross-department canada.ca urls as the departmentUrl in the matching page-language (CDS-SNC is responsible for these cross-department services):
       Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
       GCKey help/Aide pour GCKey: https://www.canada.ca/en/government/sign-in-online-account/gckey.html or fr: https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne/clegc.html
       Response to US tariffs: https://international.canada.ca/en/global-affairs/campaigns/canada-us-engagement or fr: https://international.canada.ca/fr/affaires-mondiales/campagnes/engagement-canada-etats-unis
@@ -112,7 +112,7 @@ ${departmentsString}
 - Collection and assessment of duties and import taxes, CARM (GRCA in French) → CBSA-ASFC (administering department)
 - Find a member of Parliament →  HOC-CDC (administering department)
 - Find permits and licences to start or grow a business → BIZPAL-PERLE (federal/provincial/territorial/municipal partnership administered by ISED-ISDE)
-
+- ATIP (Access to Information), AIPRP (Accès à l’information et protection des renseignements personnels) → TBS-SCT (administering department)
 
 ## Response Format:
 <analysis>


### PR DESCRIPTION
# Summary | Résumé

Needs the context so if person is asking about 'their application' from the passport page, the search query that is created will say 'passport application' instead of useless 'application' 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
