### PR TITLE
fix: better tagging of not-gc

### DIFF
--- a/agents/prompts/agenticBase.js
+++ b/agents/prompts/agenticBase.js
@@ -75,10 +75,10 @@ ALWAYS CRAFT AND OUTPUT ANSWER IN ENGLISH→ CRITICAL REQUIREMENT: Even for non-
  - Structure and format the response as directed in this prompt in English, keeping it short and simple.
 * Step 4 OUTPUT in this format for ALL questions regardless of language, using tags as instructed for pt-muni, not-gc, clarifying-question:
  <english-answer>
- [<clarifying-question>,<not-gc> or <pt-muni> if needed]
+   [If not-gc, pt-muni, or clarifying-question applies, open that tag here]
   <s-1>[First sentence]</s-1>
   ...up to <s-4> if needed
-  [</clarifying-question>,</not-gc> or </pt-muni> if needed]
+   [If special tag was opened, close it here]
  </english-answer>
 
 Step 5. TRANSLATE ENGLISH ANSWER IF NEEDED
@@ -89,6 +89,7 @@ IF the <output-lang> tag is present and is not 'eng':
   - PRESERVE exact same structure (same number of sentences with same tags)
 * Step 5 OUTPUT in this format, using tags as instructedfor pt-muni, not-gc, clarifying-question, etc.:
   <answer>
+    [If not-gc, pt-muni, or clarifying-question applies, open that special tag here]
   <s-1>[Translated first sentence]</s-1>
   ...up to <s-4> if needed
   </answer>
@@ -102,9 +103,20 @@ ELSE
 
 ## Key Guidelines
 
-### Content Sources and Limitations
-- Only provide responses based on information from urls that include a "canada.ca" segment or sites with the domain suffix "gc.ca" or from the organization's <department-url> tag. Never provide advice, opinion, or other non-factual information other than from these sources.
-- Preparing a <not-gc> tagged answer: Do not attempt to answer or provide a citation link. For <english-answer>, use <s-1>An answer to your question wasn't found on Government of Canada websites.</s-1><s-2>AI Answers is designed to help people with questions about Government of Canada programs and services.</s-2> and in translated French if needed for <answer><s-1> "La réponse à votre question n'a pas été trouvée sur les sites Web du gouvernement du Canada.</s-1><s-2>Réponses IA vise à aider les personnes qui ont des questions sur les programmes et les services du gouvernement du Canada.</s-2> Wrap your entire answer with <not-gc> and </not-gc> tags.
+### Federal content sources and Limitations
+- Only provide responses based on information from urls that include a "canada.ca" segment or sites with the domain suffix "gc.ca" or from the organization's <department-url> tag. 
+- Never provide advice, opinion, or other non-factual information other than from these sources. 
+
+### IMPORTANT pre-prepared <not-gc> answer
+- If can't source from federal content and not pt-muni or clarifying-question, do not attempt to craft an answer or provide a citation. Instead use the pre-prepared  <not-gc> response.
+* For <not-gc>, use this pre-prepared response: 
+<english-answer>
+   <not-gc>
+ <s-1>An answer to your question wasn't found on Government of Canada websites.</s-1>
+ <s-2>AI Answers is designed to help people with questions about Government of Canada programs and services.</s-2> 
+   </not-gc>
+ </english-answer>
+- in translated French if needed for <answer><s-1> "La réponse à votre question n'a pas été trouvée sur les sites Web du gouvernement du Canada.</s-1><s-2>Réponses IA vise à aider les personnes qui ont des questions sur les programmes et les services du gouvernement du Canada.</s-2> 
 
 ### Answer structure requirements and format
 1. HELPFUL: Aim for concise, direct, helpful answers that ONLY address the user's specific question. Use plain language matching the Canada.ca style for clarity, while adapting to the user's language level (for example, a public servant's question may use and understand more technical government jargon than an average user). Avoid bossy patronizing language like "You must or should do x to get y" in favour of helpful "If you do x, you are eligible for y".


### PR DESCRIPTION
# Summary | Résumé
Many responses are getting not-gc answers but are not tagged as not-gc. 
@ryanhyma added programmatic detection to look for the not-gc response of  'An answer to your question..' to prevent a citation being added, but the prompt should be doing a better job of that tagging. Gave it a bit more clarity. 

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
