### PR TITLE
Pii agent back to gpt4o

### DIFF
--- a/SYSTEM_CARD.md
+++ b/SYSTEM_CARD.md
@@ -94,6 +94,7 @@ Two entry points appear on the left: "External uses" (Canada.ca, AI Answers) and
   - Pages modified within the last 4 months
   - Unfamiliar URLs not in training data
   - Specific details like numbers, codes, dates, dollar amounts
+  - exploring sub-agents for API and MCP calls
 - **URL validation**: Automatically checks if citation URLs are active and accessible
 - **Context generation**: Derives fresh context for **every question**, including follow-on questions, to ensure accurate department identification and relevant content
 - **Content verification**: Prioritizes freshly downloaded content over training data
@@ -106,7 +107,7 @@ The system uses a **multi-step LangGraph pipeline** that orchestrates all proces
 2. **Short Query Validation** (Programmatic): Block queries that are too short to be meaningful
 3. **Two-Stage Question Blocking**:
    - **Stage 1** (Programmatic): Pattern-based blocking for profanity, threats, and common PI (word lists configurable by admins via Settings page)
-   - **Stage 2** (AI - configurable model): AI detects personal information that slipped through; question is then blocked
+   - **Stage 2** (AI - Azure OpenAI GPT-4o, Canada East region): AI detects personal information that slipped through; question is then blocked
 4. **Translation** (AI - configurable mini model): Detects language and translates to English for processing
 5. **Query Rewrite & Search** (AI - mini model): Rewrite the translated question into an optimized search query and run it against Canada.ca or Google. If the first search returns zero or one result, automatically rewrite again with a simplified query and retry; the better result set is kept.
 6. **Context Derivation** (AI - full model): Department matching and context generation from search results; optionally loads department-specific scenarios

--- a/SYSTEM_CARD.md
+++ b/SYSTEM_CARD.md
@@ -94,7 +94,6 @@ Two entry points appear on the left: "External uses" (Canada.ca, AI Answers) and
   - Pages modified within the last 4 months
   - Unfamiliar URLs not in training data
   - Specific details like numbers, codes, dates, dollar amounts
-  - exploring sub-agents for API and MCP calls
 - **URL validation**: Automatically checks if citation URLs are active and accessible
 - **Context generation**: Derives fresh context for **every question**, including follow-on questions, to ensure accurate department identification and relevant content
 - **Content verification**: Prioritizes freshly downloaded content over training data

--- a/SYSTEM_CARD_FR.md
+++ b/SYSTEM_CARD_FR.md
@@ -105,7 +105,7 @@ Le système utilise un **pipeline LangGraph multi-étapes** qui orchestre tout l
 2. **Validation de requête courte** (Programmatique) : Bloque les requêtes trop courtes pour être significatives
 3. **Rédaction en deux étapes** :
    - **Étape 1** (Programmatique) : Filtrage basé sur motifs pour la profanité, les menaces et les renseignements personnels courants (listes de mots configurables par les administrateurs via la page Paramètres)
-   - **Étape 2** (IA - modèle configurable) : Détection alimentée par IA des renseignements personnels qui ont échappé au premier filtrage
+   - **Étape 2** (IA - GPT-4o Azure OpenAI, région Canada Est) : Détection alimentée par IA des renseignements personnels qui ont échappé au premier filtrage
 4. **Traduction** (IA - mini modèle configurable) : Détecte la langue et traduit en anglais pour le traitement
 5. **Réécriture de requête et recherche** (IA - mini modèle) : Réécrit la question traduite en une requête de recherche optimisée et l'exécute sur Canada.ca ou Google. Si la première recherche ne retourne aucun résultat ou un seul résultat, une nouvelle réécriture simplifiée est effectuée automatiquement et la recherche est relancée; le meilleur ensemble de résultats est conservé.
 6. **Dérivation de contexte** (IA - modèle complet) : Correspondance de département et génération de contexte à partir des résultats de recherche; charge optionnellement les scénarios spécifiques au département

