### PR TITLE
fix: view chat in original page language

### DIFF
--- a/api/chat/chat-dashboard.js
+++ b/api/chat/chat-dashboard.js
@@ -198,6 +198,9 @@ async function chatDashboardHandler(req, res) {
         },
         expertEmails: {
           $addToSet: '$interactions.expertEmail'
+        },
+        pageLanguages: {
+          $addToSet: '$interactions.context.pageLanguage'
         }
       }
     });
@@ -257,6 +260,31 @@ async function chatDashboardHandler(req, res) {
               ]
             }
           }
+        },
+        pageLanguage: {
+          $let: {
+            vars: {
+              filteredLangs: {
+                $filter: {
+                  input: '$pageLanguages',
+                  as: 'lang',
+                  cond: {
+                    $and: [
+                      { $ne: ['$$lang', null] },
+                      { $ne: ['$$lang', ''] }
+                    ]
+                  }
+                }
+              }
+            },
+            in: {
+              $cond: [
+                { $gt: [{ $size: '$$filteredLangs' }, 0] },
+                { $arrayElemAt: ['$$filteredLangs', 0] },
+                ''
+              ]
+            }
+          }
         }
       }
     });
@@ -304,7 +332,8 @@ async function chatDashboardHandler(req, res) {
       department: chat.department || '',
       expertEmail: chat.expertEmail || '',
       creatorEmail: chat.creatorEmail || '',
-      date: chat.createdAt ? chat.createdAt.toISOString() : null
+      date: chat.createdAt ? chat.createdAt.toISOString() : null,
+      pageLanguage: chat.pageLanguage || ''
     }));
 
     if (isDataTablesMode) {

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -172,10 +172,12 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
     {
       title: t('admin.chatDashboard.columns.chatId', 'Chat ID'),
       data: 'chatId',
-      render: (value) => {
+      render: (value, type, row) => {
         if (!value) return '';
         const safeId = escapeHtmlAttribute(value);
-        return `<a href="/${lang}?chat=${safeId}&review=1">${safeId}</a>`;
+        // Use the chat's original pageLanguage, fallback to 'en' if not available
+        const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
+        return `<a href="/${chatLang}?chat=${safeId}&review=1">${safeId}</a>`;
       }
     },
     {


### PR DESCRIPTION
# Summary | Résumé

How It Works Now
When a chat was created on the FR page → link opens as /fr?chat=...&review=1
When a chat was created on the EN page → link opens as /en?chat=...&review=1
If pageLanguage is missing/null → defaults to /en?chat=...&review=1 (safe fallback)
The chat will now open in the same language context as when the end-user originally created it!
---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
