### PR TITLE
batch bug missing questions

### DIFF
--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -163,6 +163,12 @@ async function handler(req, res) {
 
   res.write(': connected\n\n');
 
+  // Send periodic SSE comments to prevent proxies (e.g. Akamai) from dropping
+  // idle connections during long LLM calls (GPT-5.1 reasoning can take 60-120s).
+  let keepAliveTimer = setInterval(() => {
+    try { res.write(': ping\n\n'); } catch (_e) { clearInterval(keepAliveTimer); }
+  }, 15000);
+
   let resultSent = false;
   let streamError = null;
 
@@ -228,6 +234,7 @@ async function handler(req, res) {
       resultSent = true;
     }
   } finally {
+    clearInterval(keepAliveTimer);
     if (!resultSent && !streamError) {
       writeEvent(res, 'error', { message: 'Graph completed without result payload' });
     }

--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -8,8 +8,13 @@ import { graphRequestContext } from '../../agents/graphs/requestContext.js';
 const REQUIRED_METHOD = 'POST';
 
 function writeEvent(res, event, data) {
-  res.write(`event: ${event}\n`);
-  res.write(`data: ${JSON.stringify(data)}\n\n`);
+  try {
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  } catch (_e) {
+    // Client may have disconnected after receiving the result; ignore write
+    // failures so the graph can finish running (notably persistNode).
+  }
 }
 
 function buildGraphErrorPayload(error) {
@@ -202,11 +207,13 @@ async function handler(req, res) {
 
     await graphRequestContext.run(store, async () => {
       const stream = await appToRun.stream(input, { streamMode: 'updates' });
+      // Drain the full stream — do NOT break after emitting the result.
+      // The `result` is emitted by verifyNode, but persistNode runs after and
+      // saves the Chat to MongoDB. Breaking early cancels the async iterator
+      // and can leave persistNode unfinished, causing items to be silently
+      // dropped from the DB.
       for await (const update of stream) {
         traverseForUpdates(update, handlers);
-        if (resultSent) {
-          break;
-        }
       }
     });
   } catch (err) {

--- a/config/ai-models.js
+++ b/config/ai-models.js
@@ -27,7 +27,7 @@ const AI_MODELS = {
         model: "gpt-5-mini",
         maxTokens: 10024,
         temperature: 0.0,
-        timeoutMs: 60000,
+        timeoutMs: 120000,
         reasoning: {
           effort: "low"
         }
@@ -44,7 +44,7 @@ const AI_MODELS = {
         model: "gpt-5.1",
         maxTokens: 10024,
         temperature: 0.0,
-        timeoutMs: 60000,
+        timeoutMs: 180000,
         reasoning: {
           effort: "low"
         }
@@ -53,7 +53,7 @@ const AI_MODELS = {
         model: "gpt-5.1",
         maxTokens: 10024,
         temperature: 0.0,
-        timeoutMs: 60000,
+        timeoutMs: 180000,
         reasoning: {
           effort: "low"
         }

--- a/src/components/batch/BatchUpload.js
+++ b/src/components/batch/BatchUpload.js
@@ -40,7 +40,7 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
       return;
     }
 
-    if (!uploadedFile.name.endsWith('.csv')) {
+    if (!uploadedFile.name.toLowerCase().endsWith('.csv')) {
       setError(t('batch.upload.error.invalidFile'));
       setFile(null);
       return;
@@ -149,8 +149,13 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
           setProcessing(false);
         }
       } catch (err) {
-        setError(t('batch.upload.error.readFailed'));
+        // Surface the actual parse error (e.g. missing column, empty file)
+        // so the admin can see what's wrong with the CSV.
+        const detail = err?.message || t('batch.upload.error.readFailed');
+        setError(detail);
         console.error('Error reading file:', err);
+        // Re-show the upload button so the user can retry without re-selecting
+        setFileUploaded(false);
         setProcessing(false);
       }
     }
@@ -171,14 +176,13 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
         throw new Error('The CSV file is empty or invalid.');
       }
 
-      const headers = jsonData[0].map((header) => header.trim().toUpperCase());
-      const problemDetailsIndex = headers.findIndex(
-        (h) => h === 'PROBLEM DETAILS' || h === 'QUESTION' || h === 'REDACTEDQUESTION'
-      );
+      const headers = jsonData[0].map((header) => String(header ?? '').trim().toUpperCase());
+      const QUESTION_HEADERS = ['PROBLEM DETAILS', 'PROBLEMDETAILS', 'QUESTION', 'REDACTEDQUESTION', 'REDACTED QUESTION'];
+      const problemDetailsIndex = headers.findIndex((h) => QUESTION_HEADERS.includes(h));
 
       if (problemDetailsIndex === -1) {
         throw new Error(
-          'Required column "PROBLEM DETAILS/REDACTEDQUESTION" not found in CSV file. Please ensure you are using a file with that column or downloaded from the Feedback Viewer.'
+          `Required question column not found in CSV file. Expected one of: ${QUESTION_HEADERS.join(', ')}. Found headers: ${headers.filter(Boolean).join(', ') || '(none)'}.`
         );
       }
 
@@ -187,13 +191,14 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
         .map((row) => {
           const entry = {};
           headers.forEach((header, index) => {
-            const key = header === 'PROBLEM DETAILS' ? 'REDACTEDQUESTION' : header;
-            entry[key] = row[index]?.trim() || '';
+            const key = (header === 'PROBLEM DETAILS' || header === 'PROBLEMDETAILS' || header === 'REDACTED QUESTION')
+              ? 'REDACTEDQUESTION'
+              : header;
+            entry[key] = String(row[index] ?? '').trim();
           });
-          console.log('Processing entry:', entry);
           return entry;
         })
-        .filter((entry) => entry['REDACTEDQUESTION']); // Only filter based on 'QUESTION' presence
+        .filter((entry) => entry['REDACTEDQUESTION']);
 
       console.log(`Found ${entries.length} valid entries to process`);
       return entries;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -267,6 +267,7 @@
       "error": {
         "noFile": "Please select a file first.",
         "nameRequired": "Please enter a batch name.",
+        "invalidFile": "Invalid file type. Please upload a .csv file.",
         "readFailed": "Failed to read the file. Please try uploading again.",
         "saveFailed": "Failed to save batch to server. Please try again."
       }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -267,6 +267,7 @@
       "error": {
         "noFile": "Veuillez sélectionner un fichier d'abord.",
         "nameRequired": "Veuillez entrer un nom de lot.",
+        "invalidFile": "Type de fichier non valide. Veuillez télécharger un fichier .csv.",
         "readFailed": "Impossible de lire le fichier. Veuillez réessayer de le télécharger.",
         "saveFailed": "Impossible d'enregistrer le lot sur le serveur. Veuillez réessayer."
       }

--- a/src/services/BatchService.js
+++ b/src/services/BatchService.js
@@ -481,9 +481,11 @@ class BatchService {
     if (!err) return false;
     const m = (err.status || err.code || '').toString().toLowerCase();
     const msg = (err.message || '').toLowerCase();
-    // treat network and 5xx/429 as transient
+    // treat network, 5xx/429, and dropped SSE connections as transient
     if (msg.includes('timeout') || msg.includes('network') || msg.includes('502') || msg.includes('503') || msg.includes('504')) return true;
     if (m === '429' || msg.includes('rate limit') || msg.includes('too many requests')) return true;
+    // SSE stream closed before result (e.g. proxy dropped idle connection during long LLM call)
+    if (msg.includes('stream ended') || msg.includes('aborted')) return true;
     return false;
   }
 


### PR DESCRIPTION
Issue: https://github.com/cds-snc/ai-answers/issues/1272 - batches miss too many questions
There are
  three contributing factors:

  1. No SSE keepalive heartbeat —
  GPT-5.1 reasoning takes 60-120s with
  zero data flowing. Akamai drops idle
  SSE connections during that window.
  2. _isTransientError misses
  connection-drop errors — "Graph
  stream ended before result event"
  doesn't match any retry pattern, so
  dropped connections don't retry.
  3. timeoutMs: 60000 is too tight for
  GPT-5.1 — 60s LLM timeout is shorter
  than GPT-5.1's actual response time.

  The pattern "smaller files are worse"
   makes sense: with concurrency=3, a
  4-question batch has 3 connections
  open simultaneously, all going idle
  during reasoning, all getting dropped
   at once.
   
   Fix
 - keepAliveTimer is declared in handler scope before the try and cleared in finally — no leak paths. Closure over keepAliveTimer inside the callback works because setInterval returns synchronously before the first tick.
  - SSE comment : ping\n\n is ignored by GraphClient.processEvent (no event:/data: prefix → falls through returning { done: false }). Verified.
  - The keepalive runs on the event loop independent of the for await stream, so it fires even during a blocking answerNode LLM call.
  - _isTransientError addition is safe: user-initiated cancel in BatchService doesn't pass a signal to GraphClient, so 'aborted' in an error message always comes from network/stream drops, never user action. No risk of spurious retries.
  - Timeouts fit comfortably under the server's 300s Express timeout.

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
