### PR TITLE
404 canada.ca urls getting through

### DIFF
--- a/agents/graphs/DefaultGraph.js
+++ b/agents/graphs/DefaultGraph.js
@@ -181,6 +181,7 @@ graph.addNode('verifyNode', async (state) => {
       department: state.department,
       translationF: state.translationF,
       chatId: state.chatId,
+      tools: state.answer?.tools || [],
     });
 
     finalCitationUrl = citationResult.url || citationResult.fallbackUrl;

--- a/agents/graphs/DefaultWithVectorGraph.js
+++ b/agents/graphs/DefaultWithVectorGraph.js
@@ -287,6 +287,7 @@ graph.addNode('verifyNode', async (state) => {
       department: state.department,
       translationF: state.translationF,
       chatId: state.chatId,
+      tools: state.answer?.tools || [],
     });
 
     finalCitationUrl = citationResult.url || citationResult.fallbackUrl;

--- a/agents/graphs/GPT5MiniDefaultGraph.js
+++ b/agents/graphs/GPT5MiniDefaultGraph.js
@@ -186,6 +186,7 @@ graph.addNode('verifyNode', async (state) => {
             department: state.department,
             translationF: state.translationF,
             chatId: state.chatId,
+            tools: state.answer?.tools || [],
         });
 
         finalCitationUrl = citationResult.url || citationResult.fallbackUrl;

--- a/agents/graphs/GPT5OneChatGraph.js
+++ b/agents/graphs/GPT5OneChatGraph.js
@@ -186,6 +186,7 @@ graph.addNode('verifyNode', async (state) => {
             department: state.department,
             translationF: state.translationF,
             chatId: state.chatId,
+            tools: state.answer?.tools || [],
         });
 
         finalCitationUrl = citationResult.url || citationResult.fallbackUrl;

--- a/agents/graphs/GPT5OneDefaultGraph.js
+++ b/agents/graphs/GPT5OneDefaultGraph.js
@@ -186,6 +186,7 @@ graph.addNode('verifyNode', async (state) => {
             department: state.department,
             translationF: state.translationF,
             chatId: state.chatId,
+            tools: state.answer?.tools || [],
         });
 
         finalCitationUrl = citationResult.url || citationResult.fallbackUrl;

--- a/agents/graphs/InstantAndQAGraph.js
+++ b/agents/graphs/InstantAndQAGraph.js
@@ -303,6 +303,7 @@ graph.addNode('verifyNode', async (state) => {
       department: state.department,
       translationF: state.translationF,
       chatId: state.chatId,
+      tools: state.answer?.tools || [],
     });
 
     finalCitationUrl = citationResult.url || citationResult.fallbackUrl;


### PR DESCRIPTION
Context                                                  │
│                                                          │
│ Since commit 772eac22 (Dec 2025), verifyCitation calls   │
│ validateUrlFormatting instead of validateUrl. **The        │
│ formatting-only method has a tautology bug that accepts  │
│ all URLs unconditionally — it never rejects anything.    │**
│ This lets hallucinated canada.ca URLs through to users   │
│ as citations.                                            │
│                                                          │
│ The original validateUrl (HTTP HEAD/GET) was removed for │
│  performance. The fix should only do live checks when    │
│ necessary: skip URLs already verified by the             │
│ downloadWebPage tool during the answer step, and only    │
│ live-check canada.ca URLs that weren't previously        │
│ fetched.             

 - GraphWorkflowHelper.js: verifyCitation now accepts a tools param and uses a three-tier strategy: skip check if URL was already downloaded, live HEAD/GET for unverified canada.ca URLs, pass-through for non-canada.ca URLs.
  - Six graph files: All pass tools: state.answer?.tools || [] to verifyCitation.
  - No changes to UrlValidationService.js — reuses existing validateUrl for live checks and validateUrlFormatting for fallback generation.

# Summary | Résumé

404 errors in trial - need to prevent but not overload
(https://github.com/cds-snc/ai-answers/issues/1091)

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
