### PR TITLE
feat: run search query again if failed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Environment notes
 - **React build restriction**: Files imported by frontend code (`src/`) must live inside `src/`. Never place shared config intended for UI components in `config/` (root) — use `src/config/` instead. Server-side code (`api/`, `agents/`, `services/`) can import from anywhere.
+- **Test runner**: This project uses **vitest**, not jest. Run tests with `npx vitest run <path>` (or `npm test` for all).
 
 ## How to work well in this codebase
 

--- a/agents/prompts/queryRewriteAgentPrompt.js
+++ b/agents/prompts/queryRewriteAgentPrompt.js
@@ -20,6 +20,8 @@ GOAL:
 - Don't add 'Canada' (handled later) 
 - Search engines return fewer results as queries get longer. Distill the user's question to the essential terms that will match government web pages — drop conversational filler, adjectives, and stacking multiple subtopics into one query. If the question covers several distinct concepts, focus on the primary intent.
 - Craft keyword queries, not full sentences. Keep important nouns and verb tense (e.g. "pgwp letter expired" → "pgwp letter expired", NOT "pgwp expiry", or "how do I certify my electric product" → "certify electric product" NOT "certification electric product"). Don't add your own interpretations or terms (e.g. "My EI temporary password expired" → "EI temporary password expired", NOT "EI temporary password expired My Service Canada Account")
+- Long, rambly questions must be aggressively trimmed to the core intent:
+    - "I made honest mistakes on my tax returns from 2025 and want to know about the Voluntary Disclosures Program VDP and form RC199 and if I'll face penalties for aggressive tax schemes" → "voluntary disclosures program RC199"
 - temporary: if question includes "grocery rebate",  add new name of "Canada groceries and essentials benefit" to query
 - replace (not add) generic terms with known gov terms when possible - e.g "industry code" → NAICS (SCIAN in FR), "unemployment insurance" → EI (AE), "job code" → NOC (CNP in FR). Only replace terms that are clearly synonymous. Never map form numbers or codes to department names — form numbers are already specific enough for search.
 - When referringUrl is present and is a government of Canada url, it's often very relevant. Decide whether the topic or dept in the URL aligns with user's question:

--- a/agents/prompts/queryRewriteAgentPrompt.js
+++ b/agents/prompts/queryRewriteAgentPrompt.js
@@ -1,5 +1,5 @@
 export const PROMPT = `
-You are the search query agent in the AI Answers pipeline on Canada.ca. Your only job is to craft a short keyword search query — another agent will use the results to answer the user's question.
+You are the search query agent in the AI Answers pipeline on Canada.ca. Your only job is to craft an effective keyword search query — another agent will use the results to answer the user's question.
 
 CRAFT SEARCH QUERY (JSON IN/OUT)
 
@@ -14,11 +14,12 @@ INPUT (JSON):
 }
 
 GOAL:
-- Using provided inputs, craft a concise, effective Google Canada search query to retrieve authoritative Government of Canada pages relevant to user's intent.
+- Using provided inputs, craft a concise, effective search query to retrieve authoritative Government of Canada pages relevant to user's intent.
 - If pageLanguage contains 'fr' or 'fra' for French, write search query in French; otherwise English.
 - NEVER include site: or domain: operators (handled programmatically later)
 - Don't add 'Canada' (handled later) 
-- Craft effective search keyword queries, not full sentences. Keep important nouns and verb tense (e.g. "pgwp letter expired" → "pgwp letter expired", NOT "pgwp expiry", or "how do I certify my electric product" → "certify electric product" NOT "certification electric product"). Don't add your own interpretations or terms (e.g. "My EI temporary password expired" → "EI temporary password expired", NOT "EI temporary password expired My Service Canada Account")
+- Search engines return fewer results as queries get longer. Distill the user's question to the essential terms that will match government web pages — drop conversational filler, adjectives, and stacking multiple subtopics into one query. If the question covers several distinct concepts, focus on the primary intent.
+- Craft keyword queries, not full sentences. Keep important nouns and verb tense (e.g. "pgwp letter expired" → "pgwp letter expired", NOT "pgwp expiry", or "how do I certify my electric product" → "certify electric product" NOT "certification electric product"). Don't add your own interpretations or terms (e.g. "My EI temporary password expired" → "EI temporary password expired", NOT "EI temporary password expired My Service Canada Account")
 - temporary: if question includes "grocery rebate",  add new name of "Canada groceries and essentials benefit" to query
 - replace (not add) generic terms with known gov terms when possible - e.g "industry code" → NAICS (SCIAN in FR), "unemployment insurance" → EI (AE), "job code" → NOC (CNP in FR). Only replace terms that are clearly synonymous. Never map form numbers or codes to department names — form numbers are already specific enough for search.
 - When referringUrl is present and is a government of Canada url, it's often very relevant. Decide whether the topic or dept in the URL aligns with user's question:
@@ -49,12 +50,11 @@ If no history, build query from translatedText (and referringUrl when relevant).
 OUTPUT (JSON):
 Return a single JSON object only (no surrounding text):
 {
-  "query": string,                // crafted search query (short keywords)
+  "query": string,                // crafted search query (keywords)
 }
 
 Rules:
 - Output only valid JSON, nothing else.
-- Keep query short and focused (prefer under ~10 tokens when possible).
 - NEVER invent or infer department names, acronyms, or program names that do not appear in the question or referringUrl. If you are unsure which department a form or program belongs to, do NOT guess — use only the words from the question.
 `;
 

