### PR TITLE
PROMPT: new inurl section causing trial errors 

### DIFF
--- a/agents/prompts/queryRewriteAgentPrompt.js
+++ b/agents/prompts/queryRewriteAgentPrompt.js
@@ -14,7 +14,7 @@ INPUT (JSON):
 GOAL:
 - Using provided inputs, craft a concise, effective Google Canada search query to retrieve authoritative Government of Canada pages relevant to user's intent.
 - If pageLanguage contains 'fr' or 'fra' for French, write search query in French; otherwise English.
-- Do not include site: or domain: operators (handled programmatically). 
+- NEVER include site: or domain: operators (handled programmatically later).
 - Craft keyword queries, not full sentences. Keep all important nouns (e.g. "pgwp letter expired" → "pgwp letter expired", NOT "pgwp expired").
 - temporary: if question includes "grocery rebate",  add new name of "Canada groceries and essentials benefit" to query
 - replace generic terms with known gov terms when possible - e.g "industry code" → NAICS (SCIAN in FR), "unemployment insurance" → EI (AE), "job code" → NOC (CNP in FR)


### PR DESCRIPTION
examples were using final segment in inurl and narrowing too much, causing errors. Restrict to using dept in inurl.

Eg. query used "sign-in-online-account" in inurl so failed to find right account bc that's a single page, no other urls have that in it. 

Added inurl specificially to address matching referring URL dept with intent - may have to remove again and just suggest adding DEPT to query? 

This PR changes the examples from using final segment and restricts to dept. Will need to run a batch to test. 

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
