### PR TITLE
feat: add dev:quick script for easy local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,46 @@ AI Answers is a specialized AI chat agent designed for Government of Canada webs
 - **Production**: https://ai-answers.alpha.canada.ca
 
 
+
+### Quick Start
+To start the application locally with a disposable in-memory database and pre-seeded data:
+
+#### 1. Configure Environment Variables
+Create a `.env` file in the project root with the following variables:
+
+```bash
+# Required for Azure OpenAI (default provider)
+AZURE_OPENAI_API_KEY=your_azure_openai_api_key      # Azure OpenAI service API key
+AZURE_OPENAI_ENDPOINT=https://your-instance.openai.azure.com/  # Azure OpenAI endpoint URL
+AZURE_OPENAI_API_VERSION=2024-06-01                 # Azure OpenAI API version
+
+# Required for application security
+JWT_SECRET_KEY=your_random_secret_key               # Secret key for JWT token signing
+
+# Optional - Google Search (for context retrieval)
+GOOGLE_API_KEY=your_google_api_key                  # Google Custom Search API key
+GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id       # Google Programmable Search Engine ID
+
+# Optional - GC Notify (for 2FA and password reset emails)
+GC_NOTIFY_API_KEY=your_gc_notify_api_key            # GC Notify API key for email notifications
+
+# Development settings (usually left as-is)
+NODE_ENV=development                                # Environment mode
+USER_AGENT=testtest                               # User agent for web requests
+DANGEROUSLY_DISABLE_HOST_CHECK=true                 # Allows React dev server to run
+```
+
+#### 2. Run the Quick Start Command
+```bash
+npm run dev:quick
+```
+
+This command will:
+1. Start an in-memory MongoDB instance.
+2. Seed it with default users:
+   - Admin: `admin@admin.com` / `admin`
+   - Partner: `partner@example.com` / `partner`
+3. Start the backend (port 3001) and frontend (port 3000) with hot-reloading enabled.
+
+**Note:** Data is not persistent and will reset when you stop the command.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3206,6 +3206,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3808,6 +3809,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -4691,6 +4693,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -5303,6 +5306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5325,6 +5329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5636,7 +5641,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5653,7 +5657,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5670,7 +5673,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5687,7 +5689,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5704,7 +5705,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5721,7 +5721,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5738,7 +5737,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5755,7 +5753,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5772,7 +5769,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5789,7 +5785,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5806,7 +5801,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5823,7 +5817,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5840,7 +5833,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5857,7 +5849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5874,7 +5865,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5891,7 +5881,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5908,7 +5897,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5925,7 +5913,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5942,7 +5929,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5959,7 +5945,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5976,7 +5961,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5993,7 +5977,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6010,7 +5993,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6027,7 +6009,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6044,7 +6025,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6061,7 +6041,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6195,6 +6174,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -7812,6 +7792,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -9790,6 +9771,7 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.2.tgz",
       "integrity": "sha512-ZdnbHmHEl8E5vN0GWDtONe5w6j3CrSqqxZM4hNLBPkV/aouWKug7D5/Mi6RazfYO5U4fmHQYLwMz60rHcx0G4g==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -9893,7 +9875,6 @@
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
       "integrity": "sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.15",
         "better-opn": "^3.0.2",
@@ -9938,7 +9919,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11002,8 +10982,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/q": {
       "version": "1.5.8",
@@ -11254,6 +11233,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -11813,6 +11793,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11929,6 +11910,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12408,7 +12390,6 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -12910,7 +12891,6 @@
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -13113,8 +13093,7 @@
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
-      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
-      "peer": true
+      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ=="
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -13141,6 +13120,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -15939,7 +15919,6 @@
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -16084,6 +16063,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -16901,6 +16881,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
       "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
@@ -19541,6 +19522,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -22839,6 +22821,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -22881,7 +22864,6 @@
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -24575,6 +24557,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
       "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
@@ -25299,6 +25282,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -26003,6 +25987,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -27149,6 +27134,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -27614,6 +27600,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -27718,6 +27705,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -27770,6 +27758,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28052,7 +28041,6 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -28069,7 +28057,6 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -28083,7 +28070,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28610,6 +28596,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -28871,6 +28858,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -31314,7 +31302,6 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -32772,6 +32759,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -32923,6 +32911,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -32994,6 +32983,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -33442,6 +33432,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -33903,6 +33894,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -33912,6 +33904,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eject": "react-scripts eject",
     "start-server": "node server/server.js",
     "dev": "concurrently \"node test/mem-mongo.js\" \"npm run start-server\" \"npm start\"",
