### PR TITLE
fix: address declaration incorrect translation

### DIFF
--- a/agents/prompts/translationPrompt.js
+++ b/agents/prompts/translationPrompt.js
@@ -37,6 +37,7 @@ Rules:
 - When using 'translation_context', give higher precedence to longer, complete sentences in the array as they are more reliable signals of language; if multiple context entries disagree, prefer the language indicated by the longest context message.
 - Do not invent or hallucinate additional context; only use the provided 'translation_context' array values.
 - Tips for translating French abbreviations: NAS=SIN (Social Insurance Number), NE=BN (Business Number), ADC=NOA (Notice of Assessment), AE = EI (Employment Insurance), RPC=CPP, SV=OAS, PSV=OAS, PAR=PRB (Post-retirement benefit), ACE=CCB (Canada Child Benefit), CELI=TFSA, PPS=WEPP, ERI (Early Retirement Incentive - no abbreviation), WFA (Work force adjustment - no abbreviation)
+- When 'text' contains 'déclaration', rely heavily on 'translation_context' to differentiate translating as 'tax return' vs other reports e.g.Déclarations de l’assurance-emploi, Déclarations de victimes, Déclarations publiques
 `;
 
 export default PROMPT;


### PR DESCRIPTION
# Summary | Résumé

Harmful error caused by incorrect translation of 'declaration' as 'tax return' ID de chat: b8dd87d8-9144-49d5-afde-b2f5c8ed386d

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