--- a/agents/prompts/queryRewriteAgentPrompt.js
+++ b/agents/prompts/queryRewriteAgentPrompt.js
@@ -58,3 +58,32 @@ Rules:
 - NEVER invent or infer department names, acronyms, or program names that do not appear in the question or referringUrl. If you are unsure which department a form or program belongs to, do NOT guess — use only the words from the question.
 `;
 
+export const RETRY_PROMPT = `
+You are the search query agent in the AI Answers pipeline on Canada.ca. A previous search query returned too few results (0 or 1). Your job is to craft a NEW, simpler keyword query that is more likely to return results.
+
+INPUT (JSON):
+{
+  "translatedText": string,       // original user question
+  "failedQuery": string,          // the search query that failed to return enough results
+  "pageLanguage": string,         // 'en' or 'fr'
+  "referringUrl": string|null     // optional
+}
+
+STRATEGY:
+- The failed query was too specific, too long, or contained terms the search engine couldn't match.
+- Your new query must differ from failedQuery — repeating the same query will return the same poor results. Change the wording: drop words, use synonyms, or broaden the scope.
+- Remove jargon, uncommon words, acronyms the search engine may not index, and overly specific modifiers.
+- Keep only the core nouns/verbs that capture the user's intent.
+- If the failed query used an inurl: operator, try without it.
+- Aim for 3-5 broad keywords maximum.
+- If pageLanguage is 'fr', write the query in French; otherwise English.
+- Do NOT add 'Canada' (handled programmatically).
+- Do NOT add site: or domain: operators.
+
+OUTPUT (JSON):
+Return a single JSON object only (no surrounding text):
+{
+  "query": string   // simplified search query
+}
+`;
+

--- a/agents/strategies/queryRewriteStrategy.js
+++ b/agents/strategies/queryRewriteStrategy.js
@@ -1,9 +1,24 @@
-import { PROMPT as QUERY_REWRITE_PROMPT } from '../prompts/queryRewriteAgentPrompt.js';
+import { PROMPT as QUERY_REWRITE_PROMPT, RETRY_PROMPT } from '../prompts/queryRewriteAgentPrompt.js';
 
 export const queryRewriteStrategy = {
   // request: { translationData: { translatedText, translatedLanguage, originalText, noTranslation, translationContext }, referringUrl, pageLanguage }
+  // Retry mode: when request.failedQuery is set, uses RETRY_PROMPT to generate a simpler query
   buildMessages: (request = {}) => {
-    const { translationData = {}, referringUrl = '', pageLanguage: pageLanguage = '' } = request;
+    const { translationData = {}, referringUrl = '', pageLanguage: pageLanguage = '', failedQuery } = request;
+
+    // Retry mode: use simplified prompt with the failed query
+    if (failedQuery) {
+      const translatedText = translationData.translatedText || translationData.originalText || '';
+      const system = { role: 'system', content: RETRY_PROMPT };
+      const userPayload = {
+        translatedText,
+        failedQuery,
+        pageLanguage,
+        referringUrl: referringUrl || null,
+      };
+      return [system, { role: 'user', content: JSON.stringify(userPayload) }];
+    }
+
     const system = { role: 'system', content: QUERY_REWRITE_PROMPT };
     // Provide a JSON blob to the user part so the agent can use structured inputs.
     // The prompt expects a top-level object: { translatedText, pageLanguage, referringUrl }

--- a/services/SearchContextService.js
+++ b/services/SearchContextService.js
@@ -14,6 +14,14 @@ async function performSearch(query, lang, searchService = 'canadaca', chatId = '
     return await exponentialBackoff(() => searchFunction(query, lang));
 }
 
+function countSearchResults(resultsString) {
+    if (!resultsString || resultsString === 'No results found.') return 0;
+    // Coveo results use "Summary:", Google results use "Title:"
+    const summaryCount = (resultsString.match(/^Summary: /gm) || []).length;
+    const titleCount = (resultsString.match(/^Title: /gm) || []).length;
+    return Math.max(summaryCount, titleCount);
+}
+
 export const SearchContextService = {
     async search({ chatId = 'system', searchService = 'canadaca', agentType = 'openai', referringUrl = '', translationData = null, pageLanguage = '' }) {
         ServerLoggingService.info('Received request to search.', chatId, { searchService, referringUrl });
@@ -33,8 +41,45 @@ export const SearchContextService = {
         const searchQuery = rewriteResult.query;
         ServerLoggingService.info('SearchContextAgent rewrite result:', chatId, { pageLanguage, ...rewriteResult });
 
-        const searchResults = await performSearch(searchQuery, lang, searchService, chatId);
+        let searchResults = await performSearch(searchQuery, lang, searchService, chatId);
         ServerLoggingService.debug('Search results:', chatId, searchResults);
+
+        // Retry with a simplified query if search returned 0 or 1 results
+        const resultCount = countSearchResults(searchResults?.results);
+        if (resultCount <= 1) {
+            try {
+                ServerLoggingService.info('Search returned too few results, retrying with simplified query', chatId, {
+                    failedQuery: searchQuery,
+                    resultCount,
+                });
+
+                const retryRequest = { translationData, referringUrl, pageLanguage: lang, failedQuery: searchQuery };
+                const retryRewrite = await AgentOrchestratorService.invokeWithStrategy({
+                    chatId,
+                    agentType,
+                    request: retryRequest,
+                    createAgentFn: createQueryRewriteAgent,
+                    strategy: queryRewriteStrategy,
+                });
+                const retryQuery = retryRewrite.query;
+                ServerLoggingService.info('SearchContextAgent retry rewrite result:', chatId, { retryQuery, originalFailedQuery: searchQuery });
+
+                const retryResults = await performSearch(retryQuery, lang, searchService, chatId);
+                const retryCount = countSearchResults(retryResults?.results);
+                ServerLoggingService.info('Retry search results:', chatId, { retryQuery, retryResultCount: retryCount });
+
+                // Use retry results if they're better, otherwise keep original
+                if (retryCount > resultCount) {
+                    return {
+                        ...retryResults,
+                        ...retryRewrite,
+                        query: retryQuery,
+                    };
+                }
+            } catch (retryError) {
+                ServerLoggingService.error('Search retry failed, using original results', chatId, retryError);
+            }
+        }
 
         return {
             ...searchResults,


### PR DESCRIPTION
# Summary | Résumé

> search results sometimes fail to get any results, or just get one, this often causes errors. If no or one result, run the search query again. 

Changes made                                                
                                                              
  agents/prompts/queryRewriteAgentPrompt.js — Added           
  RETRY_PROMPT export that instructs the LLM to simplify a    
  failed query by removing jargon, uncommon words, and overly 
  specific modifiers, aiming for 3-5 broad keywords.          
                                                              
  agents/strategies/queryRewriteStrategy.js — When            
  request.failedQuery is present, buildMessages now uses
  RETRY_PROMPT instead of the normal prompt and sends {       
  translatedText, failedQuery, pageLanguage, referringUrl } to
   the LLM (no history needed for retries).                 

  services/SearchContextService.js — Added                    
  countSearchResults() helper that counts Summary: / Title:
  occurrences in the result string. After the initial search, 
  if ≤1 results:                                    
  - Logs the failed query and result count                  
  - Calls queryRewrite again in retry mode with the failed    
  query                                                   
  - Searches again with the simplified query                  
  - Uses retry results only if they're better than the
  original; otherwise keeps original                          
  - Only the final winning query is returned (same shape as   
  before)                                                   
                                                              
  Still TODO                                        
                                                              
  - If retry also returns 0 results, surface a user-facing    
  error message asking them to rephrase with more detail    
  - The dead deriveContext export in                          
  agents/graphs/services/contextService.js is unused — flag   
  for cleanup  

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
