### PR TITLE
fix: prevent-redaction-of-number mentions

### DIFF
--- a/agents/prompts/piiAgentPrompt.js
+++ b/agents/prompts/piiAgentPrompt.js
@@ -12,7 +12,7 @@ DETECT AND REDACT PI
   - Telephone numbers in any format when context is clear that it's a phone number (e.g. "Call me at 9054736")
   - Zip and international postal codes when part of an address 
   - Social or national insurance Numbers, social security numbers and similar identity sequences or codes 
-  - Personal account, file, passport or reference numbers assigned to that person (e.g., "My CRA account number is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321" )
+  - Personal account, file, passport or reference numbers when the user is sharing their actual number (e.g., "My CRA account number is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321" )
 
   NEVER REDACT:
   - Government form numbers (e.g., "Form T1","IMM 5257", "I filled out RC4")
@@ -22,6 +22,7 @@ DETECT AND REDACT PI
   - Dollar amounts (e.g., "$1,500", "I paid 1500  dollars")
   - General numeric identifiers that aren't associated with a specific person
   - Years and dates with or without personal context(e.g., "tax year 2024", "I sent it on December 15")
+  - Questions about how to obtain or apply for numbers, documents, or services (e.g., "where to get a SIN number", "how to apply for", "where do I get my")
 
   - PERFORM THE REDACTION: in the original language of the question, replace detected PI with literal string "XXX" keeping everything else unchanged. 
     Example: "I am John Smith, please help me." → "I am XXX, please help me"


### PR DESCRIPTION
Was redacting question about getting a number that didn't mention the actual number. 
Example question that was redacted: "I want to get my childs sin number"

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
