### PR TITLE
feat: update URL truncation in filter show domain and segment

### DIFF
--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -62,21 +62,26 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
     [lang]
   );
 
-  // Helper function to truncate URL to path only (max 3 segments)
-  const truncateUrl = useCallback((url) => {
-    if (!url) return '';
-    try {
-      const urlObj = new URL(url);
-      const pathParts = urlObj.pathname.split('/').filter(part => part !== '');
+// Helper function to truncate URL to path only (max 3 segments)
+const truncateUrl = useCallback((url) => {
+  if (!url) return '';
+  try {
+    const urlObj = new URL(url);
+    const pathParts = urlObj.pathname.split('/').filter(part => part !== '');
 
-      // Keep only the last 3 path segments
-      const truncatedParts = pathParts.slice(-3);
-
-      return '/' + truncatedParts.join('/');
-    } catch {
-      return url;
+    // If no path segments or only 1 segment, show the domain
+    if (pathParts.length <= 1) {
+      const domain = urlObj.hostname.replace(/^www\./, '');
+      return pathParts.length === 1 ? `${domain}/${pathParts[0]}` : domain;
     }
-  }, []);
+
+    // Keep only the last 3 path segments for longer URLs
+    const truncatedParts = pathParts.slice(-3);
+    return '/' + truncatedParts.join('/');
+  } catch {
+    return url;
+  }
+}, []);
 
   // Helper function to truncate email to username only
   const truncateEmail = useCallback((email) => {


### PR DESCRIPTION
Will display like this:

'https://canada.ca' → 'canada.ca'
'https://www.canada.ca/en' → 'canada.ca/en'
'https://canada.ca/en/services' → '/en/services'
'https://canada.ca/en/services/benefits/ei' → '/services/benefits/ei'
'https://canada.ca/en/services/benefits/ei/apply' → '/benefits/ei/apply'