### PR TITLE
Bug - referring URL not being passed to chat view 

### DIFF
--- a/__tests__/api.chat-dashboard.filters.all.test.js
+++ b/__tests__/api.chat-dashboard.filters.all.test.js
@@ -168,9 +168,11 @@ describe('api/chat/chat-dashboard - per-filter pipeline creation', () => {
       length: 10
     });
     expect(ChatModel.Chat.aggregate).toHaveBeenCalled();
-    // Use .filter().pop() to get the LAST sort stage, as there is an earlier sort stage for grouping stability
-    const sortStages = capturedPipeline.filter(stage => stage && stage.$sort);
-    const sortStage = sortStages[sortStages.length - 1];
+    // There is an earlier pre-group $sort for deterministic grouping.
+    // Assert on the later dynamic sort stage that includes interactionCount.
+    const sortStage = capturedPipeline.find(
+      stage => stage && stage.$sort && Object.prototype.hasOwnProperty.call(stage.$sort, 'interactionCount')
+    );
     expect(sortStage).toBeDefined();
     expect(sortStage.$sort.interactionCount).toBeDefined();
   });

--- a/__tests__/api.chat-dashboard.referringUrl.test.js
+++ b/__tests__/api.chat-dashboard.referringUrl.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Chat } from '../models/chat.js';
+import chatDashboardHandler from '../api/chat/chat-dashboard.js';
+
+vi.mock('../middleware/auth.js', () => ({
+    withProtection: (handler) => (req, res) => handler(req, res),
+    authMiddleware: {},
+    partnerOrAdminMiddleware: {}
+}));
+vi.mock('../api/db/db-connect.js', () => ({ default: vi.fn() }));
+vi.mock('../models/chat.js', () => ({
+    Chat: {
+        aggregate: vi.fn(() => ({
+            allowDiskUse: vi.fn(() => Promise.resolve([]))
+        }))
+    }
+}));
+
+describe('Chat Dashboard API - Referring URL Filter', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should include referringUrl regex in the aggregation pipeline when filtered', async () => {
+        const req = {
+            method: 'GET',
+            query: {
+                startDate: '2025-01-01',
+                endDate: '2025-01-02',
+                referringUrl: 'canada.ca/en/services'
+            }
+        };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn()
+        };
+
+        await chatDashboardHandler(req, res);
+
+        // Capture the pipeline passed to aggregate
+        const pipeline = vi.mocked(Chat.aggregate).mock.calls[0][0];
+
+        // Find the match stage that includes the referringUrl filter
+        // Based on chat-dashboard.js, it uses getChatFilterConditions and pushes to a $match stage
+        const matchStage = pipeline.find(stage => stage.$match && stage.$match.$and);
+        expect(matchStage).toBeDefined();
+
+        const referringUrlFilter = matchStage.$match.$and.find(cond =>
+            cond['interactions.referringUrl'] && cond['interactions.referringUrl'].$regex
+        );
+
+        expect(referringUrlFilter).toBeDefined();
+        expect(referringUrlFilter['interactions.referringUrl'].$regex).toContain('canada\\.ca/en/services');
+    });
+});

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -138,6 +138,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
       }, 200);
     }
   }, [initialMessages, targetInteractionId]);