+    "dev:quick": "node scripts/start-quick.js",
     "lint": "cross-env NODE_ENV=development dotenv -e .env eslint \"src/**/*.{js,jsx}\"",
     "test:e2e": "cross-env NODE_ENV=test dotenv -e .env powershell ./scripts/run-e2e-tests.ps1"
   },

--- a/scripts/start-quick.js
+++ b/scripts/start-quick.js
@@ -1,0 +1,105 @@
+import 'dotenv/config';
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { spawn } from "child_process";
+import fs from 'fs';
+import path from "path";
+import { fileURLToPath } from "url";
+
+// Get directory of this script
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+async function start() {
+    console.log("Starting Quick Dev Environment...");
+
+    // 1. Start In-Memory MongoDB
+    console.log("Starting MongoDB Memory Server...");
+    const mongod = await MongoMemoryServer.create({
+        instance: {
+            port: 27017 // Try default port, or random if busy
+        }
+    });
+    const uri = mongod.getUri();
+    console.log(`MongoDB Memory Server started at: ${uri}`);
+
+    // 2. Run Seeding Script
+    console.log("Seeding database...");
+    await new Promise((resolve, reject) => {
+        const seeder = spawn("node", ["seeds/seed.js"], {
+            cwd: rootDir,
+            stdio: "inherit",
+            env: {
+                ...process.env,
+                MONGODB_URI: uri
+            },
+            shell: true
+        });
+
+        seeder.on("exit", (code) => {
+            if (code === 0) {
+                console.log("Database seeded successfully.");
+                resolve();
+            } else {
+                console.error(`Seeding failed with code ${code}`);
+                reject(new Error("Seeding failed"));
+            }
+        });
+    });
+
+    // 3. Start Backend and Frontend Concurrently
+    console.log("Starting Backend and Frontend...");
+
+    const backend = spawn("npm", ["run", "start-server"], {
+        cwd: rootDir,
+        env: {
+            ...process.env,
+            MONGODB_URI: uri,
+            // Ensure backend knows where to look if it cares, but mostly MONGODB_URI is key
+            PORT: "3001"
+        },
+        shell: true
+    });
+
+    const frontend = spawn("npm", ["start"], { // react-scripts start
+        cwd: rootDir,
+        env: {
+            ...process.env,
+            // React app needs to know where API is if it's not proxied by default
+            // But package.json proxy "http://localhost:3001" handles this usually.
+            PORT: "3000"
+        },
+        shell: true
+    });
+
+    // Pipe outputs
+    backend.stdout.on('data', (data) => {
+        process.stdout.write(`[BACKEND] ${data}`);
+    });
+    backend.stderr.on('data', (data) => {
+        process.stderr.write(`[BACKEND ERROR] ${data}`);
+    });
+
+    frontend.stdout.on('data', (data) => {
+        process.stdout.write(`[FRONTEND] ${data}`);
+    });
+    frontend.stderr.on('data', (data) => {
+        process.stderr.write(`[FRONTEND ERROR] ${data}`);
+    });
+
+    // Handle exits
+    const cleanup = async () => {
+        console.log("Stopping servers...");
+        backend.kill();
+        frontend.kill();
+        await mongod.stop();
+        process.exit();
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+}
+
+start().catch(err => {
+    console.error("Startup failed:", err);
+    process.exit(1);
+});

--- a/seeds/data.json
+++ b/seeds/data.json
@@ -1,0 +1,80 @@
+{
+    "users": [
+        {
+            "_id": "507f1f77bcf86cd799439011",
+            "email": "admin@admin.com",
+            "password": "admin",
+            "role": "admin",
+            "active": true
+        },
+        {
+            "_id": "507f1f77bcf86cd799439012",
+            "email": "partner@example.com",
+            "password": "partner",
+            "role": "partner",
+            "active": true
+        }
+    ],
+    "settings": [
+        {
+            "key": "siteStatus",
+            "value": "available"
+        },
+        {
+            "key": "provider",
+            "value": "azure"
+        },
+        {
+            "key": "deploymentMode",
+            "value": "CDS"
+        },
+        {
+            "key": "site.baseUrl",
+            "value": "http://localhost:3000"
+        }
+    ],
+    "chats": [
+        {
+            "_id": "507f1f77bcf86cd799439021",
+            "chatId": "chat-sample-123",
+            "interactions": [
+                "507f1f77bcf86cd799439031"
+            ],
+            "createdAt": "2023-01-01T12:00:00.000Z"
+        }
+    ],
+    "interactions": [
+        {
+            "_id": "507f1f77bcf86cd799439031",
+            "interactionId": "interaction-sample-001",
+            "question": "507f1f77bcf86cd799439041",
+            "answer": "507f1f77bcf86cd799439051",
+            "expertFeedback": "507f1f77bcf86cd799439061",
+            "createdAt": "2023-01-01T12:00:00.000Z"
+        }
+    ],
+    "questions": [
+        {
+            "_id": "507f1f77bcf86cd799439041",
+            "redactedQuestion": "What is the capital of Canada?",
+            "language": "en",
+            "createdAt": "2023-01-01T12:00:00.000Z"
+        }
+    ],
+    "answers": [
+        {
+            "_id": "507f1f77bcf86cd799439051",
+            "content": "The capital of Canada is Ottawa.",
+            "createdAt": "2023-01-01T12:00:05.000Z"
+        }
+    ],
+    "expertFeedbacks": [
+        {
+            "_id": "507f1f77bcf86cd799439061",
+            "totalScore": 5,
+            "expertEmail": "expert@example.com",
+            "feedback": "This is a great, accurate answer!",
+            "createdAt": "2023-01-01T12:05:00.000Z"
+        }
+    ]
+}

--- a/seeds/seed.js
+++ b/seeds/seed.js
@@ -1,0 +1,91 @@
+import mongoose from 'mongoose';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import bcrypt from 'bcryptjs';
+import dotenv from 'dotenv';
+import dbConnect from '../api/db/db-connect.js';
+import { User } from '../models/user.js';
+import { Setting } from '../models/setting.js';
+import { Chat } from '../models/chat.js';
+import { Interaction } from '../models/interaction.js';
+import { Question } from '../models/question.js';
+import { Answer } from '../models/answer.js';
+import { ExpertFeedback } from '../models/expertFeedback.js';
+import { PublicFeedback } from '../models/publicFeedback.js';
+import { Context } from '../models/context.js';
+import { Eval } from '../models/eval.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load env vars if ensuring we can connect (though usually passed by wrapper)
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) {
+    console.error("Error: MONGODB_URI is not defined.");
+    process.exit(1);
+}
+
+async function seed() {
+    try {
+        console.log(`Connecting to MongoDB at ${MONGODB_URI}...`);
+        // Using dbConnect ensures all schemas are registered
+        await dbConnect();
+        console.log("Connected to MongoDB.");
+        console.log("Registered models:", mongoose.modelNames());
+
+
+        // Read data
+        const dataPath = path.join(__dirname, 'data.json');
+        const rawData = fs.readFileSync(dataPath, 'utf-8');
+        const data = JSON.parse(rawData);
+
+        // Clear existing data
+        console.log("Clearing existing collections...");
+        await User.deleteMany({});
+        await Setting.deleteMany({});
+        await Chat.deleteMany({});
+        await Interaction.deleteMany({});
+        await Question.deleteMany({});
+        await Answer.deleteMany({});
+        await ExpertFeedback.deleteMany({});
+        await PublicFeedback.deleteMany({});
+        await Context.deleteMany({});
+        await Eval.deleteMany({});
+
+        // transform users (hash password)
+        console.log("Seeding Users...");
+        for (const u of data.users) {
+            // Manually hashing because we might be inserting raw or using new User()
+            // If we use new User(u).save(), the pre-save hook will hash it.
+            // Let's use the model to trigger validations and hooks.
+            const user = new User(u);
+            // The pre-save hook in models/user.js hashes the password
+            await user.save();
+        }
+
+        // Settings
+        console.log("Seeding Settings...");
+        await Setting.insertMany(data.settings);
+
+        // Chats & related
+        console.log("Seeding Chat History...");
+        await ExpertFeedback.insertMany(data.expertFeedbacks || []);
+        await Question.insertMany(data.questions);
+        await Answer.insertMany(data.answers);
+        await Interaction.insertMany(data.interactions);
+        await Chat.insertMany(data.chats);
+
+
+        console.log("Seeding completed successfully.");
+        process.exit(0);
+
+    } catch (error) {
+        console.error("Seeding failed:", error);
+        process.exit(1);
+    }
+}
+
+seed();


### PR DESCRIPTION
- Add scripts/start-quick.js for in-memory MongoDB + seeding + hot-reload
- Add seeds/data.json with default users, settings, and sample chats
- Add seeds/seed.js to populate database on startup
- Add dev:quick npm script to package.json
- Update README.md with Quick Start documentation and .env requirements

Start and edit front-end without restarting, and easy startup with npm run dev:quick