### PR TITLE
fix: json labels

### DIFF
--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -447,7 +447,7 @@ const ChatInterface = ({
                       }
                       onSkip={focusTextarea}
                       skipButtonLabel={safeT(
-                        "homepage.textarea.ariaLabel.skipfo"
+                        "homepage.chat.textarea.ariaLabel.skipfo"
                       )}
                     />
                   )}


### PR DESCRIPTION
My local preview isn't working, so I can't check if this works. The label paths were changed and didn't link up anymore.

Can't stop code-spaces from auto-formatting the ' tags.