+
+  // Sync initialReferringUrl when it arrives asynchronously (e.g. after chat
+  // data is fetched in review mode). useState only captures the initial null.
+  useEffect(() => {
+    if (initialReferringUrl) {
+      setReferringUrl(initialReferringUrl);
+    }
+  }, [initialReferringUrl]);
   // This effect sets up a resize listener to update isMobile state for citation icon and link styling
   useEffect(() => {
     const handleResize = () => {

--- a/src/components/chat/__tests__/ChatAppContainer.referringUrl.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.referringUrl.test.js
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import ChatAppContainer from '../ChatAppContainer';
+import { usePageContext } from '../../../hooks/usePageParam';
+
+// Mock hooks before importing components that use them
+vi.mock('../../../hooks/usePageParam', () => ({
+    usePageContext: vi.fn(),
+    DEPARTMENT_MAPPINGS: {
+        'revenue-agency': { code: 'CRA', en: 'revenue-agency', fr: 'agence-revenu' }
+    }
+}));
+
+vi.mock('../../../hooks/useTranslations', () => ({
+    useTranslations: vi.fn(() => ({
+        t: (k) => {
+            const mockT = (val) => val;
+            mockT.text = (val) => val;
+            return mockT(k);
+        }
+    }))
+}));
+
+// Mock services
+vi.mock('../../../services/DataStoreService', () => ({ default: { getPublicSetting: vi.fn(() => Promise.resolve('azure')) } }));
+vi.mock('../../../services/SessionService', () => ({ default: { getChatId: vi.fn(() => Promise.resolve('abc')) } }));
+vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)) } }));
+vi.mock('../../../services/ChatWorkflowService', () => ({ ChatWorkflowService: { processResponse: vi.fn() }, RedactionError: class { }, ShortQueryValidation: class { } }));
+
+vi.mock('../ChatInterface', () => ({
+    default: ({ referringUrl, handleReferringUrlChange, turnCount, readOnly }) => (
+        <div data-testid="chat-interface">
+            <div data-testid="url-display">{referringUrl}</div>
+            <button data-testid="change-btn" onClick={() => handleReferringUrlChange({ target: { value: 'manual-url' } })}>Change</button>
+            <div data-testid="turn-count">{turnCount}</div>
+            {turnCount === 0 && referringUrl && !readOnly && (
+                <div data-testid="hint">Hint: {referringUrl}</div>
+            )}
+        </div>
+    )
+}));
+
+describe('ChatAppContainer - Referring URL', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('prefers initialReferringUrl (Review Mode)', async () => {
+        render(<ChatAppContainer lang="en" initialReferringUrl="init-url" readOnly={true} />);
+        await waitFor(() => expect(screen.getByTestId('url-display').textContent).toBe('init-url'));
+    });
+
+    it('prefers pageUrl over clientReferrer (Live Mode)', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: 'page-url', department: '' });
+
+        // Pass clientReferrer prop directly as HomePage.js would
+        render(<ChatAppContainer lang="en" clientReferrer="ref-url" />);
+        await waitFor(() => expect(screen.getByTestId('url-display').textContent).toBe('page-url'));
+    });
+
+    it('falls back to clientReferrer prop if pageUrl is missing', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+
+        // Simulating HomePage.js behavior: <ChatAppContainer clientReferrer={document.referrer} />
+        render(<ChatAppContainer lang="en" clientReferrer="ref-url" />);
+        await waitFor(() => expect(screen.getByTestId('url-display').textContent).toBe('ref-url'));
+    });
+
+    it('handles manual update and shows hint', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: 'original-url', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        // Initial hint from pageUrl
+        const hint = await screen.findByTestId('hint');
+        expect(hint.textContent).toContain('original-url');
+
+        // Change it
+        fireEvent.click(screen.getByTestId('change-btn'));
+
+        await waitFor(() => expect(screen.getByTestId('url-display').textContent).toBe('manual-url'));
+    });
+});

