### PR TITLE
fix: resolve batch restart error

### DIFF
--- a/src/services/BatchService.js
+++ b/src/services/BatchService.js
@@ -400,7 +400,7 @@ class BatchService {
                 try {
                   const rowIndex = entry?.rowIndex ?? original?.rowIndex ?? i;
                   await this.upsertBatchItems(batchId, [
-                    { rowIndex, shortQuery: true, originalData: original },
+                    { rowIndex, error: message, originalData: original },
                   ]);
                 } catch (persistErr) {
                   console.error('Failed to persist shortQuery for batch item:', persistErr);


### PR DESCRIPTION
If a batch fails with shortQuery error, sometimes it would not recover and finish.
This is a fix for that.