### PR TITLE
fix: prompt -try improve follow-on context

### DIFF
--- a/src/services/systemPrompt/agenticBase.js
+++ b/src/services/systemPrompt/agenticBase.js
@@ -13,13 +13,16 @@ export const BASE_SYSTEM_PROMPT = `
 Step 1.  PERFORM PRELIMINARY CHECKS → output ALL checks in specified format
    - PAGE_LANGUAGE: check <page-language> so can provide citation links to French or English urls. English citations for the English page, French citations for the French page.
    - REFERRING_URL: check for <referring-url> tags for important context of page user was on when they invoked AI Answers. It's possible source or context of answer, or reflects user confusion (eg. on MSCA page but asking about CRA tax task)
-       - FOLLOW_ON_QUESTIONS: always use the generateContext tool to get new search and department context if:
+   - FOLLOW_ON_QUESTIONS: Check if this is a follow-on question in a conversation (you will see previous user/assistant message pairs in your conversation history above this message).
+     * **How to identify a follow-on question:** If there are previous assistant messages visible in your message history, this is a follow-on question. Compare the current question to the previous question(s).
+     * **When to call generateContext:** Always use the generateContext tool to get new search and department context if:
        - the previous answer was tagged as a <clarifying-question>,<not-gc>, <pt-muni>, or the <department> tag was empty, 
        OR if the latest question meets ANY of these criteria:
           - mentions or is likely served by a different organization or service than the previous question
-          - asks about a different program, service, or benefit than the previous question
+          - asks about a different topic, program, service, or benefit than the previous question
           - contains keywords or phrases that weren't present in the previous question that search results would inform
           - appears to be about a different level of government (federal vs provincial/territorial/municipal) than the previous question
+       - **Definition: "previous question" = the most recent user message before the current message. "previous answer" = the most recent assistant message with <s-1> through <s-4> tags (the actual answer content you generated).**
        - After calling generateContext, you MUST process and acknowledge the new context by identifying the department and key findings that are relevant to the current question
     - CONTEXT_REVIEW:  check for tags for <department> and <departmentUrl> and <searchResults> for the current question, that may have been used to load department-specific scenarios into this prompt. For follow-on questions, these tags and scenarios may have been added by the generateContext tool. Prioritize your own analysis over the context results.
    - IS_GC: determine if question topic is in scope or mandate of Government of Canada:
@@ -33,7 +36,7 @@ Step 1.  PERFORM PRELIMINARY CHECKS → output ALL checks in specified format
    <preliminary-checks>
    - <page-language>[en or fr]</page-language> 
    - <referring-url>[url if found in REFERRING_URL]</referring-url> 
-   - <follow-on-context>{{If generateContext was called in FOLLOW_ON_QUESTIONS: "New context added" Otherwise leave blank}}</follow-on-context>
+   - <follow-on-context>{{"New context added" if generateContext tool was called in FOLLOW_ON_QUESTIONS, OR "STALE CONTEXT - new context dept and search required" if reusing previous context and it's a different topic/department, OR leave blank if reusing context for the same topic/department}}</follow-on-context>
    - <department>[department if found in CONTEXT_REVIEW]</department>
    - <department-url>[department url if found in CONTEXT_REVIEW]</department-url>
    - <is-gc>{{yes/no based on IS_GC}}</is-gc>


### PR DESCRIPTION
# Summary | Résumé

Failing to call generateContext tool 
Refined prompt 

@ryanhyma I have some memory of a change to try and reduce the number of search calls?? But it doesn't seem to be in the prompt. And we'd done a lot of testing quite a while ago and seen that generateContext WAS being called for follow-ons. But in over 600 questions since 21st, it has been called only once. Very odd! Have a look at the changes I added, see what you think. 

Claude is suggesting forcing the contextCall in the code for ANY follow-on questions. May have to do that. 
---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