--- a/tests/e2e/chat-referring-url.spec.js
+++ b/tests/e2e/chat-referring-url.spec.js
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '../../.env') });
+
+const TEST_ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'e2e-admin@example.com';
+const TEST_ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'password123';
+
+async function sendQuestionAndGetChatId(page, question) {
+    const textarea = page.locator('textarea#message');
+    await textarea.focus();
+    await page.keyboard.type(question);
+    await page.waitForTimeout(500);
+    await page.locator('.btn-primary-send').click();
+    await page.waitForSelector('.message.ai .ai-message-content', { state: 'visible', timeout: 30000 });
+
+    const chatIdText = (await page.locator('.chat-id').last().textContent()) || '';
+    const match = chatIdText.match(/Chat ID:\s*([a-z0-9-]+)/i);
+    if (!match) {
+        throw new Error(`Could not find Chat ID in UI. Text was: "${chatIdText}"`);
+    }
+    return match[1];
+}
+
+async function loginAsAdmin(page) {
+    await page.goto('/en/signin');
+    await page.fill('#email', TEST_ADMIN_EMAIL);
+    await page.fill('#password', TEST_ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(url => !url.toString().includes('signin'), { timeout: 15000 });
+}
+
+async function verifyReferringUrlInReviewMode(page, chatId, expectedUrl) {
+    await page.goto(`/en?chat=${encodeURIComponent(chatId)}&review=1`);
+    await page.waitForSelector('.referring-url-chat', { timeout: 15000 });
+    const topBanner = page.locator('.referring-url-chat').first();
+    await expect(topBanner).toContainText(expectedUrl);
+}
+
+test.describe('Referring URL Lifecycle', () => {
+    test.afterEach(async ({ page }) => {
+        if (process.env.TEST_HEADED === 'true') {
+            console.log('Test finished, waiting 5s for inspection...');
+            await page.waitForTimeout(5000);
+        }
+    });
+
+    test('should capture referring URL from URL parameter and show it in review mode', async ({ page }) => {
+        const testReferrer = 'https://www.canada.ca/en/services/jobs/opportunities.html';
+        const encodedReferrer = encodeURIComponent(testReferrer);
+
+        await page.goto(`/en?ref=${encodedReferrer}`);
+
+        await page.waitForSelector('#displayReferringURL', { state: 'visible', timeout: 15000 });
+        const hint = page.locator('#displayReferringURL');
+        await expect(hint).toContainText('Page you were on:');
+        await expect(hint).toContainText('canada.ca/.../opportunities.html');
+
+        const chatId = await sendQuestionAndGetChatId(page, 'Hello, catching ref from URL!');
+        await loginAsAdmin(page);
+        await verifyReferringUrlInReviewMode(page, chatId, testReferrer);
+    });
+
+    test('should capture referring URL from document.referrer simulation and show it in review mode', async ({ page }) => {
+        const referrerSite = 'https://external-search.ca/search?q=benefits';
+        await page.goto('/en', { referer: referrerSite });
+
+        await page.waitForSelector('#displayReferringURL', { state: 'visible', timeout: 15000 });
+        const hint = page.locator('#displayReferringURL');
+        await expect(hint).toContainText('Page you were on:');
+        await expect(hint).toContainText('external-search.ca/.../');
+
+        const chatId = await sendQuestionAndGetChatId(page, 'Hello, catching ref from document.referrer!');
+        await loginAsAdmin(page);
+        await verifyReferringUrlInReviewMode(page, chatId, referrerSite);
+    });
+
+    test('should allow manual override of referring URL and show it in review mode', async ({ page }) => {
+        await loginAsAdmin(page);
+        await page.goto('/en');
+
+        const optionsDetails = page.locator('gcds-details[details-title="Options"]');
+        await optionsDetails.waitFor({ state: 'visible', timeout: 15000 });
+        await optionsDetails.evaluate((el) => {
+            el.setAttribute('open', '');
+        });
+        await page.waitForSelector('#referring-url', { state: 'visible', timeout: 15000 });
+
+        const manualUrl = 'https://manual-override.ca/page';
+        await page.fill('#referring-url', manualUrl);
+        const chatId = await sendQuestionAndGetChatId(page, 'Hello with manual override!');
+        await verifyReferringUrlInReviewMode(page, chatId, manualUrl);
+    });
+
+    test('should display referring URL in Review Mode (using API interception)', async ({ page }) => {
+        const chatId = 'mock-chat-' + Date.now();
+        const testUrl = 'https://canada.ca/referring-viewer-test';
+
+        // Correct pattern based on getApiUrl: /api/db/db-chat
+        await page.route('**/api/db/db-chat**', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    chat: {
+                        chatId,
+                        pageLanguage: 'en',
+                        referringUrl: testUrl,
+                        interactions: [
+                            {
+                                interactionId: 'inter-1',
+                                question: { redactedQuestion: 'test question' },
+                                answer: { paragraphs: ['test answer'], answerType: 'normal' },
+                                referringUrl: testUrl,
+                                createdAt: new Date()
+                            }
+                        ],
+                        createdAt: new Date()
+                    }
+                })
+            });
+        });
+
+        await page.goto(`/en?chat=${chatId}&review=1`);
+
+        // Wait for the component to render
+        await page.waitForSelector('.referring-url-chat', { timeout: 15000 });
+
+        const topBanner = page.locator('.referring-url-chat').first();
+        await expect(topBanner).toContainText(testUrl);
+
+        const infoBox = page.locator('a', { hasText: testUrl }).first();
+        await expect(infoBox).toBeVisible();
+    });
+});


### PR DESCRIPTION
https://github.com/cds-snc/ai-answers/issues/1076

The initialMessages prop had a useEffect
  sync, but initialReferringUrl never did — the useState
  initializer always ran with null because the chat data
  fetch happens asynchronously after mount. It likely went
  unnoticed because the referring URL may have been tested
  via the ?ref= query parameter path (which works through
  pageUrl) rather than the review mode path.

  The fix adds a useEffect that watches initialReferringUrl
  and updates the referringUrl state when it arrives from
  the async fetch, matching the pattern already used for
  initialMessages.

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
