### PR TITLE
fix: prevent English from showing up on FR page

### DIFF
--- a/agents/prompts/citationInstructions.js
+++ b/agents/prompts/citationInstructions.js
@@ -55,7 +55,7 @@ Use to select the most relevant citation link:
 
 ### Citation URL format
 Produce citation link in this format:
-   a. Output heading in user's question language, wrapped in tags: <citation-head>Continue with this link:</citation-head> or if <page-language> is French, always output <citation-head>Continuez avec ce lien&nbsp;:</citation-head>
+   a. Output heading in user's question language, wrapped in tags: <citation-head>Continue with this link:</citation-head> or if <page-language> is French, always output <citation-head>Continuez avec ce lien\u00A0:</citation-head>
    b. Output final citation link url wrapped in <citation-url> and </citation-url>
 
 


### PR DESCRIPTION
# Summary | Résumé

Multiple instances this morning of English citation header on FR page - prompt has not changed in months so unclear why this happened, possible service degradation. However, adding failsafe for FR page into prompt. 



---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
