### PR TITLE
fix: remove-shot-from-threatwords

### DIFF
--- a/src/services/redactions/threats_en.txt
+++ b/src/services/redactions/threats_en.txt
@@ -18,7 +18,6 @@ murdered
 shoot
 shoots
 shooting
-shot
 strangle
 sword
 torture

--- a/src/services/redactions/threats_en.txt
+++ b/src/services/redactions/threats_en.txt
@@ -10,8 +10,6 @@ detonate
 hostage
 hunt down
 kill
-killed
-killing
 knife
 murder
 shoot

--- a/src/services/redactions/threats_en.txt
+++ b/src/services/redactions/threats_en.txt
@@ -14,7 +14,6 @@ killed
 killing
 knife
 murder
-murdered
 shoot
 shoots
 shooting

--- a/src/services/redactions/threats_fr.txt
+++ b/src/services/redactions/threats_fr.txt
@@ -11,13 +11,6 @@ bombardé
 explosif
 explosifs
 fusillade
-tirer
-tirerai
-tirera
-tirerons
-tireront
-tirons
-tiré
 otage
 meurtre
 tuer

--- a/src/services/redactions/threats_fr.txt
+++ b/src/services/redactions/threats_fr.txt
@@ -13,11 +13,4 @@ explosifs
 fusillade
 otage
 meurtre
-tuer
-tuerai
-tuera
-tuerons
-tueront
-tuons
-tué
-tuerie
+


### PR DESCRIPTION
Used for vaccines questions- HC request to not redact - removed just 'shot' 
Annie pointed out tirer is not used for vaccines but IS used for CRA questions in the 'to pull' definition - so removed all versions of 'tirer' 
Removed 'murdered' bc it's used for missing and murdered indigenous women. 

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
