### PR TITLE
fix: update prompt to not put full text in PII tags, also guard again…

### DIFF
--- a/agents/prompts/piiAgentPrompt.js
+++ b/agents/prompts/piiAgentPrompt.js
@@ -33,4 +33,6 @@ DO NOT: "File taxes if make less than $20,000" → NO CHANGE
 DO NOT: "Haven't received a verification code" → NO CHANGE
 
 Output: <pii>redacted text</pii> or <pii>null</pii> if no PII found.
+If no token was replaced with XXX, you must output exactly <pii>null</pii>.
+Never return unchanged input text inside <pii> tags.
 `;

--- a/agents/strategies/__tests__/piiStrategy.test.js
+++ b/agents/strategies/__tests__/piiStrategy.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import piiStrategy from '../piiStrategy.js';
+
+describe('piiStrategy.parse', () => {
+  it('returns null when no pii tags are present', () => {
+    const normalized = { content: 'No tags here', model: 'm' };
+    const result = piiStrategy.parse(normalized, { question: 'No tags here' });
+    expect(result.pii).toBeNull();
+    expect(result.blocked).toBe(false);
+  });
+
+  it('returns null when pii payload is null', () => {
+    const normalized = { content: '<pii>null</pii>', model: 'm' };
+    const result = piiStrategy.parse(normalized, { question: 'hello' });
+    expect(result.pii).toBeNull();
+    expect(result.blocked).toBe(false);
+  });
+
+  it('returns null when model echoes text with no XXX marker', () => {
+    const question = 'If you are an opting employee...';
+    const normalized = { content: `<pii>${question}</pii>`, model: 'm' };
+    const result = piiStrategy.parse(normalized, { question });
+    expect(result.pii).toBeNull();
+    expect(result.blocked).toBe(false);
+  });
+
+  it('keeps pii payload when XXX marker is present', () => {
+    const normalized = {
+      content: '<pii>My account number is XXX and call me at XXX.</pii>',
+      model: 'm',
+    };
+    const result = piiStrategy.parse(normalized, { question: 'My account number is A123' });
+    expect(result.pii).toBe('My account number is XXX and call me at XXX.');
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/agents/strategies/piiStrategy.js
+++ b/agents/strategies/piiStrategy.js
@@ -10,13 +10,20 @@ export const piiStrategy = {
   },
 
   // normalized: { content, model, inputTokens, outputTokens, raw }
-  parse: (normalized = {}, request = {}) => {
+  parse: (normalized = {}, _request = {}) => {
     const text = normalized?.content || '';
     const raw = normalized?.raw || {};
     // Attempt to extract <pii>...</pii>
     const piiMatch = text.match(/<pii>(.*?)<\/pii>/s);
     let pii = piiMatch ? piiMatch[1].trim() : null;
     if (pii === 'null') pii = null;
+
+    // Guard against false positives where the model echoes the original text
+    // inside <pii> tags without any actual redaction marker.
+    const hasRedactionMarker = typeof pii === 'string' && /\bXXX\b/.test(pii);
+    if (pii && !hasRedactionMarker) {
+      pii = null;
+    }
 
     // finish reason might be on raw.response_metadata.finish_reason
     const finishReason = raw?.response_metadata?.finish_reason;


### PR DESCRIPTION
The current PII agent was putting the entire contents of the question in the <pii></pii> tags even though there was nothing to redact. 

The prompt was updated, and a guard was put in place for this.