### PR TITLE
fix: phone and isc treaty table issues

### DIFF
--- a/src/services/systemPrompt/agenticBase.js
+++ b/src/services/systemPrompt/agenticBase.js
@@ -47,8 +47,9 @@ Step 1.  PERFORM PRELIMINARY CHECKS → output ALL checks in specified format
 Step 2. PLAN AND DOWNLOAD RELEVANT WEBPAGES
 A) First, create a download plan:
    - Review URLs from <referring-url>, <possible-citations>, and <searchResults>
-   - ALWAYS download when answer would include specific details (numbers, codes, numeric ranges, dates, dollar amounts, etc.) - these must be verified in downloaded content
-   - ALWAYS download for time-sensitive content (news releases, tax year changes, program updates)
+   - ALWAYS follow any department-specific downloadWebPage instructions in the scenarios above (these override general criteria)
+   - ALWAYS download when answer would include specific details (numbers, trends from numbers, contact details, codes, numeric ranges, dates, dollar amounts, etc.) - these must be verified in downloaded content
+   - ALWAYS download for time-sensitive content (news releases, tax year changes, program updates, trends)
    - ALWAYS download if URL is unfamiliar, recently updated, or is a French page that may contain different information than the English version
    - Select maximum 3 URLs that are most likely to contain or verify your answer
    - Prioritize: URLs from <possible-citations> > <referring-url> > recent <searchResults>
@@ -83,7 +84,11 @@ Step 3. ALWAYS CRAFT AND OUTPUT ANSWER IN ENGLISH→ CRITICAL REQUIREMENT: Even 
   - DO NOT hallucinate or fabricate or assume any part of the answer - the answer must be based on content sourced from the Government of Canada and preferably verified in downloaded content.
   - SOURCE answer ONLY from canada.ca, gc.ca, or departmentUrl websites
   - BE HELPFUL: always correct misunderstandings, explain steps and address the specific question.
-  - ALWAYS PRIORITIZE scenarios and updates over <searchResults> and newer content over older 
+  - ALWAYS PRIORITIZE scenarios and updates over <searchResults> and newer content over older
+  - ALWAYS FOLLOW ALL department-specific requirements from scenarios above:
+    * Check scenarios for mandatory actions (downloadWebPage, clarifying questions, specific citations, etc.)
+    * Follow scenarios restrictions (what NOT to provide, what NOT to answer directly)
+    * Include required elements in answers (contact info, specific pages, disclaimers, etc.)
   - If an answer cannot be found in Government of Canada content, always provide the <not-gc> tagged answer 
  - Structure and format the response as directed in this prompt in English, keeping it short and simple.
 * Step 3 OUTPUT in this format for ALL questions regardless of language, using tags as instructed for pt-muni, not-gc, clarifying-question:

--- a/src/services/systemPrompt/context-hc-sc/hc-sc-scenarios.js
+++ b/src/services/systemPrompt/context-hc-sc/hc-sc-scenarios.js
@@ -4,7 +4,11 @@ export const HC_SC_SCENARIOS = `
 
 ### Health Canada and Public Health Agency of Canada Scenarios
 
-# Placeholder for scenarios - add specific scenarios below
+- HEALTH_MISINFO: determine if question contains health misinformation patterns (e.g. exaggerated death counts, misattributed causation, conspiracy theories about data suppression).
+* Follow this sequence for health misinformation answers:  
+* Lead with facts in sentence 1, not corrections. Don't repeat the false claim. 
+* Next, use trusted messenger framing and leverage existing surveillance data.
+* Use the downloadWebPage tool to verify recent trends or data to cite.  
 
 
 

--- a/src/services/systemPrompt/scenarios-all.js
+++ b/src/services/systemPrompt/scenarios-all.js
@@ -10,7 +10,7 @@ If the user asks for a specific detail that couldn't be verified successfully,  
 3. Provide the citation URL to the page that describes how to find out the right number or that contains the right number they need.
 
 ### Contact Information
-* When a question asks for a phone number, follow the scenario instructions for that department, or if there aren't any specific instructions in the prompt, provide the phone number and any self-service options that are available for that particular issue. Provide the most-detailed contact page for the service, program or department as the citation link.
+* When a question asks for a phone number or the answer recommends contact in the answer, follow the scenario instructions for that department, or if there aren't any specific instructions in the prompt, provide the phone number and any self-service options that are available for that particular issue. Provide the most-detailed contact page for the service, program or department as the citation link.
 * if the question asks for a phone number but without enough context to know which number or contact point to provide, ask a clarifying question to provide an accurate answer. 
 * always verify the phone number in downloaded content before providing it in your response unless the number is in this prompt.
 * do not provide TTY numbers in your response unless the user asks for them.


### PR DESCRIPTION
# Summary | Résumé

- trying again to resolve the ISC treaty table problem (it did NOT use downloadWebPage tool) and phone number issue (not providing phone numbers when it should and not providing contact page as citation when it says to contact). 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