--- a/agents/AgentFactory.js
+++ b/agents/AgentFactory.js
@@ -188,6 +188,11 @@ const createPIIAgent = async (agentType, chatId = 'system') => {
     case 'openai-gpt51-chat': {
       // PII detection must stay in-region (Canada East). gpt-5-mini routes to
       // global inference, so force gpt-4o regardless of the caller's model choice.
+      // TODO: this branch uses the short-form Azure constructor options
+      // (azureApiKey/azureEndpoint/apiVersion) to match the sibling 'azure' case,
+      // while every other factory function's gpt51 branch uses the long form
+      // (azureOpenAIApiKey/azureOpenAIEndpoint/azureOpenAIApiVersion).
+      // Pick one style and apply consistently across this file.
       const azureConfig = getModelConfig('azure', 'gpt-4o');
       llm = new AzureChatOpenAI({
         azureApiKey: process.env.AZURE_OPENAI_API_KEY,

--- a/agents/AgentFactory.js
+++ b/agents/AgentFactory.js
@@ -1,8 +1,7 @@
 import { createReactAgent } from '@langchain/langgraph/prebuilt';
-import { ChatOpenAI, AzureChatOpenAI } from '@langchain/openai';
+import { AzureChatOpenAI } from '@langchain/openai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatCohere } from '@langchain/cohere';
-import OpenAI from 'openai';
 import downloadWebPageTool from './tools/downloadWebPage.js';
 import checkUrlStatusTool from './tools/checkURL.js';
 import { ToolTrackingHandler } from './ToolTrackingHandler.js';
@@ -42,9 +41,7 @@ const createTools = (chatId = 'system', agentType = 'openai') => {
 
 const createAzureOpenAIAgent = async (chatId = 'system', modelOverride = null) => {
   const modelConfig = getModelConfig('azure', modelOverride);
-  const isGPT5 = modelOverride === 'azure-gpt5-mini' ||
-    modelConfig.name === 'openai-gpt5-mini' ||
-    modelConfig.name === 'openai-gpt51' ||
+  const isGPT5 = modelConfig.name === 'openai-gpt51' ||
     modelConfig.name === 'openai-gpt51-chat';
 
   const openai = new AzureChatOpenAI({
@@ -71,35 +68,6 @@ const createAzureOpenAIAgent = async (chatId = 'system', modelOverride = null) =
     }
   });
   agent.callbacks = callbacks;
-  return agent;
-};
-
-const createOpenAIAgent = async (chatId = 'system') => {
-  const modelConfig = getModelConfig('openai');
-  const openai = new ChatOpenAI({
-    openAIApiKey: process.env.OPENAI_API_KEY,
-    modelName: modelConfig.name,
-    temperature: modelConfig.temperature,
-    maxTokens: modelConfig.maxTokens,
-    timeout: modelConfig.timeoutMs,
-
-  });
-
-  const { tools, callbacks } = createTools(chatId, 'openai');
-
-
-  const agent = await createReactAgent({
-    llm: openai,
-    tools,
-    agentConfig: {
-      handleParsingErrors: true,
-      maxIterations: 25,
-      returnIntermediateSteps: true,
-      parallel_tool_calls: false
-    }
-  });
-  agent.callbacks = callbacks;
-  console.log('Creating OpenAI context agent with model:', modelConfig.name);
   return agent;
 };
 
@@ -138,17 +106,6 @@ const createClaudeAgent = async (chatId = 'system') => {
 const createContextAgent = async (agentType, chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      const openaiConfig = getModelConfig('openai');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: openaiConfig.name,
-        temperature: openaiConfig.temperature,
-        maxTokens: openaiConfig.maxTokens,
-        timeout: openaiConfig.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const azureConfig = getModelConfig('azure');
       llm = new AzureChatOpenAI({
@@ -161,22 +118,6 @@ const createContextAgent = async (agentType, chatId = 'system') => {
         timeout: azureConfig.timeoutMs,
       });
       console.log('Creating Azure OpenAI context agent with model:', azureConfig.name);
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const azureConfig = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: azureConfig.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: azureConfig.model,
-        reasoning: azureConfig.reasoning,
-        maxCompletionTokens: azureConfig.maxTokens,
-        timeout: azureConfig.timeoutMs,
-      });
-      console.log('Creating GPT5 Mini Azure OpenAI context agent with model:', azureConfig.name);
       break;
     }
     case 'openai-gpt51':
@@ -230,17 +171,6 @@ const createContextAgent = async (agentType, chatId = 'system') => {
 const createPIIAgent = async (agentType, chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      const openaiConfig = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: openaiConfig.name,
-        temperature: openaiConfig.temperature,
-        maxTokens: openaiConfig.maxTokens,
-        timeout: openaiConfig.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const azureConfig = getModelConfig('azure', 'gpt-4o');
       llm = new AzureChatOpenAI({
@@ -254,33 +184,18 @@ const createPIIAgent = async (agentType, chatId = 'system') => {
       });
       break;
     }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      //https://idc-aiservprivpoc-ais01.cognitiveservices.azure.com/openai/responses?api-version=2025-04-01-preview
-      const azureConfig = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: azureConfig.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: azureConfig.model,
-        reasoning: azureConfig.reasoning,
-        maxCompletionTokens: azureConfig.maxTokens,
-        timeout: azureConfig.timeoutMs,
-      });
-      break;
-    }
     case 'openai-gpt51':
     case 'openai-gpt51-chat': {
-      const azureConfig = getModelConfig('azure', 'openai-gpt5-mini');
+      // PII detection must stay in-region (Canada East). gpt-5-mini routes to
+      // global inference, so force gpt-4o regardless of the caller's model choice.
+      const azureConfig = getModelConfig('azure', 'gpt-4o');
       llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
+        azureApiKey: process.env.AZURE_OPENAI_API_KEY,
+        azureEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
+        apiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-06-01',
         azureOpenAIApiDeploymentName: azureConfig.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: azureConfig.model,
-        reasoning: azureConfig.reasoning,
-        maxCompletionTokens: azureConfig.maxTokens,
+        temperature: azureConfig.temperature,
+        maxTokens: azureConfig.maxTokens,
         timeout: azureConfig.timeoutMs,
       });
       break;
@@ -295,17 +210,6 @@ const createPIIAgent = async (agentType, chatId = 'system') => {
 const createQueryRewriteAgent = async (agentType, chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      const openaiConfig = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: openaiConfig.name,
-        temperature: openaiConfig.temperature,
-        maxTokens: openaiConfig.maxTokens,
-        timeout: openaiConfig.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const azureConfig = getModelConfig('azure', 'openai-gpt41-mini');
       llm = new AzureChatOpenAI({
@@ -315,21 +219,6 @@ const createQueryRewriteAgent = async (agentType, chatId = 'system') => {
         azureOpenAIApiDeploymentName: azureConfig.name,
         temperature: azureConfig.temperature,
         maxTokens: azureConfig.maxTokens,
-        timeout: azureConfig.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const azureConfig = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: azureConfig.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: azureConfig.model,
-        reasoning: azureConfig.reasoning,
-        maxCompletionTokens: azureConfig.maxTokens,
         timeout: azureConfig.timeoutMs,
       });
       break;
@@ -357,21 +246,9 @@ const createQueryRewriteAgent = async (agentType, chatId = 'system') => {
 };
 
 // Ranker agent: LLM-only agent that uses the reranker prompt. Supports 'openai' and 'azure'.
-const createRankerAgent = async (agentType = 'openai', chatId = 'system') => {
+const createRankerAgent = async (agentType = 'openai-gpt51', chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      // Use the smaller 4.1-mini model for ranking to reduce latency/cost
-      const cfg = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: cfg.name,
-        temperature: cfg.temperature,
-        maxTokens: 4000,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       // Use the Azure deployment mapped to the mini variant when available
       const cfg = getModelConfig('azure', 'openai-gpt41');
@@ -382,21 +259,6 @@ const createRankerAgent = async (agentType = 'openai', chatId = 'system') => {
         azureOpenAIApiDeploymentName: cfg.name,
         temperature: cfg.temperature,
         maxTokens: 4000,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const cfg = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: cfg.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: cfg.model,
-        reasoning: cfg.reasoning,
-        maxCompletionTokens: 4000,
         timeout: cfg.timeoutMs,
       });
       break;
@@ -425,21 +287,9 @@ const createRankerAgent = async (agentType = 'openai', chatId = 'system') => {
 };
 
 // Translation agent: LLM-only agent that uses the translation prompt. Supports 'openai' and 'azure'.
-const createTranslationAgent = async (agentType = 'openai', chatId = 'system') => {
+const createTranslationAgent = async (agentType = 'openai-gpt51', chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      // Use a compact model for translations to reduce latency/cost
-      const cfg = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: cfg.name,
-        temperature: 0,
-        maxTokens: cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const cfg = getModelConfig('azure', 'openai-gpt41-mini');
       llm = new AzureChatOpenAI({
@@ -449,21 +299,6 @@ const createTranslationAgent = async (agentType = 'openai', chatId = 'system') =
         azureOpenAIApiDeploymentName: cfg.name,
         temperature: 0,
         maxTokens: cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const cfg = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: cfg.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: cfg.model,
-        reasoning: cfg.reasoning,
-        maxCompletionTokens: cfg.maxTokens,
         timeout: cfg.timeoutMs,
       });
       break;
@@ -493,20 +328,9 @@ const createTranslationAgent = async (agentType = 'openai', chatId = 'system') =
 
 // Sentence-compare agent: LLM-only agent that compares a single source sentence to up to 10
 // candidate sentences using the sentenceCompare prompt/strategy. Supports 'openai' and 'azure'.
-const createSentenceCompareAgent = async (agentType = 'openai', chatId = 'system', maxTokens = undefined) => {
+const createSentenceCompareAgent = async (agentType = 'openai-gpt51', chatId = 'system', maxTokens = undefined) => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      const cfg = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: cfg.name,
-        temperature: cfg.temperature,
-        maxTokens: maxTokens ?? cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const cfg = getModelConfig('azure', 'openai-gpt41-mini');
       llm = new AzureChatOpenAI({
@@ -516,21 +340,6 @@ const createSentenceCompareAgent = async (agentType = 'openai', chatId = 'system
         azureOpenAIApiDeploymentName: cfg.name,
         temperature: cfg.temperature,
         maxTokens: maxTokens ?? cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const cfg = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: cfg.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: cfg.model,
-        reasoning: cfg.reasoning,
-        maxCompletionTokens: maxTokens ?? cfg.maxTokens,
         timeout: cfg.timeoutMs,
       });
       break;
@@ -559,20 +368,9 @@ const createSentenceCompareAgent = async (agentType = 'openai', chatId = 'system
 
 // Fallback-compare agent: LLM-only agent that compares a single source sentence to a single
 // high-score fallback candidate. Supports 'openai' and 'azure'.
-const createFallbackCompareAgent = async (agentType = 'openai', chatId = 'system', maxTokens = undefined) => {
+const createFallbackCompareAgent = async (agentType = 'openai-gpt51', chatId = 'system', maxTokens = undefined) => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      const cfg = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: cfg.name,
-        temperature: cfg.temperature,
-        maxTokens: maxTokens ?? cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const cfg = getModelConfig('azure', 'openai-gpt41-mini');
       llm = new AzureChatOpenAI({
@@ -582,21 +380,6 @@ const createFallbackCompareAgent = async (agentType = 'openai', chatId = 'system
         azureOpenAIApiDeploymentName: cfg.name,
         temperature: cfg.temperature,
         maxTokens: maxTokens ?? cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const cfg = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: cfg.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: cfg.model,
-        reasoning: cfg.reasoning,
-        maxCompletionTokens: maxTokens ?? cfg.maxTokens,
         timeout: cfg.timeoutMs,
       });
       break;
@@ -625,21 +408,9 @@ const createFallbackCompareAgent = async (agentType = 'openai', chatId = 'system
 
 // Detect-language agent: LLM-only agent that uses the detectLanguage prompt/strategy.
 // Returns an LLM configured for low-latency deterministic responses.
-const createDetectLanguageAgent = async (agentType = 'openai', chatId = 'system') => {
+const createDetectLanguageAgent = async (agentType = 'openai-gpt51', chatId = 'system') => {
   let llm;
   switch (agentType) {
-    case 'openai': {
-      // Use a compact model and deterministic settings
-      const cfg = getModelConfig('openai', 'gpt-4.1-mini');
-      llm = new ChatOpenAI({
-        openAIApiKey: process.env.OPENAI_API_KEY,
-        modelName: cfg.name,
-        temperature: 0,
-        maxTokens: cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
     case 'azure': {
       const cfg = getModelConfig('azure', 'openai-gpt41-mini');
       llm = new AzureChatOpenAI({
@@ -649,21 +420,6 @@ const createDetectLanguageAgent = async (agentType = 'openai', chatId = 'system'
         azureOpenAIApiDeploymentName: cfg.name,
         temperature: 0,
         maxTokens: cfg.maxTokens,
-        timeout: cfg.timeoutMs,
-      });
-      break;
-    }
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini': {
-      const cfg = getModelConfig('azure', 'openai-gpt5-mini');
-      llm = new AzureChatOpenAI({
-        azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,
-        azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT,
-        azureOpenAIApiDeploymentName: cfg.name,
-        azureOpenAIApiVersion: "2025-04-01-preview",
-        model: cfg.model,
-        reasoning: cfg.reasoning,
-        maxCompletionTokens: cfg.maxTokens,
         timeout: cfg.timeoutMs,
       });
       break;
@@ -694,13 +450,8 @@ const createDetectLanguageAgent = async (agentType = 'openai', chatId = 'system'
 // New helper to create chat agents based on provider
 const createChatAgent = async (provider, chatId = 'system') => {
   switch (provider) {
-    case 'openai':
-      return await createOpenAIAgent(chatId);
     case 'azure':
       return await createAzureOpenAIAgent(chatId);
-    case 'openai-gpt5-mini':
-    case 'azure-gpt5-mini':
-      return await createAzureOpenAIAgent(chatId, 'openai-gpt5-mini');
     case 'openai-gpt51':
     case 'openai-gpt51-chat':
       return await createAzureOpenAIAgent(chatId, provider);
@@ -712,6 +463,6 @@ const createChatAgent = async (provider, chatId = 'system') => {
   }
 };
 
-export { createClaudeAgent, createCohereAgent, createOpenAIAgent, createAzureOpenAIAgent, createContextAgent, createChatAgent, createPIIAgent, createQueryRewriteAgent, createRankerAgent, createTranslationAgent, createDetectLanguageAgent, createSentenceCompareAgent, createFallbackCompareAgent };
+export { createClaudeAgent, createCohereAgent, createAzureOpenAIAgent, createContextAgent, createChatAgent, createPIIAgent, createQueryRewriteAgent, createRankerAgent, createTranslationAgent, createDetectLanguageAgent, createSentenceCompareAgent, createFallbackCompareAgent };
 
 

--- a/agents/AgentOrchestratorService.js
+++ b/agents/AgentOrchestratorService.js
@@ -3,7 +3,7 @@ import ServerLoggingService from '../services/ServerLoggingService.js';
 class AgentOrchestratorServiceClass {
   async invokeWithStrategy({
     chatId = 'system',
-    agentType = 'openai',
+    agentType = 'openai-gpt51',
     request = {},
     createAgentFn, // (agentType, chatId) => agent
     strategy,

--- a/agents/graphs/services/piiService.js
+++ b/agents/graphs/services/piiService.js
@@ -1,6 +1,6 @@
 import { invokePIIAgent } from '../../../services/PIIAgentService.js';
 
-export async function checkPII({ chatId = 'system', message, agentType = 'openai' }) {
+export async function checkPII({ chatId = 'system', message, agentType = 'openai-gpt51' }) {
   if (!message) return { pii: null, blocked: false };
   return invokePIIAgent(agentType, { chatId, question: message });
 }

--- a/agents/graphs/services/translationService.js
+++ b/agents/graphs/services/translationService.js
@@ -1,5 +1,5 @@
 import { translateQuestion as translateFromService } from '../../../services/TranslationAgentService.js';
 
-export async function translateQuestion({ text, desiredLanguage, selectedAI = 'openai', chatId = 'translate', translationContext = [] }) {
+export async function translateQuestion({ text, desiredLanguage, selectedAI = 'openai-gpt51', chatId = 'translate', translationContext = [] }) {
   return translateFromService({ text, desiredLanguage, selectedAI, chatId, translationContext });
 }

--- a/agents/tools/contextAgentTool.js
+++ b/agents/tools/contextAgentTool.js
@@ -9,7 +9,7 @@ import { contextSearch as canadaSearch } from "./canadaCaContextSearch.js";
  * performs a search based on the question and returns the generated context
  * string from the context agent.
  */
-const createContextAgentTool = (agentType = 'openai') =>
+const createContextAgentTool = (agentType = 'openai-gpt51') =>
   tool(
     async ({ question, lang = 'en', searchProvider = 'google', chatId = 'system' }) => {
       const systemPrompt = await loadContextSystemPrompt(lang);

--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -4,6 +4,7 @@ import ConversationIntegrityService from '../../services/ConversationIntegritySe
 import { withOptionalUser } from '../../middleware/auth.js';
 import { getGraphApp } from '../../agents/graphs/registry.js';
 import { graphRequestContext } from '../../agents/graphs/requestContext.js';
+import { MODEL_VALUES } from '../../src/config/workflows.js';
 
 const REQUIRED_METHOD = 'POST';
 
@@ -111,9 +112,9 @@ async function handler(req, res) {
   // Server-side Model Resolution
   // The model.default setting decouples model choice from workflow choice.
   // Workflows no longer need to hardcode a model — the server injects it here.
-  // Falls back to 'openai-gpt51' when model.default hasn't been saved yet
-  // (e.g. first deploy before an admin visits Settings).
-  const defaultModel = SettingsService.get('model.default') || 'openai-gpt51';
+  // Falls back to the first MODEL_VALUES entry when model.default hasn't been
+  // saved yet (e.g. first deploy before an admin visits Settings).
+  const defaultModel = SettingsService.get('model.default') || MODEL_VALUES[0];
   if (!req.user) {
     // Unauthenticated users: forced to use the system default model
     input.selectedAI = defaultModel;
@@ -126,7 +127,7 @@ async function handler(req, res) {
   // They've been removed; map old names (from DB, localStorage, in-progress batches) to DefaultGraph
   // and extract the implied model so behaviour is unchanged.
   const LEGACY_MODEL_MAP = {
-    'GPT5MiniDefaultGraph': 'openai-gpt5-mini',
+    'GPT5MiniDefaultGraph': 'openai-gpt51',
     'GPT5OneDefaultGraph': 'openai-gpt51',
     'GPT5OneChatGraph': 'openai-gpt51-chat',
   };

--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -125,7 +125,8 @@ async function handler(req, res) {
 
   // Legacy graph name mapping — GPT5* graphs were copies of DefaultGraph with a hardcoded model.
   // They've been removed; map old names (from DB, localStorage, in-progress batches) to DefaultGraph
-  // and extract the implied model so behaviour is unchanged.
+  // and coerce the implied model. GPT5MiniDefaultGraph originally implied openai-gpt5-mini, but
+  // gpt-5-mini is no longer a selectable provider, so legacy records fall back to openai-gpt51.
   const LEGACY_MODEL_MAP = {
     'GPT5MiniDefaultGraph': 'openai-gpt51',
     'GPT5OneDefaultGraph': 'openai-gpt51',

--- a/services/AnswerGenerationService.js
+++ b/services/AnswerGenerationService.js
@@ -23,7 +23,7 @@ const convertInteractionsToMessages = (interactions) => {
 
 
 async function invokeAgent({
-    provider = 'openai',
+    provider = 'openai-gpt51',
     message,
     conversationHistory = [],
     lang,

--- a/services/EvaluationService.js
+++ b/services/EvaluationService.js
@@ -173,14 +173,7 @@ class EvaluationService {
             // Fetch deploymentMode and vectorServiceType from SettingsService
             const deploymentMode = SettingsService.get('deploymentMode') || 'CDS';
             const vectorServiceType = SettingsService.get('vectorServiceType') || 'imvectordb';
-            // Resolve the ai provider from SettingsService (single source of truth)
-            let providerSetting = null;
-            try {
-                providerSetting = SettingsService.get('provider');
-            } catch (e) {
-                providerSetting = null;
-            }
-            const aiProviderToUse = providerSetting || 'openai';
+            const aiProviderToUse = SettingsService.get('model.default') || 'openai-gpt51';
             if (deploymentMode === 'CDS') {
                 // Ensure only one concurrent initialization creates the Piscina pool
                 if (!pool) {
@@ -340,14 +333,7 @@ class EvaluationService {
         const deploymentMode = SettingsService.get('deploymentMode') || 'CDS';
 
 
-        // Resolve global ai provider from settings once (single source of truth)
-        let globalProvider = 'openai';
-        try {
-            const p = SettingsService.get('provider');
-            if (p) globalProvider = p;
-        } catch (e) {
-            globalProvider = 'openai';
-        }
+        const globalProvider = SettingsService.get('model.default') || 'openai-gpt51';
 
         // Compute the batch concurrency from the configured concurrency so the
         // same value is used for slicing batches and for the worker pool.

--- a/services/SearchContextService.js
+++ b/services/SearchContextService.js
@@ -23,7 +23,7 @@ function countSearchResults(resultsString) {
 }
 
 export const SearchContextService = {
-    async search({ chatId = 'system', searchService = 'canadaca', agentType = 'openai', referringUrl = '', translationData = null, pageLanguage = '' }) {
+    async search({ chatId = 'system', searchService = 'canadaca', agentType = 'openai-gpt51', referringUrl = '', translationData = null, pageLanguage = '' }) {
         ServerLoggingService.info('Received request to search.', chatId, { searchService, referringUrl });
 
         const pageLang = (pageLanguage || '').toLowerCase();

--- a/services/TranslationAgentService.js
+++ b/services/TranslationAgentService.js
@@ -3,7 +3,7 @@ import { createTranslationAgent } from '../agents/AgentFactory.js';
 import { translationStrategy } from '../agents/strategies/translationStrategy.js';
 import ServerLoggingService from './ServerLoggingService.js';
 
-export async function translateQuestion({ text, desiredLanguage, selectedAI = 'openai', chatId = 'translate', translationContext = [] }) {
+export async function translateQuestion({ text, desiredLanguage, selectedAI = 'openai-gpt51', chatId = 'translate', translationContext = [] }) {
   try {
     const createAgentFn = async (agentType, id) => {
       return createTranslationAgent(agentType, id);

--- a/services/evaluation.worker.js
+++ b/services/evaluation.worker.js
@@ -134,7 +134,7 @@ function formatCompareInput(questionFlow, answerText) {
     return sections.join('\n\n');
 }
 
-async function runFallbackCompareCheck({ sourceInteraction, fallbackInteraction, sourceQuestionFlow = null, fallbackQuestionFlow = null, aiProvider = 'openai' }) {
+async function runFallbackCompareCheck({ sourceInteraction, fallbackInteraction, sourceQuestionFlow = null, fallbackQuestionFlow = null, aiProvider = 'openai-gpt51' }) {
     try {
         const sourceText = extractAnswerText(sourceInteraction);
         const candidateText = extractAnswerText(fallbackInteraction);
@@ -162,7 +162,7 @@ async function runFallbackCompareCheck({ sourceInteraction, fallbackInteraction,
         const started = Date.now();
         const agentResult = await AgentOrchestratorService.invokeWithStrategy({
             chatId: 'fallback-compare',
-            agentType: aiProvider || 'openai',
+            agentType: aiProvider || 'openai-gpt51',
             request,
             createAgentFn,
             strategy: fallbackCompareStrategy
@@ -172,7 +172,7 @@ async function runFallbackCompareCheck({ sourceInteraction, fallbackInteraction,
             checks: agentResult?.parsed ?? null,
             raw: agentResult?.raw ?? null,
             meta: {
-                provider: aiProvider || 'openai',
+                provider: aiProvider || 'openai-gpt51',
                 model: agentResult?.model || '',
                 inputTokens: agentResult?.inputTokens ?? null,
                 outputTokens: agentResult?.outputTokens ?? null,
@@ -189,7 +189,7 @@ async function runFallbackCompareCheck({ sourceInteraction, fallbackInteraction,
 }
 
 
-async function tryQAMatchHighScoreFallback(interaction, chatId, sourceEmbedding, similarEmbeddings, failedSentenceTraces = [], aiProvider = 'openai', stageRecorder = null, stageTimeline = []) {
+async function tryQAMatchHighScoreFallback(interaction, chatId, sourceEmbedding, similarEmbeddings, failedSentenceTraces = [], aiProvider = 'openai-gpt51', stageRecorder = null, stageTimeline = []) {
     const timeline = stageRecorder?.timeline || stageTimeline || [];
     try {
         stageRecorder?.(EvaluationStages.FALLBACK_QA_HIGH, 'started', 'fallback_started', 'QA high score fallback started', {
@@ -595,7 +595,7 @@ async function findSimilarEmbeddingsWithFeedback(sourceEmbedding, similarityThre
 }
 
 
-async function findBestSentenceMatches(sourceEmbedding, topMatches, aiProvider = 'openai') {
+async function findBestSentenceMatches(sourceEmbedding, topMatches, aiProvider = 'openai-gpt51') {
     // Get the set of allowed interaction IDs from topMatches
     const allowedInteractionIds = new Set(topMatches.map(m => m.embedding.interactionId._id.toString()));
     let bestSentenceMatches = [];
@@ -686,7 +686,7 @@ async function findBestSentenceMatches(sourceEmbedding, topMatches, aiProvider =
                     const createAgentFn = async (agentType, localChatId) => await createSentenceCompareAgent(agentType, localChatId, 5000);
                     const request = { source: sourceSentenceText || '', candidates: candidateStrings };
                     const t0 = Date.now();
-                    const compareResult = await AgentOrchestratorService.invokeWithStrategy({ chatId: 'sentence-compare', agentType: aiProvider || 'openai', request, createAgentFn, strategy: sentenceCompareStrategy });
+                    const compareResult = await AgentOrchestratorService.invokeWithStrategy({ chatId: 'sentence-compare', agentType: aiProvider || 'openai-gpt51', request, createAgentFn, strategy: sentenceCompareStrategy });
                     const latencyMs = Date.now() - t0;
                     // parse winner
                         const winner = compareResult?.parsed?.winner;
@@ -733,7 +733,7 @@ async function findBestSentenceMatches(sourceEmbedding, topMatches, aiProvider =
                         });
                         // Attach light telemetry on the object for later Eval persistence (top-level)
                         bestSentenceMatches.__agentTelemetry = {
-                            provider: aiProvider || 'openai',
+                            provider: aiProvider || 'openai-gpt51',
                             model: compareResult?.model || '',
                             inputTokens: compareResult?.inputTokens ?? null,
                             outputTokens: compareResult?.outputTokens ?? null,
@@ -1140,7 +1140,7 @@ async function createNoMatchEvaluation(interaction, chatId, reason, stageTimelin
 
 
 export { runFallbackCompareCheck };
-export default async function ({ interactionId, chatId, aiProvider = 'openai', forceFallbackEval = false }) {
+export default async function ({ interactionId, chatId, aiProvider = 'openai-gpt51', forceFallbackEval = false }) {
     await dbConnect();
     const stageTimeline = [];
     const recordStage = createStageRecorder(stageTimeline);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -964,11 +964,6 @@
       "imvectordb": "IMVectorDB (local)",
       "documentdb": "DocumentDB (AWS)"
     },
-    "providerLabel": "Provider",
-    "provider": {
-      "openai": "OpenAI",
-      "azure": "Azure OpenAI"
-    },
     "baseUrlLabel": "Base URL (e.g. https://example.com)",
     "twoFA": {
       "title": "Two-factor authentication",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -964,11 +964,6 @@
       "imvectordb": "IMVectorDB (local)",
       "documentdb": "DocumentDB (AWS)"
     },
-    "providerLabel": "Fournisseur",
-    "provider": {
-      "openai": "OpenAI",
-      "azure": "Azure OpenAI"
-    },
     "baseUrlLabel": "URL de base (ex. https://exemple.com)",
     "twoFA": {
       "title": "Authentification à deux facteurs",

--- a/src/pages/BatchPage.js
+++ b/src/pages/BatchPage.js
@@ -70,7 +70,7 @@ const BatchPage = ({ lang = 'en' }) => {
       BatchService.runBatch({
         entries,
         batchName: persisted?.name || batchId,
-        selectedAI: persisted?.aiProvider || 'openai',
+        selectedAI: persisted?.aiProvider || 'openai-gpt51',
         lang: persisted?.pageLanguage || language || 'en',
         searchProvider: persisted?.searchProvider || '',
         // Prefer the workflow explicitly provided by the caller (restart), fall back to the persisted value

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -17,10 +17,6 @@ const SettingsPage = ({ lang = 'en' }) => {
   const [baseUrl, setBaseUrl] = useState('');
   const [savingBaseUrl, setSavingBaseUrl] = useState(false);
 
-  // New state for provider (openai | azure)
-  const [provider, setProvider] = useState('openai');
-  const [savingProvider, setSavingProvider] = useState(false);
-
   // Global default workflow setting (Default | DefaultWithVector | DefaultWithVectorGraph)
   const [defaultWorkflow, setDefaultWorkflow] = useState('DefaultGraph');
   const [savingDefaultWorkflow, setSavingDefaultWorkflow] = useState(false);
@@ -78,9 +74,6 @@ const SettingsPage = ({ lang = 'en' }) => {
       setVectorServiceType(type);
       const url = await DataStoreService.getSetting('site.baseUrl', '');
       setBaseUrl(url ?? '');
-      // Load provider setting
-      const providerSetting = await DataStoreService.getSetting('provider', 'openai');
-      setProvider(providerSetting);
       // Load default workflow setting
       const defaultWorkflowSetting = await DataStoreService.getSetting('workflow.default', 'DefaultGraph');
       // Validate default workflow against known options
@@ -295,19 +288,6 @@ const SettingsPage = ({ lang = 'en' }) => {
     }
   };
 
-  // Handler for provider setting
-  const handleProviderChange = async (e) => {
-    const newValue = e.target.value;
-    setProvider(newValue);
-    setSavingProvider(true);
-    try {
-      const current = await saveAndVerify('provider', newValue);
-      setProvider(current);
-    } finally {
-      setSavingProvider(false);
-    }
-  };
-
   const handleDeploymentModeChange = async (e) => {
     const newMode = e.target.value;
     setDeploymentMode(newMode);
@@ -434,19 +414,6 @@ const SettingsPage = ({ lang = 'en' }) => {
           >
             <option value="imvectordb">{t('settings.vectorServiceType.imvectordb')}</option>
             <option value="documentdb">{t('settings.vectorServiceType.documentdb')}</option>
-          </select>
-
-          <label htmlFor="provider" className="mb-200 display-block mt-400">
-            {t('settings.providerLabel')}
-          </label>
-          <select
-            id="provider"
-            value={provider}
-            onChange={handleProviderChange}
-            disabled={savingProvider}
-          >
-            <option value="openai">{t('settings.provider.openai')}</option>
-            <option value="azure">{t('settings.provider.azure')}</option>
           </select>
 
           <label htmlFor="default-workflow" className="mb-200 display-block mt-400">

--- a/src/services/BatchService.js
+++ b/src/services/BatchService.js
@@ -52,7 +52,7 @@ class BatchService {
    * Start a batch: decide whether to derive context or send batch messages.
    * Returns whatever the underlying service returns (usually an object with batchId).
    */
-  async startBatch({ entries = [], selectedAI = 'openai', selectedLanguage = 'en', batchName = '', selectedSearch = 'google', workflow = 'Default', concurrency = DEFAULT_CONCURRENCY, retries = DEFAULT_RETRIES, onProgress = () => { }, onStatusUpdate = () => { }, abortSignal = null, statsPollingIntervalMs = 5000, batchId = null } = {}) {
+  async startBatch({ entries = [], selectedAI = 'openai-gpt51', selectedLanguage = 'en', batchName = '', selectedSearch = 'google', workflow = 'Default', concurrency = DEFAULT_CONCURRENCY, retries = DEFAULT_RETRIES, onProgress = () => { }, onStatusUpdate = () => { }, abortSignal = null, statsPollingIntervalMs = 5000, batchId = null } = {}) {
     if (!entries || !entries.length) throw new Error('No entries provided to startBatch');
     if (!batchId) throw new Error('startBatch requires a server-persisted batchId; call persistBatch first');
 
@@ -244,7 +244,7 @@ class BatchService {
   async runBatch({
     entries = [],
     // batchName = `client-batch-${Date.now()}`,
-    selectedAI = 'openai',
+    selectedAI = 'openai-gpt51',
     lang = 'en',
     searchProvider = '',
     workflow = 'Default',


### PR DESCRIPTION
# Summary | Résumé

Needed to set PII agent back to GPT 4o per discussion with @ryanhyma since it's still only one avail for inference in Canada. 
- in the process discovered that we'd left the Provider dropdown in Admin Settings, even though I had rationalized into just Workflows and Models - turned out there was a whole openai branch still around from before we switched to Azure. 
- removed and cleaned up, removed the Provider dropdown. When we add models like Cohere, they will go in the Models dropdown, not separate Providers dropdown. 

<img width="670" height="238" alt="image" src="https://github.com/user-attachments/assets/338c9e25-741a-4601-8a37-7bb2a0f67f5f" />

Run tests, run code review, next step, test in preview 

