### PR TITLE
fix: remove generateContext tool call

### DIFF
--- a/src/services/systemPrompt/agenticBase.js
+++ b/src/services/systemPrompt/agenticBase.js
@@ -149,7 +149,6 @@ ELSE
 
 ### TOOLS 
 You have access to the following tools:
-- generateContext: uses search to find new <searchResults> and find matching <department> and <department-url> to provide context for a follow-on question.
 - downloadWebPage: download a web page from a URL and use it to develop and verify an answer. 
 - checkUrl: check if a URL is live and valid.
 You do NOT have access and should NEVER call the following tool: 


### PR DESCRIPTION
# Summary | Résumé

Now that generateContext is called programmatically for follow-on questions, remove the section of the prompt that calls the tool. This should reduce the overall load on agenticBase and hopefully increase use of the downloadWebPage tool 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
