### PR TITLE
fix(auth): normalize email in signup and remove duplicate reset email

### DIFF
--- a/__tests__/auth-signup.test.js
+++ b/__tests__/auth-signup.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import signupHandler from '../api/auth/auth-signup.js';
+import { User } from '../models/user.js';
+
+// Mock dependencies
+vi.mock('../models/user.js', () => {
+    const UserMock = vi.fn();
+    UserMock.findOne = vi.fn();
+    UserMock.countDocuments = vi.fn();
+    return { User: UserMock };
+});
+
+vi.mock('../api/db/db-connect.js', () => ({
+    default: vi.fn().mockResolvedValue(true)
+}));
+
+// Mock speakeasy
+vi.mock('speakeasy', () => ({
+    default: {
+        generateSecret: () => ({ base32: 'secret' })
+    }
+}));
+
+describe('Auth Signup Handler', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should normalize email (lowercase) before checking existence', async () => {
+        const req = {
+            body: {
+                email: 'TestUser@Example.Com',
+                password: 'password123'
+            },
+            login: vi.fn((user, cb) => cb(null))
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        // Mock User.findOne to return null (no user found)
+        User.findOne.mockResolvedValue(null);
+        User.countDocuments.mockResolvedValue(0);
+
+        // Mock User constructor
+        User.mockImplementation((data) => ({
+            ...data,
+            save: vi.fn().mockResolvedValue(true),
+            _id: 'mock-id'
+        }));
+
+        await signupHandler(req, res);
+
+        // Verify findOne was called with normalized email
+        expect(User.findOne).toHaveBeenCalledWith({
+            email: 'testuser@example.com'
+        });
+
+        // Verify User was instantiated with normalized email
+        expect(User).toHaveBeenCalledWith(expect.objectContaining({
+            email: 'testuser@example.com'
+        }));
+
+        // Verify success response
+        expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should normalize email (trim) before checking existence', async () => {
+        const req = {
+            body: {
+                email: '  testuser@example.com  ',
+                password: 'password123'
+            },
+            login: vi.fn((user, cb) => cb(null))
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        User.findOne.mockResolvedValue(null);
+        User.countDocuments.mockResolvedValue(0);
+        User.mockImplementation((data) => ({
+            ...data,
+            save: vi.fn().mockResolvedValue(true),
+            _id: 'mock-id'
+        }));
+
+        await signupHandler(req, res);
+
+        expect(User.findOne).toHaveBeenCalledWith({
+            email: 'testuser@example.com'
+        });
+    });
+
+    it('should reject if email is missing', async () => {
+        const req = { body: { password: 'pass' } }; // No email
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        await signupHandler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('required')
+        }));
+    });
+
+    it('should reject if existing user found (normalized check)', async () => {
+        const req = {
+            body: {
+                email: 'Exists@Example.Com',
+                password: 'password123'
+            }
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        // Mock finding a user
+        User.findOne.mockResolvedValue({ _id: 'existing-id', email: 'exists@example.com' });
+
+        await signupHandler(req, res);
+
+        expect(User.findOne).toHaveBeenCalledWith({ email: 'exists@example.com' });
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            message: 'User already exists'
+        }));
+    });
+});

--- a/api/auth/auth-reset-password.js
+++ b/api/auth/auth-reset-password.js
@@ -59,24 +59,6 @@ const resetPasswordHandler = async (req, res) => {
 
     console.info(`[auth-reset-password][${os.hostname()}] Password updated successfully for: ${email}`);
 
-    // Send success notification via GC Notify
-    try {
-      const templateId = SettingsService.get('notify.resetTemplateId') || process.env.GC_NOTIFY_RESET_TEMPLATE_ID;
-      if (templateId) {
-        await GCNotifyService.sendEmail({
-          email: user.email,
-          templateId,
-          personalisation: {
-            name: '', // Required by many templates
-            reset_link: ''
-          }
-        });
-      }
-    } catch (notifyError) {
-      console.warn(`[auth-reset-password][${os.hostname()}] Failed to send success notification:`, notifyError);
-      // Don't fail the request if notification fails
-    }
-
     return res.status(200).json({ success: true, message: 'password reset successfully' });
   } catch (err) {
     console.error(`[auth-reset-password][${os.hostname()}] Error:`, err);

--- a/api/auth/auth-signup.js
+++ b/api/auth/auth-signup.js
@@ -15,8 +15,10 @@ const signupHandler = async (req, res) => {
       });
     }
 
+    const normalizedEmail = email.toLowerCase().trim();
+
     // Check if user already exists
-    const existingUser = await User.findOne({ email });
+    const existingUser = await User.findOne({ email: normalizedEmail });
     if (existingUser) {
       return res.status(400).json({
         success: false,
@@ -34,7 +36,7 @@ const signupHandler = async (req, res) => {
 
     // Create new user (automatically active if first user)
     const user = new User({
-      email,
+      email: normalizedEmail,
       password,
       role: isFirstUser ? "admin" : "partner",
       active: isFirstUser, // First user is automatically active


### PR DESCRIPTION
- Normalize email (lowercase + trim) before checking existence in signup handler to prevent case-variant duplicates
- Remove errant email notification with blank reset_link after successful password reset
- Add unit tests for signup email normalization

