### PR TITLE
SIN over-redaction - blocking mentions without actual number

### DIFF
--- a/agents/prompts/piiAgentPrompt.js
+++ b/agents/prompts/piiAgentPrompt.js
@@ -10,22 +10,32 @@ DETECT AND REDACT PI
   - Home addresses with street numbers (e.g.,
   "123 Main Street", "456 rue Principale")
   - Telephone numbers in any format when context is clear that it's a phone number (e.g. "Call me at 9054736")
-  - Zip and international postal codes when part of an address 
-  - Social or national insurance Numbers, social security numbers and similar identity sequences or codes 
-  - Personal account, file, passport or reference numbers when the user is sharing their actual number (e.g., "My CRA business number(BN)is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321" )
+  - Zip and international postal codes when part of an address
+  - Actual Social Insurance Numbers, social security numbers and similar identity number sequences (e.g., "my SIN is 123-456-789", "SIN: 123456789", "NAS 123 456 789")
+  - Actual personal account, file, passport or reference numbers when the user is sharing their specific number (e.g., "My CRA business number is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321")
 
   NEVER REDACT:
   - Government form numbers (e.g., "Form T1","IMM 5257", "I filled out RC4")
-  - Product serial numbers or model numbers  (e.g., "Serial number ABC123", "Model
-  XYZ-789")
+  - Product serial numbers or model numbers  (e.g., "Serial number ABC123", "Model XYZ-789")
   - Codes for occupations, businesses, taxes etc. (e.g. "I used NOC code 1234")
-  - Dollar amounts (e.g., "$1,500", "I paid 1500  dollars")
+  - Dollar amounts (e.g., "$1,500", "I paid 1500 dollars")
   - General numeric identifiers that aren't associated with a specific person
-  - Years and dates with or without personal context(e.g., "tax year 2024", "I sent it on December 15")
-  - Questions about how to obtain or apply for numbers, documents, or services (e.g., "where to get a SIN number", "how to apply for", "where do I get my")
+  - Years and dates with or without personal context (e.g., "tax year 2024", "I sent it on December 15")
+  - Mentions of document types or identifier types WITHOUT the actual number (e.g., "where to get a SIN number", "how to apply for a SIN", "where do I get my SIN", "I need my passport", "what is a business number")
+  - Questions asking about how to obtain, apply for, or find documents or identifier numbers (e.g., "how do I get a SIN", "where can I find my account number", "how to apply for passport")
 
-  - PERFORM THE REDACTION: in the original language of the question, replace detected PI with literal string "XXX" keeping everything else unchanged. 
+  CRITICAL DISTINCTION:
+  - "where is my SIN number" → DO NOT REDACT (asking where to find it, no actual number provided)
+  - "my SIN is 123-456-789" → REDACT to "my SIN is XXX" (actual number provided)
+  - "I need to get my SIN" → DO NOT REDACT (just mentioning the document type)
+  - "SIN 123456789" → REDACT to "SIN XXX" (actual number provided)
+  - "how do I apply for a passport" → DO NOT REDACT (asking how to apply)
+  - "my passport number is HB65321" → REDACT to "my passport number is XXX" (actual number provided)
+
+  - PERFORM THE REDACTION: in the original language of the question, replace detected PI with literal string "XXX" keeping everything else unchanged.
     Example: "I am John Smith, please help me." → "I am XXX, please help me"
+    Example: "My SIN is 123-456-789" → "My SIN is XXX"
+    Example: "Where do I find my SIN number?" → "Where do I find my SIN number?" (NO REDACTION)
     Example: "我住在橡树街123号" → "我住在XXX"
 
   - OUTPUT: <pii>redacted question string with XXX replacements</pii> or <pii>null</pii> if no PI was detected and replaced.

--- a/system-prompt-documentation.md
+++ b/system-prompt-documentation.md
@@ -1,7 +1,7 @@
 # AI Answers System Prompt Documentation
 ## DefaultWorkflow Pipeline
 
-**Generated:** 2025-10-21T14:59:59.025Z
+**Generated:** 2025-10-21T16:44:13.258Z
 **Language:** en
 **Example Department:** EDSC-ESDC
 
@@ -44,22 +44,32 @@ DETECT AND REDACT PI
   - Home addresses with street numbers (e.g.,
   "123 Main Street", "456 rue Principale")
   - Telephone numbers in any format when context is clear that it's a phone number (e.g. "Call me at 9054736")
-  - Zip and international postal codes when part of an address 
-  - Social or national insurance Numbers, social security numbers and similar identity sequences or codes 
-  - Personal account, file, passport or reference numbers when the user is sharing their actual number (e.g., "My CRA business number(BN)is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321" )
+  - Zip and international postal codes when part of an address
+  - Actual Social Insurance Numbers, social security numbers and similar identity number sequences (e.g., "my SIN is 123-456-789", "SIN: 123456789", "NAS 123 456 789")
+  - Actual personal account, file, passport or reference numbers when the user is sharing their specific number (e.g., "My CRA business number is 987654321", "My IRCC personal reference code is B7632", "Numero de passeport HB65321")
 
   NEVER REDACT:
   - Government form numbers (e.g., "Form T1","IMM 5257", "I filled out RC4")
-  - Product serial numbers or model numbers  (e.g., "Serial number ABC123", "Model
-  XYZ-789")
+  - Product serial numbers or model numbers  (e.g., "Serial number ABC123", "Model XYZ-789")
   - Codes for occupations, businesses, taxes etc. (e.g. "I used NOC code 1234")
-  - Dollar amounts (e.g., "$1,500", "I paid 1500  dollars")
+  - Dollar amounts (e.g., "$1,500", "I paid 1500 dollars")
   - General numeric identifiers that aren't associated with a specific person
-  - Years and dates with or without personal context(e.g., "tax year 2024", "I sent it on December 15")
-  - Questions about how to obtain or apply for numbers, documents, or services (e.g., "where to get a SIN number", "how to apply for", "where do I get my")
+  - Years and dates with or without personal context (e.g., "tax year 2024", "I sent it on December 15")
+  - Mentions of document types or identifier types WITHOUT the actual number (e.g., "where to get a SIN number", "how to apply for a SIN", "where do I get my SIN", "I need my passport", "what is a business number")
+  - Questions asking about how to obtain, apply for, or find documents or identifier numbers (e.g., "how do I get a SIN", "where can I find my account number", "how to apply for passport")
 
-  - PERFORM THE REDACTION: in the original language of the question, replace detected PI with literal string "XXX" keeping everything else unchanged. 
+  CRITICAL DISTINCTION:
+  - "where is my SIN number" → DO NOT REDACT (asking where to find it, no actual number provided)
+  - "my SIN is 123-456-789" → REDACT to "my SIN is XXX" (actual number provided)
+  - "I need to get my SIN" → DO NOT REDACT (just mentioning the document type)
+  - "SIN 123456789" → REDACT to "SIN XXX" (actual number provided)
+  - "how do I apply for a passport" → DO NOT REDACT (asking how to apply)
+  - "my passport number is HB65321" → REDACT to "my passport number is XXX" (actual number provided)
+
+  - PERFORM THE REDACTION: in the original language of the question, replace detected PI with literal string "XXX" keeping everything else unchanged.
     Example: "I am John Smith, please help me." → "I am XXX, please help me"
+    Example: "My SIN is 123-456-789" → "My SIN is XXX"
+    Example: "Where do I find my SIN number?" → "Where do I find my SIN number?" (NO REDACTION)
     Example: "我住在橡树街123号" → "我住在XXX"
 
   - OUTPUT: <pii>redacted question string with XXX replacements</pii> or <pii>null</pii> if no PI was detected and replaced.


### PR DESCRIPTION
# Summary | Résumé

Tighten up prompt to clarify that it should only redact the ACTUAL number and to never redact mentions of the numbers/sequences. 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
