### PR TITLE
ReferredPublic wasn't implemented in chat logs

### DIFF
--- a/api/chat/chat-export-logs.js
+++ b/api/chat/chat-export-logs.js
@@ -432,7 +432,8 @@ async function chatExportHandler(req, res) {
         //    For aggregate, we already define lookups.
         //    I will need to ADD conditional lookups to the pipeline based on `view`.
 
-        const isAggregate = department || referringUrl || urlEn || urlFr || answerType || partnerEval || aiEval;
+        const isAggregate = department || referringUrl || urlEn || urlFr || answerType || partnerEval || aiEval
+            || userType === 'referredPublic';
 
         if (isAggregate) {
             const pipeline = [];

--- a/api/util/chat-filters.js
+++ b/api/util/chat-filters.js
@@ -255,7 +255,17 @@ export function getChatFilterConditions(filters, options = {}) {
     conditions.push({ [userField]: { $exists: true, $ne: null } });
   } else if (filters.userType === 'referredPublic') {
     conditions.push({ [userField]: { $exists: false } });
-    conditions.push({ [withPath('referringUrl')]: { $exists: true, $nin: [null, ''] } });
+    conditions.push({
+      [withPath('referringUrl')]: {
+        $regex: '(canada\\.ca|gc\\.ca)',
+        $options: 'i'
+      }
+    });
+    conditions.push({
+      [withPath('referringUrl')]: {
+        $not: { $regex: '(digital\\.canada\\.ca|blog\\.canada\\.ca)', $options: 'i' }
+      }
+    });
   }
 
   // department


### PR DESCRIPTION
Issue https://github.com/cds-snc/ai-answers/issues/1085 - new filter not applied to chat logs
And fix so that filter ONLY picks canada.ca or gc.ca referring domains and not the blog posts - will narrow down to trial pages with banner. 

Maybe should call this filter 'From banner' but leave it as public-referred for now because it's not specifically looking for the banner. 

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
