### PR TITLE
Performance metrics redesign

### DIFF
--- a/agents/prompts/scenarios/departments_EN.js
+++ b/agents/prompts/scenarios/departments_EN.js
@@ -412,7 +412,7 @@ export const departments_EN = [
   {
     "name": "Competition Tribunal",
     "url": "https://www.ct-tc.gc.ca/en/home.html",
-    "abbrKey": "CT"
+    "abbrKey": "CT-TC"
   },
   {
     "name": "Conflict of Interest and Ethics Commissioner (Office of the)",
@@ -477,7 +477,7 @@ export const departments_EN = [
   {
     "name": "Democratic Institutions",
     "url": "https://www.canada.ca/en/democratic-institutions.html",
-    "abbrKey": "DI"
+    "abbrKey": "DEMO"
   },
   {
     "name": "Digital Museums Canada",
@@ -637,7 +637,7 @@ export const departments_EN = [
   {
     "name": "Impact Canada",
     "url": "https://impact.canada.ca/en",
-    "abbrKey": "IC"
+    "abbrKey": "IMPACT"
   },
   {
     "name": "Independent Review Panel for Defence Acquisition",
@@ -702,7 +702,7 @@ export const departments_EN = [
   {
     "name": "Labour Program",
     "url": "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour.html",
-    "abbrKey": "LP"
+    "abbrKey": "TRAVAIL-LABOUR"
   },
   {
     "name": "Laurentian Pilotage Authority Canada",
@@ -792,7 +792,7 @@ export const departments_EN = [
   {
     "name": "Canada Science and Technology Museum",
     "url": "https://ingeniumcanada.org/scitech",
-    "abbrKey": "INGEN-SCI"
+    "abbrKey": "INGENIUM"
   },
   {
     "name": "National Research Council Canada",
@@ -842,7 +842,7 @@ export const departments_EN = [
   {
     "name": "Parks Canada",
     "url": "https://parks.canada.ca/index",
-    "abbrKey": "PC"
+    "abbrKey": "PARKS-PARCS"
   },
   {
     "name": "Parole Board of Canada",
@@ -877,7 +877,7 @@ export const departments_EN = [
   {
     "name": "Privacy Commissioner of Canada (Office of the)",
     "url": "https://www.priv.gc.ca/en/",
-    "abbrKey": "OPC-CPVP"
+    "abbrKey": "PRIV"
   },
   {
     "name": "Privy Council Office",
@@ -1032,7 +1032,7 @@ export const departments_EN = [
   {
     "name": "Telefilm Canada",
     "url": "https://www.telefilm.ca/en/?q=en",
-    "abbrKey": "TFC"
+    "abbrKey": "TELEFILM"
   },
   {
     "name": "Translation Bureau",

--- a/agents/prompts/scenarios/departments_FR.js
+++ b/agents/prompts/scenarios/departments_FR.js
@@ -302,7 +302,7 @@ export const departments_FR = [
   {
     "name": "Commissariat à la protection de la vie privée du Canada",
     "url": "https://www.priv.gc.ca/fr/",
-    "abbrKey": "OPC-CPVP"
+    "abbrKey": "PRIV"
   },
   {
     "name": "Commissariat à l'information au Canada",
@@ -657,7 +657,7 @@ export const departments_FR = [
   {
     "name": "Impact Canada",
     "url": "https://impact.canada.ca/fr",
-    "abbrKey": "IC"
+    "abbrKey": "IMPACT"
   },
   {
     "name": "Logement, Infrastructures et Collectivités Canada",
@@ -677,7 +677,7 @@ export const departments_FR = [
   {
     "name": "Institutions démocratiques",
     "url": "https://www.canada.ca/fr/institutions-democratiques.html",
-    "abbrKey": "DI"
+    "abbrKey": "DEMO"
   },
   {
     "name": "Instituts de recherche en santé du Canada",
@@ -777,7 +777,7 @@ export const departments_FR = [
   {
     "name": "Musée des sciences et de la technologie du Canada",
     "url": "https://ingeniumcanada.org/fr/scitech",
-    "abbrKey": "INGEN-SCI"
+    "abbrKey": "INGENIUM"
   },
   {
     "name": "Musées numériques Canada",
@@ -847,7 +847,7 @@ export const departments_FR = [
   {
     "name": "Parcs Canada",
     "url": "https://parcs.canada.ca/index",
-    "abbrKey": "PC"
+    "abbrKey": "PARKS-PARCS"
   },
   {
     "name": "Parlement du Canada",
@@ -892,7 +892,7 @@ export const departments_FR = [
   {
     "name": "Programme du travail",
     "url": "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail.html",
-    "abbrKey": "LP"
+    "abbrKey": "TRAVAIL-LABOUR"
   },
   {
     "name": "Recherche et développement pour la Défense Canada",
@@ -1032,7 +1032,7 @@ export const departments_FR = [
   {
     "name": "Téléfilm Canada",
     "url": "https://www.telefilm.ca/fr/?q=fr",
-    "abbrKey": "TFC"
+    "abbrKey": "TELEFILM"
   },
   {
     "name": "Transports Canada",
@@ -1052,7 +1052,7 @@ export const departments_FR = [
   {
     "name": "Tribunal de la concurrence",
     "url": "https://www.ct-tc.gc.ca/fr/accueil.html",
-    "abbrKey": "CT"
+    "abbrKey": "CT-TC"
   },
   {
     "name": "Tribunal de la protection des fonctionnaires divulgateurs Canada",

--- a/api/metrics/metrics-ai-eval.js
+++ b/api/metrics/metrics-ai-eval.js
@@ -74,6 +74,8 @@ function buildAiEvalPipeline(dateFilter, extraFilters = [], departmentFilter = [
                 category: getAiEvalAggregationExpression('$autoEval.expertFeedback')
             }
         },
+        // Exclude questions that have a human expert eval — expert takes precedence
+        { $match: { 'interactions.expertFeedback': { $eq: null } } },
         // Project only fields needed for aggregation (optimization)
         {
             $project: {

--- a/api/metrics/metrics-departments.js
+++ b/api/metrics/metrics-departments.js
@@ -43,8 +43,12 @@ function buildDepartmentPipeline(dateFilter, extraFilters = [], departmentFilter
         ...(departmentFilter.length > 0 ? [{ $match: { $and: departmentFilter } }] : []),
         {
             $addFields: {
-                hasExpertFeedback: { $cond: [{ $ne: ['$expertFeedback', null] }, 1, 0] },
                 category: getPartnerEvalAggregationExpression('$expertFeedback')
+            }
+        },
+        {
+            $addFields: {
+                hasExpertFeedback: { $cond: [{ $ne: ['$category', null] }, 1, 0] }
             }
         },
         // Project only fields needed for aggregation (optimization)

--- a/api/metrics/metrics-expert-feedback.js
+++ b/api/metrics/metrics-expert-feedback.js
@@ -44,7 +44,17 @@ function buildExpertFeedbackPipeline(dateFilter, extraFilters = [], departmentFi
         { $match: { expertFeedback: { $ne: null } } },
         {
             $addFields: {
-                category: getPartnerEvalAggregationExpression('$expertFeedback')
+                category: getPartnerEvalAggregationExpression('$expertFeedback'),
+                hasContentIssue: {
+                    $cond: [{
+                        $or: [
+                            { $eq: ['$expertFeedback.sentence1ContentIssue', true] },
+                            { $eq: ['$expertFeedback.sentence2ContentIssue', true] },
+                            { $eq: ['$expertFeedback.sentence3ContentIssue', true] },
+                            { $eq: ['$expertFeedback.sentence4ContentIssue', true] }
+                        ]
+                    }, 1, 0]
+                }
             }
         },
         // Project only fields needed for aggregation (optimization)
@@ -53,6 +63,7 @@ function buildExpertFeedbackPipeline(dateFilter, extraFilters = [], departmentFi
                 pageLanguage: 1,
                 department: 1,
                 category: 1,
+                hasContentIssue: 1,
                 // Keep IDs for potential cross-filter lookups
                 answerId: '$interactions.answer',
                 autoEvalId: '$interactions.autoEval'
@@ -143,7 +154,10 @@ function buildExpertFeedbackPipeline(dateFilter, extraFilters = [], departmentFi
             hasCitationErrorFr: { $sum: { $cond: [{ $and: [{ $eq: ['$category', 'hasCitationError'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } },
             harmful: { $sum: { $cond: [{ $eq: ['$category', 'harmful'] }, 1, 0] } },
             harmfulEn: { $sum: { $cond: [{ $and: [{ $eq: ['$category', 'harmful'] }, { $eq: ['$pageLanguage', 'en'] }] }, 1, 0] } },
-            harmfulFr: { $sum: { $cond: [{ $and: [{ $eq: ['$category', 'harmful'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } }
+            harmfulFr: { $sum: { $cond: [{ $and: [{ $eq: ['$category', 'harmful'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } },
+            hasContentIssue: { $sum: '$hasContentIssue' },
+            hasContentIssueEn: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'en'] }, '$hasContentIssue', 0] } },
+            hasContentIssueFr: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'fr'] }, '$hasContentIssue', 0] } }
         }
     });
 
@@ -167,7 +181,8 @@ async function getExpertMetrics(req, res) {
                 needsImprovement: { total: expert.needsImprovement || 0, en: expert.needsImprovementEn || 0, fr: expert.needsImprovementFr || 0 },
                 hasError: { total: expert.hasError || 0, en: expert.hasErrorEn || 0, fr: expert.hasErrorFr || 0 },
                 hasCitationError: { total: expert.hasCitationError || 0, en: expert.hasCitationErrorEn || 0, fr: expert.hasCitationErrorFr || 0 },
-                harmful: { total: expert.harmful || 0, en: expert.harmfulEn || 0, fr: expert.harmfulFr || 0 }
+                harmful: { total: expert.harmful || 0, en: expert.harmfulEn || 0, fr: expert.harmfulFr || 0 },
+                hasContentIssue: { total: expert.hasContentIssue || 0, en: expert.hasContentIssueEn || 0, fr: expert.hasContentIssueFr || 0 }
             }
         };
         return res.status(200).json({ success: true, metrics });

--- a/api/metrics/metrics-usage.js
+++ b/api/metrics/metrics-usage.js
@@ -77,27 +77,27 @@ function buildOverallStatsPipeline(dateFilter, extraFilters = [], departmentFilt
         }
     });
 
-    // Project minimal answer fields + Tokens
+    // Pre-compute answer tokens once so the combined totals can reuse them
+    stages.push({
+        $addFields: {
+            answerInputTokens: { $convert: { input: '$answer.inputTokens', to: 'int', onError: 0, onNull: 0 } },
+            answerOutputTokens: { $convert: { input: '$answer.outputTokens', to: 'int', onError: 0, onNull: 0 } }
+        }
+    });
+
     stages.push({
         $project: {
             chatId: 1,
             searchProvider: 1,
             pageLanguage: 1,
             department: 1,
-            inputTokens: {
-                $add: [
-                    '$contextInputTokens',
-                    { $convert: { input: '$answer.inputTokens', to: 'int', onError: 0, onNull: 0 } }
-                ]
-            },
-            outputTokens: {
-                $add: [
-                    '$contextOutputTokens',
-                    { $convert: { input: '$answer.outputTokens', to: 'int', onError: 0, onNull: 0 } }
-                ]
-            },
+            contextInputTokens: '$contextInputTokens',
+            answerInputTokens: 1,
+            contextOutputTokens: '$contextOutputTokens',
+            answerOutputTokens: 1,
+            inputTokens: { $add: ['$contextInputTokens', '$answerInputTokens'] },
+            outputTokens: { $add: ['$contextOutputTokens', '$answerOutputTokens'] },
             answerType: { $ifNull: ['$answer.answerType', 'normal'] },
-            // Keep IDs for further lookups if needed
             expertFeedbackId: 1,
             autoEvalId: 1
         }
@@ -184,7 +184,20 @@ function buildOverallStatsPipeline(dateFilter, extraFilters = [], departmentFilt
             ptMuniCountFr: { $sum: { $cond: [{ $and: [{ $eq: ['$answerType', 'pt-muni'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } },
             notGcCount: { $sum: { $cond: [{ $eq: ['$answerType', 'not-gc'] }, 1, 0] } },
             notGcCountEn: { $sum: { $cond: [{ $and: [{ $eq: ['$answerType', 'not-gc'] }, { $eq: ['$pageLanguage', 'en'] }] }, 1, 0] } },
-            notGcCountFr: { $sum: { $cond: [{ $and: [{ $eq: ['$answerType', 'not-gc'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } }
+            notGcCountFr: { $sum: { $cond: [{ $and: [{ $eq: ['$answerType', 'not-gc'] }, { $eq: ['$pageLanguage', 'fr'] }] }, 1, 0] } },
+            // Context vs answer token breakdown
+            totalContextInputTokens: { $sum: '$contextInputTokens' },
+            totalContextInputTokensEn: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'en'] }, '$contextInputTokens', 0] } },
+            totalContextInputTokensFr: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'fr'] }, '$contextInputTokens', 0] } },
+            totalAnswerInputTokens: { $sum: '$answerInputTokens' },
+            totalAnswerInputTokensEn: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'en'] }, '$answerInputTokens', 0] } },
+            totalAnswerInputTokensFr: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'fr'] }, '$answerInputTokens', 0] } },
+            totalContextOutputTokens: { $sum: '$contextOutputTokens' },
+            totalContextOutputTokensEn: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'en'] }, '$contextOutputTokens', 0] } },
+            totalContextOutputTokensFr: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'fr'] }, '$contextOutputTokens', 0] } },
+            totalAnswerOutputTokens: { $sum: '$answerOutputTokens' },
+            totalAnswerOutputTokensEn: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'en'] }, '$answerOutputTokens', 0] } },
+            totalAnswerOutputTokensFr: { $sum: { $cond: [{ $eq: ['$pageLanguage', 'fr'] }, '$answerOutputTokens', 0] } }
         }
     });
 
@@ -218,7 +231,19 @@ async function getUsageMetrics(req, res) {
                 'clarifying-question': { total: overall.clarifyingCount || 0, en: overall.clarifyingCountEn || 0, fr: overall.clarifyingCountFr || 0 },
                 'pt-muni': { total: overall.ptMuniCount || 0, en: overall.ptMuniCountEn || 0, fr: overall.ptMuniCountFr || 0 },
                 'not-gc': { total: overall.notGcCount || 0, en: overall.notGcCountEn || 0, fr: overall.notGcCountFr || 0 }
-            }
+            },
+            totalContextInputTokens: overall.totalContextInputTokens || 0,
+            totalContextInputTokensEn: overall.totalContextInputTokensEn || 0,
+            totalContextInputTokensFr: overall.totalContextInputTokensFr || 0,
+            totalAnswerInputTokens: overall.totalAnswerInputTokens || 0,
+            totalAnswerInputTokensEn: overall.totalAnswerInputTokensEn || 0,
+            totalAnswerInputTokensFr: overall.totalAnswerInputTokensFr || 0,
+            totalContextOutputTokens: overall.totalContextOutputTokens || 0,
+            totalContextOutputTokensEn: overall.totalContextOutputTokensEn || 0,
+            totalContextOutputTokensFr: overall.totalContextOutputTokensFr || 0,
+            totalAnswerOutputTokens: overall.totalAnswerOutputTokens || 0,
+            totalAnswerOutputTokensEn: overall.totalAnswerOutputTokensEn || 0,
+            totalAnswerOutputTokensFr: overall.totalAnswerOutputTokensFr || 0
         };
         return res.status(200).json({ success: true, metrics });
     } catch (error) {

--- a/api/util/chat-filters.js
+++ b/api/util/chat-filters.js
@@ -6,7 +6,7 @@ const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 export function categorizeExpertFeedback(expertFeedback) {
   if (!expertFeedback) return null;
 
-  const hasCitationError = expertFeedback.citationScore === 0;
+  const hasCitationError = expertFeedback.citationScore === 0 || expertFeedback.citationScore === 20;
   const totalScore = expertFeedback.totalScore;
 
   const feedbackFields = [
@@ -106,7 +106,7 @@ export function getPartnerEvalAggregationExpression(feedbackPath = '$interaction
                   ]
                 },
                 hasPerfectTotalScore: { $eq: ['$$ef.totalScore', 100] },
-                hasCitationError: { $eq: ['$$ef.citationScore', 0] },
+                hasCitationError: { $in: ['$$ef.citationScore', [0, 20]] },
                 hasHarmful: {
                   $or: [
                     { $eq: ['$$ef.sentence1Harmful', true] },
@@ -130,7 +130,6 @@ export function getPartnerEvalAggregationExpression(feedbackPath = '$interaction
                     { $eq: ['$$ef.sentence2Score', 80] },
                     { $eq: ['$$ef.sentence3Score', 80] },
                     { $eq: ['$$ef.sentence4Score', 80] },
-                    { $eq: ['$$ef.citationScore', 20] },
                     { $eq: ['$$ef.totalScore', 80] }
                   ]
                 }
@@ -187,7 +186,7 @@ export function getAiEvalAggregationExpression(feedbackPath = '$interactions.aut
                   ]
                 },
                 hasPerfectTotalScore: { $eq: ['$$ef.totalScore', 100] },
-                hasCitationError: { $eq: ['$$ef.citationScore', 0] },
+                hasCitationError: { $in: ['$$ef.citationScore', [0, 20]] },
                 hasHarmful: {
                   $or: [
                     { $eq: ['$$ef.sentence1Harmful', true] },
@@ -211,7 +210,6 @@ export function getAiEvalAggregationExpression(feedbackPath = '$interactions.aut
                     { $eq: ['$$ef.sentence2Score', 80] },
                     { $eq: ['$$ef.sentence3Score', 80] },
                     { $eq: ['$$ef.sentence4Score', 80] },
-                    { $eq: ['$$ef.citationScore', 20] },
                     { $eq: ['$$ef.totalScore', 80] }
                   ]
                 }

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -336,7 +336,7 @@ const FilterPanel = ({
       </summary>
       <div className="filter-panel-content">
         <div className="filter-grid">
-          {/* Left column - Date Range */}
+          {/* Left column - Date Range and Users */}
           <div className="filter-column">
             <div className="filter-row">
               <label htmlFor="dateRangePicker" className="filter-label">
@@ -350,6 +350,24 @@ const FilterPanel = ({
                 readOnly
                 style={{ backgroundColor: 'white', cursor: 'pointer' }}
               />
+            </div>
+
+            <div className="filter-row">
+              <label htmlFor="user-type" className="filter-label">
+                {t('admin.filters.users') || 'User Type'}
+              </label>
+              <select
+                id="user-type"
+                value={userType}
+                onChange={(e) => setUserType(e.target.value)}
+                className="filter-select"
+              >
+                {userTypeOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
 
@@ -366,24 +384,6 @@ const FilterPanel = ({
                 className="filter-select"
               >
                 {departmentOptions.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="filter-row">
-              <label htmlFor="user-type" className="filter-label">
-                {t('admin.filters.users') || 'User Type'}
-              </label>
-              <select
-                id="user-type"
-                value={userType}
-                onChange={(e) => setUserType(e.target.value)}
-                className="filter-select"
-              >
-                {userTypeOptions.map(option => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -13,7 +13,8 @@ const FilterPanel = ({
   isVisible = false,
   autoApply = false,
   applyButtonText = null,
-  applyDisabled = false
+  applyDisabled = false,
+  defaultUserType = 'all'
 }) => {
   const { t } = useTranslations(lang);
   const dateRangePickerRef = useRef(null);
@@ -65,7 +66,7 @@ const FilterPanel = ({
   const [department, setDepartment] = useState('');
   const [urlEn, setUrlEn] = useState('');
   const [urlFr, setUrlFr] = useState('');
-  const [userType, setUserType] = useState('all');
+  const [userType, setUserType] = useState(defaultUserType);
   const [answerType, setAnswerType] = useState([]);
   const [partnerEval, setPartnerEval] = useState([]);
   const [aiEval, setAiEval] = useState([]);
@@ -82,7 +83,7 @@ const FilterPanel = ({
         department: '',
         urlEn: '',
         urlFr: '',
-        userType: 'all',
+        userType: defaultUserType,
         answerType: 'all',
         partnerEval: 'all',
         aiEval: 'all'
@@ -289,7 +290,7 @@ const FilterPanel = ({
     setDepartment('');
     setUrlEn('');
     setUrlFr('');
-    setUserType('all');
+    setUserType(defaultUserType);
     setAnswerType([]);
     setPartnerEval([]);
     setAiEval([]);
@@ -335,7 +336,7 @@ const FilterPanel = ({
       </summary>
       <div className="filter-panel-content">
         <div className="filter-grid">
-          {/* Left column - Date Range and URL Filters */}
+          {/* Left column - Date Range */}
           <div className="filter-column">
             <div className="filter-row">
               <label htmlFor="dateRangePicker" className="filter-label">
@@ -348,34 +349,6 @@ const FilterPanel = ({
                 className="filter-input"
                 readOnly
                 style={{ backgroundColor: 'white', cursor: 'pointer' }}
-              />
-            </div>
-
-            <div className="filter-row">
-              <label htmlFor="url-en" className="filter-label">
-                {t('admin.filters.urlEn') || 'URL (EN)'}
-              </label>
-              <input
-                type="text"
-                id="url-en"
-                value={urlEn}
-                onChange={(e) => setUrlEn(e.target.value)}
-                placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
-                className="filter-input"
-              />
-            </div>
-
-            <div className="filter-row">
-              <label htmlFor="url-fr" className="filter-label">
-                {t('admin.filters.urlFr') || 'URL (FR)'}
-              </label>
-              <input
-                type="text"
-                id="url-fr"
-                value={urlFr}
-                onChange={(e) => setUrlFr(e.target.value)}
-                placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
-                className="filter-input"
               />
             </div>
           </div>
@@ -428,6 +401,32 @@ const FilterPanel = ({
                 {t('admin.filters.showAdvanced')}
               </summary>
               <div className="filter-advanced-section mt-100">
+                <div className="filter-row">
+                  <label htmlFor="url-en" className="filter-label">
+                    {t('admin.filters.urlEn') || 'URL (EN)'}
+                  </label>
+                  <input
+                    type="text"
+                    id="url-en"
+                    value={urlEn}
+                    onChange={(e) => setUrlEn(e.target.value)}
+                    placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
+                    className="filter-input"
+                  />
+                </div>
+                <div className="filter-row">
+                  <label htmlFor="url-fr" className="filter-label">
+                    {t('admin.filters.urlFr') || 'URL (FR)'}
+                  </label>
+                  <input
+                    type="text"
+                    id="url-fr"
+                    value={urlFr}
+                    onChange={(e) => setUrlFr(e.target.value)}
+                    placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
+                    className="filter-input"
+                  />
+                </div>
                 <div className="filter-row">
                   <details className="filter-checkbox-details" onToggle={handleNestedToggle}>
                     <summary className="filter-label">

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -392,6 +392,7 @@ const FilterPanel = ({
             </div>
 
             {/* Advanced Filters - Collapsible (Closed by default) */}
+            <div className="filter-label">{t('admin.filters.filterOptions')}</div>
             <details
               className="filter-advanced-details"
               open={showAdvancedFilters}

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -63,7 +63,8 @@ const initialMetricsState = {
     needsImprovement: { total: 0, en: 0, fr: 0 },
     hasError: { total: 0, en: 0, fr: 0 },
     hasCitationError: { total: 0, en: 0, fr: 0 },
-    harmful: { total: 0, en: 0, fr: 0 }
+    harmful: { total: 0, en: 0, fr: 0 },
+    hasContentIssue: { total: 0, en: 0, fr: 0 }
   },
   aiScored: {
     total: { total: 0, en: 0, fr: 0 },
@@ -247,15 +248,6 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       frCount: metrics.totalConversationsFr,
                       frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
                     },
-                    {
-                      metric: t('metrics.dashboard.googleSearches'),
-                      count: metrics.totalGoogleSearches,
-                      percentage: metrics.totalConversations ? Math.round((metrics.totalGoogleSearches / metrics.totalConversations) * 100) + '%' : '0%',
-                      enCount: '-',
-                      enPercentage: '-',
-                      frCount: '-',
-                      frPercentage: '-'
-                    }
                   ]}
                   columns={[
                     { title: t('metrics.dashboard.metric'), data: 'metric' },
@@ -329,38 +321,39 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
             {/* Table 3: Accuracy summary */}
             <SectionWrapper isLoading={loadingState.expert || loadingState.ai} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai}>
+              <GcdsText className="mb-300">{t('metrics.dashboard.accuracy.note')}</GcdsText>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <DataTable
                   data={[
                     {
                       metric: t('metrics.dashboard.accuracy.allEvaluations'),
                       totalEvaluated: metrics.expertScored.total.total + metrics.aiScored.total.total,
-                      correct: metrics.expertScored.correct.total + metrics.aiScored.correct.total,
+                      hasAnswerError: metrics.expertScored.hasError.total + metrics.aiScored.hasError.total,
                       accuracyPct: (metrics.expertScored.total.total + metrics.aiScored.total.total)
-                        ? Math.round(((metrics.expertScored.correct.total + metrics.aiScored.correct.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100) + '%'
+                        ? (100 - Math.round(((metrics.expertScored.hasError.total + metrics.aiScored.hasError.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100)) + '%'
                         : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.expertEvaluations'),
                       totalEvaluated: metrics.expertScored.total.total,
-                      correct: metrics.expertScored.correct.total,
+                      hasAnswerError: metrics.expertScored.hasError.total,
                       accuracyPct: metrics.expertScored.total.total
-                        ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%'
+                        ? (100 - Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100)) + '%'
                         : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.aiEvaluations'),
                       totalEvaluated: metrics.aiScored.total.total,
-                      correct: metrics.aiScored.correct.total,
+                      hasAnswerError: metrics.aiScored.hasError.total,
                       accuracyPct: metrics.aiScored.total.total
-                        ? Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100) + '%'
+                        ? (100 - Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100)) + '%'
                         : '0%'
                     }
                   ]}
                   columns={[
                     { title: t('metrics.dashboard.metric'), data: 'metric' },
                     { title: t('metrics.dashboard.accuracy.totalEvaluated'), data: 'totalEvaluated' },
-                    { title: t('metrics.dashboard.accuracy.correct'), data: 'correct' },
+                    { title: t('metrics.dashboard.accuracy.hasAnswerError'), data: 'hasAnswerError' },
                     { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'accuracyPct' }
                   ]}
                   options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
@@ -482,6 +475,15 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.totalOutputTokensEn ? Math.round((metrics.totalAnswerOutputTokensEn / metrics.totalOutputTokensEn) * 100) + '%' : '0%',
                       frCount: metrics.totalAnswerOutputTokensFr,
                       frPercentage: metrics.totalOutputTokensFr ? Math.round((metrics.totalAnswerOutputTokensFr / metrics.totalOutputTokensFr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.googleSearches'),
+                      count: metrics.totalGoogleSearches,
+                      percentage: metrics.totalQuestions ? Math.round((metrics.totalGoogleSearches / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enCount: '-',
+                      enPercentage: '-',
+                      frCount: '-',
+                      frPercentage: '-'
                     }
                   ]}
                   columns={[
@@ -557,6 +559,15 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.harmful.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
                       frCount: metrics.expertScored.harmful.fr,
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.harmful.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.expertScored.hasContentIssue'),
+                      count: metrics.expertScored.hasContentIssue.total,
+                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasContentIssue.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      enCount: metrics.expertScored.hasContentIssue.en,
+                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasContentIssue.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      frCount: metrics.expertScored.hasContentIssue.fr,
+                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasContentIssue.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     }
                   ]}
                   columns={[
@@ -665,22 +676,18 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                 <h3 className="mb-300">{t('metrics.dashboard.byDepartment.title')}</h3>
                 <DataTable
                   data={Object.entries(metrics.byDepartment).map(([department, data]) => ({
-                    department,
+                    department: department || t('metrics.dashboard.byDepartment.noContextDept'),
                     totalQuestions: data.total,
                     expertScoredTotal: data.expertScored.total,
-                    expertScoredCorrect: data.expertScored.correct,
-                    expertScoredNeedsImprovement: data.expertScored.needsImprovement,
                     expertScoredHasError: data.expertScored.hasError,
-                    expertScoredHasErrorPercent: data.expertScored.total ? Math.round((data.expertScored.hasError / data.expertScored.total) * 100) : 0
+                    expertScoredAccuracyPct: data.expertScored.total ? (100 - Math.round((data.expertScored.hasError / data.expertScored.total) * 100)) + '%' : '-'
                   }))}
                   columns={[
                     { title: t('metrics.dashboard.byDepartment.department'), data: 'department' },
                     { title: t('metrics.dashboard.totalQuestions'), data: 'totalQuestions' },
                     { title: t('metrics.dashboard.expertScored.total'), data: 'expertScoredTotal' },
-                    { title: t('metrics.dashboard.expertScored.correct'), data: 'expertScoredCorrect' },
-                    { title: t('metrics.dashboard.expertScored.needsImprovement'), data: 'expertScoredNeedsImprovement' },
                     { title: t('metrics.dashboard.expertScored.hasError'), data: 'expertScoredHasError' },
-                    { title: t('metrics.dashboard.expertScored.hasErrorPercent'), data: 'expertScoredHasErrorPercent' }
+                    { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'expertScoredAccuracyPct' }
                   ]}
                   options={{
                     paging: true,

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -296,7 +296,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
             {/* Table 2: Accuracy summary */}
             <SectionWrapper isLoading={loadingState.expert || loadingState.ai || loadingState.usage} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai || errorState.usage}>
-              <GcdsText className="mb-300">{t('metrics.dashboard.accuracy.note')}</GcdsText>
+              <p className="font-size-text-small mb-300">{t('metrics.dashboard.accuracy.note')}</p>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <DataTable
                   data={[

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -182,8 +182,8 @@ const MetricsDashboard = ({ lang = 'en' }) => {
     fetchMetrics(filters);
   };
 
-  const handleClearFilters = () => {
-    fetchMetrics(getDefaultDateRange());
+  const handleClearFilters = (defaultFilters) => {
+    fetchMetrics(defaultFilters || { ...getDefaultDateRange(), userType: 'public' });
   };
 
 
@@ -229,6 +229,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
         onApplyFilters={handleApplyFilters}
         onClearFilters={handleClearFilters}
         isVisible={true}
+        defaultUserType="public"
       />
 
       {hasStartedLoading && (
@@ -682,6 +683,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     department: (!department || department === 'Unknown') ? t('metrics.dashboard.byDepartment.noContextDept') : department,
                     totalQuestions: data.total,
                     expertScoredTotal: data.expertScored.total,
+                    expertScoredPct: data.total ? Math.round((data.expertScored.total / data.total) * 100) + '%' : '0%',
                     expertScoredHasError: data.expertScored.hasError,
                     expertScoredAccuracyPct: data.expertScored.total ? (100 - Math.round((data.expertScored.hasError / data.expertScored.total) * 100)) + '%' : '-'
                   }))}
@@ -689,6 +691,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     { title: t('metrics.dashboard.byDepartment.department'), data: 'department' },
                     { title: t('metrics.dashboard.totalQuestions'), data: 'totalQuestions' },
                     { title: t('metrics.dashboard.expertScored.total'), data: 'expertScoredTotal' },
+                    { title: t('metrics.dashboard.byDepartment.pctEvaluated'), data: 'expertScoredPct' },
                     { title: t('metrics.dashboard.expertScored.hasError'), data: 'expertScoredHasError' },
                     { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'expertScoredAccuracyPct' }
                   ]}

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -295,7 +295,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
             </SectionWrapper>
 
             {/* Table 2: Accuracy summary */}
-            <SectionWrapper isLoading={loadingState.expert || loadingState.ai} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai}>
+            <SectionWrapper isLoading={loadingState.expert || loadingState.ai || loadingState.usage} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai || errorState.usage}>
               <GcdsText className="mb-300">{t('metrics.dashboard.accuracy.note')}</GcdsText>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <DataTable
@@ -303,6 +303,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.accuracy.allEvaluations'),
                       totalEvaluated: metrics.expertScored.total.total + metrics.aiScored.total.total,
+                      pctOfQuestions: metrics.totalQuestions ? Math.round(((metrics.expertScored.total.total + metrics.aiScored.total.total) / metrics.totalQuestions) * 100) + '%' : '-',
                       hasAnswerError: metrics.expertScored.hasError.total + metrics.aiScored.hasError.total,
                       accuracyPct: (metrics.expertScored.total.total + metrics.aiScored.total.total)
                         ? (100 - Math.round(((metrics.expertScored.hasError.total + metrics.aiScored.hasError.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100)) + '%'
@@ -311,6 +312,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.accuracy.expertEvaluations'),
                       totalEvaluated: metrics.expertScored.total.total,
+                      pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.expertScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
                       hasAnswerError: metrics.expertScored.hasError.total,
                       accuracyPct: metrics.expertScored.total.total
                         ? (100 - Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100)) + '%'
@@ -319,6 +321,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.accuracy.aiEvaluations'),
                       totalEvaluated: metrics.aiScored.total.total,
+                      pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.aiScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
                       hasAnswerError: metrics.aiScored.hasError.total,
                       accuracyPct: metrics.aiScored.total.total
                         ? (100 - Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100)) + '%'
@@ -328,6 +331,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   columns={[
                     { title: t('metrics.dashboard.metric'), data: 'metric' },
                     { title: t('metrics.dashboard.accuracy.totalEvaluated'), data: 'totalEvaluated' },
+                    { title: t('metrics.dashboard.accuracy.pctOfQuestions'), data: 'pctOfQuestions' },
                     { title: t('metrics.dashboard.accuracy.hasAnswerError'), data: 'hasAnswerError' },
                     { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'accuracyPct' }
                   ]}

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -189,6 +189,9 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
 
   // 2nd question = sessions with 2+ questions; 3rd = sessions with 3+
+  const fmtNum = (n) => (n ?? 0).toLocaleString(lang === 'fr' ? 'fr-CA' : 'en-CA');
+  const fmtTokens = (n) => fmtNum(Math.round((n ?? 0) / 1000)) + 'K';
+
   const secondQuestionTotal = metrics.sessionsByQuestionCount.twoQuestions.total + metrics.sessionsByQuestionCount.threeQuestions.total;
   const secondQuestionEn = metrics.sessionsByQuestionCount.twoQuestions.en + metrics.sessionsByQuestionCount.threeQuestions.en;
   const secondQuestionFr = metrics.sessionsByQuestionCount.twoQuestions.fr + metrics.sessionsByQuestionCount.threeQuestions.fr;
@@ -424,61 +427,61 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.tokens.totalInput'),
-                      count: metrics.totalInputTokens,
+                      count: fmtTokens(metrics.totalInputTokens),
                       percentage: '100%',
-                      enCount: metrics.totalInputTokensEn,
+                      enCount: fmtTokens(metrics.totalInputTokensEn),
                       enPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensEn / metrics.totalInputTokens) * 100) + '%' : '0%',
-                      frCount: metrics.totalInputTokensFr,
+                      frCount: fmtTokens(metrics.totalInputTokensFr),
                       frPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensFr / metrics.totalInputTokens) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.contextInput'),
-                      count: metrics.totalContextInputTokens,
+                      count: fmtTokens(metrics.totalContextInputTokens),
                       percentage: metrics.totalInputTokens ? Math.round((metrics.totalContextInputTokens / metrics.totalInputTokens) * 100) + '%' : '0%',
-                      enCount: metrics.totalContextInputTokensEn,
+                      enCount: fmtTokens(metrics.totalContextInputTokensEn),
                       enPercentage: metrics.totalInputTokensEn ? Math.round((metrics.totalContextInputTokensEn / metrics.totalInputTokensEn) * 100) + '%' : '0%',
-                      frCount: metrics.totalContextInputTokensFr,
+                      frCount: fmtTokens(metrics.totalContextInputTokensFr),
                       frPercentage: metrics.totalInputTokensFr ? Math.round((metrics.totalContextInputTokensFr / metrics.totalInputTokensFr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.answerInput'),
-                      count: metrics.totalAnswerInputTokens,
+                      count: fmtTokens(metrics.totalAnswerInputTokens),
                       percentage: metrics.totalInputTokens ? Math.round((metrics.totalAnswerInputTokens / metrics.totalInputTokens) * 100) + '%' : '0%',
-                      enCount: metrics.totalAnswerInputTokensEn,
+                      enCount: fmtTokens(metrics.totalAnswerInputTokensEn),
                       enPercentage: metrics.totalInputTokensEn ? Math.round((metrics.totalAnswerInputTokensEn / metrics.totalInputTokensEn) * 100) + '%' : '0%',
-                      frCount: metrics.totalAnswerInputTokensFr,
+                      frCount: fmtTokens(metrics.totalAnswerInputTokensFr),
                       frPercentage: metrics.totalInputTokensFr ? Math.round((metrics.totalAnswerInputTokensFr / metrics.totalInputTokensFr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.totalOutput'),
-                      count: metrics.totalOutputTokens,
+                      count: fmtTokens(metrics.totalOutputTokens),
                       percentage: '100%',
-                      enCount: metrics.totalOutputTokensEn,
+                      enCount: fmtTokens(metrics.totalOutputTokensEn),
                       enPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensEn / metrics.totalOutputTokens) * 100) + '%' : '0%',
-                      frCount: metrics.totalOutputTokensFr,
+                      frCount: fmtTokens(metrics.totalOutputTokensFr),
                       frPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensFr / metrics.totalOutputTokens) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.contextOutput'),
-                      count: metrics.totalContextOutputTokens,
+                      count: fmtTokens(metrics.totalContextOutputTokens),
                       percentage: metrics.totalOutputTokens ? Math.round((metrics.totalContextOutputTokens / metrics.totalOutputTokens) * 100) + '%' : '0%',
-                      enCount: metrics.totalContextOutputTokensEn,
+                      enCount: fmtTokens(metrics.totalContextOutputTokensEn),
                       enPercentage: metrics.totalOutputTokensEn ? Math.round((metrics.totalContextOutputTokensEn / metrics.totalOutputTokensEn) * 100) + '%' : '0%',
-                      frCount: metrics.totalContextOutputTokensFr,
+                      frCount: fmtTokens(metrics.totalContextOutputTokensFr),
                       frPercentage: metrics.totalOutputTokensFr ? Math.round((metrics.totalContextOutputTokensFr / metrics.totalOutputTokensFr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.answerOutput'),
-                      count: metrics.totalAnswerOutputTokens,
+                      count: fmtTokens(metrics.totalAnswerOutputTokens),
                       percentage: metrics.totalOutputTokens ? Math.round((metrics.totalAnswerOutputTokens / metrics.totalOutputTokens) * 100) + '%' : '0%',
-                      enCount: metrics.totalAnswerOutputTokensEn,
+                      enCount: fmtTokens(metrics.totalAnswerOutputTokensEn),
                       enPercentage: metrics.totalOutputTokensEn ? Math.round((metrics.totalAnswerOutputTokensEn / metrics.totalOutputTokensEn) * 100) + '%' : '0%',
-                      frCount: metrics.totalAnswerOutputTokensFr,
+                      frCount: fmtTokens(metrics.totalAnswerOutputTokensFr),
                       frPercentage: metrics.totalOutputTokensFr ? Math.round((metrics.totalAnswerOutputTokensFr / metrics.totalOutputTokensFr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.tokens.googleSearches'),
-                      count: metrics.totalGoogleSearches,
+                      count: fmtNum(metrics.totalGoogleSearches),
                       percentage: metrics.totalQuestions ? Math.round((metrics.totalGoogleSearches / metrics.totalQuestions) * 100) + '%' : '0%',
                       enCount: '-',
                       enPercentage: '-',
@@ -488,11 +491,11 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   ]}
                   columns={[
                     { title: t('metrics.dashboard.metric'), data: 'metric' },
-                    { title: t('metrics.dashboard.count'), data: 'count' },
+                    { title: t('metrics.dashboard.count') + ' (K)', data: 'count' },
                     { title: t('metrics.dashboard.percentage'), data: 'percentage' },
-                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
+                    { title: t('metrics.dashboard.enCount') + ' (K)', data: 'enCount' },
                     { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
-                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
+                    { title: t('metrics.dashboard.frCount') + ' (K)', data: 'frCount' },
                     { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
                   ]}
                   options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -234,36 +234,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
           <div className="p-4">
             <h2 className="mt-400 mb-400">{t('metrics.dashboard.title')}</h2>
 
-            {/* Table 1: Sessions */}
-            <SectionWrapper isLoading={loadingState.session} title={t('metrics.dashboard.sessions.title')} error={errorState.session}>
-              <div className="bg-gray-50 p-4 rounded-lg">
-                <DataTable
-                  data={[
-                    {
-                      metric: t('metrics.dashboard.totalSessions'),
-                      count: metrics.totalConversations,
-                      percentage: '100%',
-                      enCount: metrics.totalConversationsEn,
-                      enPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsEn / metrics.totalConversations) * 100) + '%' : '0%',
-                      frCount: metrics.totalConversationsFr,
-                      frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
-                    },
-                  ]}
-                  columns={[
-                    { title: t('metrics.dashboard.metric'), data: 'metric' },
-                    { title: t('metrics.dashboard.count'), data: 'count' },
-                    { title: t('metrics.dashboard.percentage'), data: 'percentage' },
-                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
-                    { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
-                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
-                    { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
-                  ]}
-                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
-                />
-              </div>
-            </SectionWrapper>
-
-            {/* Table 2: Questions by position */}
+            {/* Table 1: Questions by position */}
             <SectionWrapper isLoading={loadingState.usage || loadingState.session} title={t('metrics.dashboard.questions.title')} error={errorState.usage || errorState.session}>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <DataTable
@@ -319,7 +290,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
               </div>
             </SectionWrapper>
 
-            {/* Table 3: Accuracy summary */}
+            {/* Table 2: Accuracy summary */}
             <SectionWrapper isLoading={loadingState.expert || loadingState.ai} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai}>
               <GcdsText className="mb-300">{t('metrics.dashboard.accuracy.note')}</GcdsText>
               <div className="bg-gray-50 p-4 rounded-lg">
@@ -355,6 +326,35 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     { title: t('metrics.dashboard.accuracy.totalEvaluated'), data: 'totalEvaluated' },
                     { title: t('metrics.dashboard.accuracy.hasAnswerError'), data: 'hasAnswerError' },
                     { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'accuracyPct' }
+                  ]}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
+                />
+              </div>
+            </SectionWrapper>
+
+            {/* Table 3: Sessions */}
+            <SectionWrapper isLoading={loadingState.session} title={t('metrics.dashboard.sessions.title')} error={errorState.session}>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <DataTable
+                  data={[
+                    {
+                      metric: t('metrics.dashboard.totalSessions'),
+                      count: metrics.totalConversations,
+                      percentage: '100%',
+                      enCount: metrics.totalConversationsEn,
+                      enPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsEn / metrics.totalConversations) * 100) + '%' : '0%',
+                      frCount: metrics.totalConversationsFr,
+                      frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
+                    },
+                  ]}
+                  columns={[
+                    { title: t('metrics.dashboard.metric'), data: 'metric' },
+                    { title: t('metrics.dashboard.count'), data: 'count' },
+                    { title: t('metrics.dashboard.percentage'), data: 'percentage' },
+                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
+                    { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
+                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
+                    { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
                   ]}
                   options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
                 />
@@ -516,24 +516,6 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       frPercentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.total.fr / metrics.expertScored.total.total) * 100) + '%' : '0%'
                     },
                     {
-                      metric: t('metrics.dashboard.expertScored.correct'),
-                      count: metrics.expertScored.correct.total,
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.correct.en,
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.correct.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.correct.fr,
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.correct.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.expertScored.needsImprovement'),
-                      count: metrics.expertScored.needsImprovement.total,
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.needsImprovement.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.needsImprovement.en,
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.needsImprovement.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.needsImprovement.fr,
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.needsImprovement.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
-                    },
-                    {
                       metric: t('metrics.dashboard.expertScored.hasError'),
                       count: metrics.expertScored.hasError.total,
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
@@ -541,15 +523,6 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
                       frCount: metrics.expertScored.hasError.fr,
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.expertScored.hasCitationError'),
-                      count: metrics.expertScored.hasCitationError.total,
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasCitationError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.hasCitationError.en,
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasCitationError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.hasCitationError.fr,
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasCitationError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.harmful'),
@@ -568,6 +541,33 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasContentIssue.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
                       frCount: metrics.expertScored.hasContentIssue.fr,
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasContentIssue.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.expertScored.correct'),
+                      count: metrics.expertScored.correct.total,
+                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      enCount: metrics.expertScored.correct.en,
+                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.correct.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      frCount: metrics.expertScored.correct.fr,
+                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.correct.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.expertScored.needsImprovement'),
+                      count: metrics.expertScored.needsImprovement.total,
+                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.needsImprovement.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      enCount: metrics.expertScored.needsImprovement.en,
+                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.needsImprovement.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      frCount: metrics.expertScored.needsImprovement.fr,
+                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.needsImprovement.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.expertScored.hasCitationError'),
+                      count: metrics.expertScored.hasCitationError.total,
+                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasCitationError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      enCount: metrics.expertScored.hasCitationError.en,
+                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasCitationError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      frCount: metrics.expertScored.hasCitationError.fr,
+                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasCitationError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     }
                   ]}
                   columns={[
@@ -608,6 +608,15 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       frPercentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.total.fr / metrics.aiScored.total.total) * 100) + '%' : '0%'
                     },
                     {
+                      metric: t('metrics.dashboard.aiScored.hasError'),
+                      count: metrics.aiScored.hasError.total,
+                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      enCount: metrics.aiScored.hasError.en,
+                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
+                      frCount: metrics.aiScored.hasError.fr,
+                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
+                    },
+                    {
                       metric: t('metrics.dashboard.aiScored.correct'),
                       count: metrics.aiScored.correct.total,
                       percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
@@ -624,15 +633,6 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.needsImprovement.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
                       frCount: metrics.aiScored.needsImprovement.fr,
                       frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.needsImprovement.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.aiScored.hasError'),
-                      count: metrics.aiScored.hasError.total,
-                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.aiScored.hasError.en,
-                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.hasError.fr,
-                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.hasCitationError'),
@@ -676,7 +676,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                 <h3 className="mb-300">{t('metrics.dashboard.byDepartment.title')}</h3>
                 <DataTable
                   data={Object.entries(metrics.byDepartment).map(([department, data]) => ({
-                    department: department || t('metrics.dashboard.byDepartment.noContextDept'),
+                    department: (!department || department === 'Unknown') ? t('metrics.dashboard.byDepartment.noContextDept') : department,
                     totalQuestions: data.total,
                     expertScoredTotal: data.expertScored.total,
                     expertScoredHasError: data.expertScored.hasError,

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -38,6 +38,18 @@ const initialMetricsState = {
   totalOutputTokens: 0,
   totalOutputTokensEn: 0,
   totalOutputTokensFr: 0,
+  totalContextInputTokens: 0,
+  totalContextInputTokensEn: 0,
+  totalContextInputTokensFr: 0,
+  totalAnswerInputTokens: 0,
+  totalAnswerInputTokensEn: 0,
+  totalAnswerInputTokensFr: 0,
+  totalContextOutputTokens: 0,
+  totalContextOutputTokensEn: 0,
+  totalContextOutputTokensFr: 0,
+  totalAnswerOutputTokens: 0,
+  totalAnswerOutputTokensEn: 0,
+  totalAnswerOutputTokensFr: 0,
   totalGoogleSearches: 0,
   answerTypes: {
     normal: { total: 0, en: 0, fr: 0 },
@@ -175,6 +187,11 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
 
 
+  // 2nd question = sessions with 2+ questions; 3rd = sessions with 3+
+  const secondQuestionTotal = metrics.sessionsByQuestionCount.twoQuestions.total + metrics.sessionsByQuestionCount.threeQuestions.total;
+  const secondQuestionEn = metrics.sessionsByQuestionCount.twoQuestions.en + metrics.sessionsByQuestionCount.threeQuestions.en;
+  const secondQuestionFr = metrics.sessionsByQuestionCount.twoQuestions.fr + metrics.sessionsByQuestionCount.threeQuestions.fr;
+
   // Helper for Section Wrapper to handle relative positioning for overlay
   const SectionWrapper = ({ children, isLoading, title, error }) => (
     <div className="mb-600 relative">
@@ -216,8 +233,8 @@ const MetricsDashboard = ({ lang = 'en' }) => {
           <div className="p-4">
             <h2 className="mt-400 mb-400">{t('metrics.dashboard.title')}</h2>
 
-            {/* Usage Metrics Section */}
-            <SectionWrapper isLoading={loadingState.usage} title={t('metrics.dashboard.usageMetrics')} error={errorState.usage}>
+            {/* Table 1: Sessions */}
+            <SectionWrapper isLoading={loadingState.session} title={t('metrics.dashboard.sessions.title')} error={errorState.session}>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <DataTable
                   data={[
@@ -231,41 +248,131 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
                     },
                     {
-                      metric: t('metrics.dashboard.sessionsByQuestionCount.singleQuestion'),
-                      count: metrics.sessionsByQuestionCount.singleQuestion.total,
-                      percentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.singleQuestion.total / metrics.totalConversations) * 100) + '%' : '0%',
-                      enCount: metrics.sessionsByQuestionCount.singleQuestion.en,
-                      enPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.singleQuestion.en / metrics.totalConversations) * 100) + '%' : '0%',
-                      frCount: metrics.sessionsByQuestionCount.singleQuestion.fr,
-                      frPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.singleQuestion.fr / metrics.totalConversations) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.sessionsByQuestionCount.twoQuestions'),
-                      count: metrics.sessionsByQuestionCount.twoQuestions.total,
-                      percentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.twoQuestions.total / metrics.totalConversations) * 100) + '%' : '0%',
-                      enCount: metrics.sessionsByQuestionCount.twoQuestions.en,
-                      enPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.twoQuestions.en / metrics.totalConversations) * 100) + '%' : '0%',
-                      frCount: metrics.sessionsByQuestionCount.twoQuestions.fr,
-                      frPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.twoQuestions.fr / metrics.totalConversations) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.sessionsByQuestionCount.threeQuestions'),
-                      count: metrics.sessionsByQuestionCount.threeQuestions.total,
-                      percentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.total / metrics.totalConversations) * 100) + '%' : '0%',
-                      enCount: metrics.sessionsByQuestionCount.threeQuestions.en,
-                      enPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.en / metrics.totalConversations) * 100) + '%' : '0%',
-                      frCount: metrics.sessionsByQuestionCount.threeQuestions.fr,
-                      frPercentage: metrics.totalConversations ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.fr / metrics.totalConversations) * 100) + '%' : '0%'
-                    },
+                      metric: t('metrics.dashboard.googleSearches'),
+                      count: metrics.totalGoogleSearches,
+                      percentage: metrics.totalConversations ? Math.round((metrics.totalGoogleSearches / metrics.totalConversations) * 100) + '%' : '0%',
+                      enCount: '-',
+                      enPercentage: '-',
+                      frCount: '-',
+                      frPercentage: '-'
+                    }
+                  ]}
+                  columns={[
+                    { title: t('metrics.dashboard.metric'), data: 'metric' },
+                    { title: t('metrics.dashboard.count'), data: 'count' },
+                    { title: t('metrics.dashboard.percentage'), data: 'percentage' },
+                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
+                    { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
+                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
+                    { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
+                  ]}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
+                />
+              </div>
+            </SectionWrapper>
+
+            {/* Table 2: Questions by position */}
+            <SectionWrapper isLoading={loadingState.usage || loadingState.session} title={t('metrics.dashboard.questions.title')} error={errorState.usage || errorState.session}>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <DataTable
+                  data={[
                     {
                       metric: t('metrics.dashboard.totalQuestions'),
                       count: metrics.totalQuestions,
-                      percentage: metrics.totalConversations ? Math.round((metrics.totalQuestions / metrics.totalConversations) * 100) + '%' : '0%',
+                      percentage: '100%',
                       enCount: metrics.totalQuestionsEn,
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsEn / metrics.totalQuestions) * 100) + '%' : '0%',
                       frCount: metrics.totalQuestionsFr,
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsFr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
+                    {
+                      metric: t('metrics.dashboard.questions.firstQuestion'),
+                      count: metrics.totalConversations,
+                      percentage: metrics.totalQuestions ? Math.round((metrics.totalConversations / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enCount: metrics.totalConversationsEn,
+                      enPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsEn / metrics.totalQuestions) * 100) + '%' : '0%',
+                      frCount: metrics.totalConversationsFr,
+                      frPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsFr / metrics.totalQuestions) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.questions.secondQuestion'),
+                      count: secondQuestionTotal,
+                      percentage: metrics.totalQuestions ? Math.round((secondQuestionTotal / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enCount: secondQuestionEn,
+                      enPercentage: metrics.totalQuestions ? Math.round((secondQuestionEn / metrics.totalQuestions) * 100) + '%' : '0%',
+                      frCount: secondQuestionFr,
+                      frPercentage: metrics.totalQuestions ? Math.round((secondQuestionFr / metrics.totalQuestions) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.questions.thirdOrMore'),
+                      count: metrics.sessionsByQuestionCount.threeQuestions.total,
+                      percentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enCount: metrics.sessionsByQuestionCount.threeQuestions.en,
+                      enPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      frCount: metrics.sessionsByQuestionCount.threeQuestions.fr,
+                      frPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                    }
+                  ]}
+                  columns={[
+                    { title: t('metrics.dashboard.metric'), data: 'metric' },
+                    { title: t('metrics.dashboard.count'), data: 'count' },
+                    { title: t('metrics.dashboard.percentage'), data: 'percentage' },
+                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
+                    { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
+                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
+                    { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
+                  ]}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
+                />
+              </div>
+            </SectionWrapper>
+
+            {/* Table 3: Accuracy summary */}
+            <SectionWrapper isLoading={loadingState.expert || loadingState.ai} title={t('metrics.dashboard.accuracy.title')} error={errorState.expert || errorState.ai}>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <DataTable
+                  data={[
+                    {
+                      metric: t('metrics.dashboard.accuracy.allEvaluations'),
+                      totalEvaluated: metrics.expertScored.total.total + metrics.aiScored.total.total,
+                      correct: metrics.expertScored.correct.total + metrics.aiScored.correct.total,
+                      accuracyPct: (metrics.expertScored.total.total + metrics.aiScored.total.total)
+                        ? Math.round(((metrics.expertScored.correct.total + metrics.aiScored.correct.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100) + '%'
+                        : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.accuracy.expertEvaluations'),
+                      totalEvaluated: metrics.expertScored.total.total,
+                      correct: metrics.expertScored.correct.total,
+                      accuracyPct: metrics.expertScored.total.total
+                        ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%'
+                        : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.accuracy.aiEvaluations'),
+                      totalEvaluated: metrics.aiScored.total.total,
+                      correct: metrics.aiScored.correct.total,
+                      accuracyPct: metrics.aiScored.total.total
+                        ? Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100) + '%'
+                        : '0%'
+                    }
+                  ]}
+                  columns={[
+                    { title: t('metrics.dashboard.metric'), data: 'metric' },
+                    { title: t('metrics.dashboard.accuracy.totalEvaluated'), data: 'totalEvaluated' },
+                    { title: t('metrics.dashboard.accuracy.correct'), data: 'correct' },
+                    { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'accuracyPct' }
+                  ]}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
+                />
+              </div>
+            </SectionWrapper>
+
+            {/* Table 4: Question types */}
+            <SectionWrapper isLoading={loadingState.usage} title={t('metrics.dashboard.questionTypes.title')} error={errorState.usage}>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <DataTable
+                  data={[
                     {
                       metric: t('metrics.dashboard.answerTypes.normal'),
                       count: metrics.answerTypes.normal.total,
@@ -301,33 +408,6 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].en / metrics.totalQuestions) * 100) + '%' : '0%',
                       frCount: metrics.answerTypes['not-gc'].fr,
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: 'Google searches',
-                      count: metrics.totalGoogleSearches,
-                      percentage: metrics.totalConversations ? Math.round((metrics.totalGoogleSearches / metrics.totalConversations) * 100) + '%' : '0%',
-                      enCount: '-',
-                      enPercentage: '-',
-                      frCount: '-',
-                      frPercentage: '-'
-                    },
-                    {
-                      metric: t('metrics.dashboard.inputTokens'),
-                      count: metrics.totalInputTokens,
-                      percentage: '100%',
-                      enCount: metrics.totalInputTokensEn,
-                      enPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensEn / metrics.totalInputTokens) * 100) + '%' : '0%',
-                      frCount: metrics.totalInputTokensFr,
-                      frPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensFr / metrics.totalInputTokens) * 100) + '%' : '0%'
-                    },
-                    {
-                      metric: t('metrics.dashboard.outputTokens'),
-                      count: metrics.totalOutputTokens,
-                      percentage: '100%',
-                      enCount: metrics.totalOutputTokensEn,
-                      enPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensEn / metrics.totalOutputTokens) * 100) + '%' : '0%',
-                      frCount: metrics.totalOutputTokensFr,
-                      frPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensFr / metrics.totalOutputTokens) * 100) + '%' : '0%'
                     }
                   ]}
                   columns={[
@@ -339,15 +419,81 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     { title: t('metrics.dashboard.frCount'), data: 'frCount' },
                     { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
                   ]}
-                  options={{
-                    paging: false,
-                    searching: false,
-                    ordering: false,
-                    info: false,
-                    stripe: true,
-                    className: 'display',
-                    language: dataTableLanguage(lang)
-                  }}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
+                />
+              </div>
+            </SectionWrapper>
+
+            {/* Table 5: Tokens */}
+            <SectionWrapper isLoading={loadingState.usage} title={t('metrics.dashboard.tokens.title')} error={errorState.usage}>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <DataTable
+                  data={[
+                    {
+                      metric: t('metrics.dashboard.tokens.totalInput'),
+                      count: metrics.totalInputTokens,
+                      percentage: '100%',
+                      enCount: metrics.totalInputTokensEn,
+                      enPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensEn / metrics.totalInputTokens) * 100) + '%' : '0%',
+                      frCount: metrics.totalInputTokensFr,
+                      frPercentage: metrics.totalInputTokens ? Math.round((metrics.totalInputTokensFr / metrics.totalInputTokens) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.contextInput'),
+                      count: metrics.totalContextInputTokens,
+                      percentage: metrics.totalInputTokens ? Math.round((metrics.totalContextInputTokens / metrics.totalInputTokens) * 100) + '%' : '0%',
+                      enCount: metrics.totalContextInputTokensEn,
+                      enPercentage: metrics.totalInputTokensEn ? Math.round((metrics.totalContextInputTokensEn / metrics.totalInputTokensEn) * 100) + '%' : '0%',
+                      frCount: metrics.totalContextInputTokensFr,
+                      frPercentage: metrics.totalInputTokensFr ? Math.round((metrics.totalContextInputTokensFr / metrics.totalInputTokensFr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.answerInput'),
+                      count: metrics.totalAnswerInputTokens,
+                      percentage: metrics.totalInputTokens ? Math.round((metrics.totalAnswerInputTokens / metrics.totalInputTokens) * 100) + '%' : '0%',
+                      enCount: metrics.totalAnswerInputTokensEn,
+                      enPercentage: metrics.totalInputTokensEn ? Math.round((metrics.totalAnswerInputTokensEn / metrics.totalInputTokensEn) * 100) + '%' : '0%',
+                      frCount: metrics.totalAnswerInputTokensFr,
+                      frPercentage: metrics.totalInputTokensFr ? Math.round((metrics.totalAnswerInputTokensFr / metrics.totalInputTokensFr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.totalOutput'),
+                      count: metrics.totalOutputTokens,
+                      percentage: '100%',
+                      enCount: metrics.totalOutputTokensEn,
+                      enPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensEn / metrics.totalOutputTokens) * 100) + '%' : '0%',
+                      frCount: metrics.totalOutputTokensFr,
+                      frPercentage: metrics.totalOutputTokens ? Math.round((metrics.totalOutputTokensFr / metrics.totalOutputTokens) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.contextOutput'),
+                      count: metrics.totalContextOutputTokens,
+                      percentage: metrics.totalOutputTokens ? Math.round((metrics.totalContextOutputTokens / metrics.totalOutputTokens) * 100) + '%' : '0%',
+                      enCount: metrics.totalContextOutputTokensEn,
+                      enPercentage: metrics.totalOutputTokensEn ? Math.round((metrics.totalContextOutputTokensEn / metrics.totalOutputTokensEn) * 100) + '%' : '0%',
+                      frCount: metrics.totalContextOutputTokensFr,
+                      frPercentage: metrics.totalOutputTokensFr ? Math.round((metrics.totalContextOutputTokensFr / metrics.totalOutputTokensFr) * 100) + '%' : '0%'
+                    },
+                    {
+                      metric: t('metrics.dashboard.tokens.answerOutput'),
+                      count: metrics.totalAnswerOutputTokens,
+                      percentage: metrics.totalOutputTokens ? Math.round((metrics.totalAnswerOutputTokens / metrics.totalOutputTokens) * 100) + '%' : '0%',
+                      enCount: metrics.totalAnswerOutputTokensEn,
+                      enPercentage: metrics.totalOutputTokensEn ? Math.round((metrics.totalAnswerOutputTokensEn / metrics.totalOutputTokensEn) * 100) + '%' : '0%',
+                      frCount: metrics.totalAnswerOutputTokensFr,
+                      frPercentage: metrics.totalOutputTokensFr ? Math.round((metrics.totalAnswerOutputTokensFr / metrics.totalOutputTokensFr) * 100) + '%' : '0%'
+                    }
+                  ]}
+                  columns={[
+                    { title: t('metrics.dashboard.metric'), data: 'metric' },
+                    { title: t('metrics.dashboard.count'), data: 'count' },
+                    { title: t('metrics.dashboard.percentage'), data: 'percentage' },
+                    { title: t('metrics.dashboard.enCount'), data: 'enCount' },
+                    { title: t('metrics.dashboard.enPercentage'), data: 'enPercentage' },
+                    { title: t('metrics.dashboard.frCount'), data: 'frCount' },
+                    { title: t('metrics.dashboard.frPercentage'), data: 'frPercentage' }
+                  ]}
+                  options={{ paging: false, searching: false, ordering: false, info: false, stripe: true, className: 'display', language: dataTableLanguage(lang) }}
                 />
               </div>
             </SectionWrapper>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1173,16 +1173,9 @@
     "timeRangeTitle": "Get usage and evaluation metrics",
     "dashboard": {
       "title": "Results",
-      "usageMetrics": "Usage metrics",
       "totalSessions": "Total sessions",
-      "inputTokens": "Input tokens",
-      "outputTokens": "Output tokens",
+      "googleSearches": "Google searches",
       "totalQuestions": "Total questions",
-      "sessionsByQuestionCount": {
-        "singleQuestion": "Single question sessions",
-        "twoQuestions": "Two question sessions",
-        "threeQuestions": "Three question sessions"
-      },
       "answerTypes": {
         "normal": "GC answers",
         "clarifyingQuestion": "Clarifying questions",
@@ -1209,7 +1202,7 @@
       },
       "aiScored": {
         "title": "AI evaluations",
-        "description": "Automated AI evaluations based on expert evaluations of similar questions",
+        "description": "Automated AI evaluations for questions without a partner evaluation",
         "total": "Total questions evaluated",
         "correct": "Correct",
         "needsImprovement": "Needs improvement",
@@ -1226,6 +1219,36 @@
         "reason": "Reason",
         "otherYes": "Other (yes)",
         "otherNo": "Other (no)"
+      },
+      "sessions": {
+        "title": "Sessions"
+      },
+      "questions": {
+        "title": "Questions",
+        "firstQuestion": "1st question",
+        "secondQuestion": "2nd question",
+        "thirdOrMore": "3rd question or more"
+      },
+      "accuracy": {
+        "title": "Accuracy summary",
+        "allEvaluations": "All evaluations",
+        "expertEvaluations": "Expert evaluations",
+        "aiEvaluations": "AI evaluations",
+        "totalEvaluated": "Total evaluated",
+        "correct": "Correct",
+        "accuracyPct": "Accuracy %"
+      },
+      "questionTypes": {
+        "title": "Question types"
+      },
+      "tokens": {
+        "title": "Tokens",
+        "totalInput": "Total input tokens",
+        "contextInput": "Context input tokens",
+        "answerInput": "Answer input tokens",
+        "totalOutput": "Total output tokens",
+        "contextOutput": "Context output tokens",
+        "answerOutput": "Answer output tokens"
       },
       "byDepartment": {
         "title": "Department breakdown of expert evaluations",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -647,6 +647,7 @@
       "evalHasError": "Error",
       "evalHasCitationError": "Citation error",
       "evalHarmful": "Harmful",
+      "filterOptions": "Filter options",
       "showAdvanced": "More filter options"
     },
     "publicEval": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -624,8 +624,8 @@
       "urlEn": "Referring URL (EN)",
       "urlFr": "Referring URL (FR)",
       "urlPlaceholder": "Filter by full or partial URL",
-      "department": "Department",
-      "allDepartments": "All departments",
+      "department": "Partner institution",
+      "allDepartments": "All institutions",
       "users": "Users",
       "allUsers": "All",
       "publicUsers": "Public",
@@ -647,7 +647,7 @@
       "evalHasError": "Error",
       "evalHasCitationError": "Citation error",
       "evalHarmful": "Harmful",
-      "showAdvanced": "See more filters"
+      "showAdvanced": "More filter options"
     },
     "publicEval": {
       "title": "Public evaluation",
@@ -1255,7 +1255,8 @@
       "byDepartment": {
         "title": "Department breakdown of expert evaluations",
         "department": "Department",
-        "noContextDept": "No context dept"
+        "noContextDept": "No context dept",
+        "pctEvaluated": "% evaluated"
       }
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1174,7 +1174,6 @@
     "dashboard": {
       "title": "Results",
       "totalSessions": "Total sessions",
-      "googleSearches": "Google searches",
       "totalQuestions": "Total questions",
       "answerTypes": {
         "normal": "GC answers",
@@ -1195,10 +1194,11 @@
         "total": "Total questions evaluated",
         "correct": "Correct",
         "needsImprovement": "Needs improvement",
-        "hasError": "Has error",
-        "hasCitationError": "Has citation error",
-        "hasErrorPercent": "Has error (%)",
-        "harmful": "Coded as harmful"
+        "hasError": "Has answer error",
+        "hasCitationError": "Citation issue",
+        "hasErrorPercent": "Has answer error (%)",
+        "harmful": "Coded as harmful",
+        "hasContentIssue": "Content issue flagged"
       },
       "aiScored": {
         "title": "AI evaluations",
@@ -1206,8 +1206,8 @@
         "total": "Total questions evaluated",
         "correct": "Correct",
         "needsImprovement": "Needs improvement",
-        "hasError": "Has error",
-        "hasCitationError": "Has citation error"
+        "hasError": "Has answer error",
+        "hasCitationError": "Citation issue"
       },
       "userScored": {
         "title": "End-user feedback (public)",
@@ -1231,11 +1231,12 @@
       },
       "accuracy": {
         "title": "Accuracy summary",
-        "allEvaluations": "All evaluations",
+        "allEvaluations": "Total evaluations",
+        "note": "If a question has both an expert and AI evaluation, only the expert evaluation is used.",
         "expertEvaluations": "Expert evaluations",
         "aiEvaluations": "AI evaluations",
         "totalEvaluated": "Total evaluated",
-        "correct": "Correct",
+        "hasAnswerError": "Has answer error",
         "accuracyPct": "Accuracy %"
       },
       "questionTypes": {
@@ -1248,11 +1249,13 @@
         "answerInput": "Answer input tokens",
         "totalOutput": "Total output tokens",
         "contextOutput": "Context output tokens",
-        "answerOutput": "Answer output tokens"
+        "answerOutput": "Answer output tokens",
+        "googleSearches": "Google search queries"
       },
       "byDepartment": {
         "title": "Department breakdown of expert evaluations",
-        "department": "Department"
+        "department": "Department",
+        "noContextDept": "No context dept"
       }
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1190,7 +1190,7 @@
       "frPercentage": "FR %",
       "expertScored": {
         "title": "Partner evaluations",
-        "description": "Evaluations by signed-in departmental partners",
+        "description": "Evaluations by signed-in partner institution users",
         "total": "Total questions evaluated",
         "correct": "Correct",
         "needsImprovement": "Needs improvement",
@@ -1236,6 +1236,7 @@
         "expertEvaluations": "Expert evaluations",
         "aiEvaluations": "AI evaluations",
         "totalEvaluated": "Total evaluated",
+        "pctOfQuestions": "% of questions",
         "hasAnswerError": "Has answer error",
         "accuracyPct": "Accuracy %"
       },
@@ -1253,9 +1254,9 @@
         "googleSearches": "Google search queries"
       },
       "byDepartment": {
-        "title": "Department breakdown of expert evaluations",
-        "department": "Department",
-        "noContextDept": "No context dept",
+        "title": "Institution breakdown of expert evaluations",
+        "department": "Institution",
+        "noContextDept": "No institution context",
         "pctEvaluated": "% evaluated"
       }
     }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1190,7 +1190,7 @@
       "frPercentage": "% FR",
       "expertScored": {
         "title": "Évaluations des partenaires",
-        "description": "Évaluations par des partenaires ministériels connectés",
+        "description": "Évaluations par des utilisateurs connectés des institutions partenaires",
         "total": "Total des questions évaluées",
         "correct": "Correct",
         "needsImprovement": "Nécessite une amélioration",
@@ -1236,6 +1236,7 @@
         "expertEvaluations": "Évaluations des experts",
         "aiEvaluations": "Évaluations IA",
         "totalEvaluated": "Total évalué",
+        "pctOfQuestions": "% des questions",
         "hasAnswerError": "Contient une erreur de réponse",
         "accuracyPct": "% d'exactitude"
       },
@@ -1253,9 +1254,9 @@
         "googleSearches": "Requêtes de recherche Google"
       },
       "byDepartment": {
-        "title": "Répartition par département des évaluations d'experts",
-        "department": "Département",
-        "noContextDept": "Aucun dépt de contexte",
+        "title": "Répartition par institution des évaluations d'experts",
+        "department": "Institution",
+        "noContextDept": "Aucun contexte d'institution",
         "pctEvaluated": "% évalué"
       }
     }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1174,7 +1174,6 @@
     "dashboard": {
       "title": "Résultats",
       "totalSessions": "Total des sessions",
-      "googleSearches": "Recherches Google",
       "totalQuestions": "Total des questions",
       "answerTypes": {
         "normal": "Réponses GC",
@@ -1195,10 +1194,11 @@
         "total": "Total des questions évaluées",
         "correct": "Correct",
         "needsImprovement": "Nécessite une amélioration",
-        "hasError": "Contient une erreur",
-        "hasCitationError": "Contient une erreur de citation",
-        "hasErrorPercent": "Contient une erreur (%)",
-        "harmful": "Codé comme nuisible"
+        "hasError": "Contient une erreur de réponse",
+        "hasCitationError": "Problème de citation",
+        "hasErrorPercent": "Contient une erreur de réponse (%)",
+        "harmful": "Codé comme nuisible",
+        "hasContentIssue": "Problème de contenu signalé"
       },
       "aiScored": {
         "title": "Évaluations IA",
@@ -1206,8 +1206,8 @@
         "total": "Total des questions évaluées",
         "correct": "Correct",
         "needsImprovement": "Nécessite une amélioration",
-        "hasError": "Contient une erreur",
-        "hasCitationError": "Contient une erreur de citation"
+        "hasError": "Contient une erreur de réponse",
+        "hasCitationError": "Problème de citation"
       },
       "userScored": {
         "title": "Rétroaction des utilisateurs (publique)",
@@ -1231,11 +1231,12 @@
       },
       "accuracy": {
         "title": "Résumé de l'exactitude",
-        "allEvaluations": "Toutes les évaluations",
+        "allEvaluations": "Total des évaluations",
+        "note": "Si une question a à la fois une évaluation d'expert et une évaluation IA, seule l'évaluation d'expert est utilisée.",
         "expertEvaluations": "Évaluations des experts",
         "aiEvaluations": "Évaluations IA",
         "totalEvaluated": "Total évalué",
-        "correct": "Correct",
+        "hasAnswerError": "Contient une erreur de réponse",
         "accuracyPct": "% d'exactitude"
       },
       "questionTypes": {
@@ -1248,11 +1249,13 @@
         "answerInput": "Jetons d'entrée de la réponse",
         "totalOutput": "Total des jetons de sortie",
         "contextOutput": "Jetons de sortie du contexte",
-        "answerOutput": "Jetons de sortie de la réponse"
+        "answerOutput": "Jetons de sortie de la réponse",
+        "googleSearches": "Requêtes de recherche Google"
       },
       "byDepartment": {
         "title": "Répartition par département des évaluations d'experts",
-        "department": "Département"
+        "department": "Département",
+        "noContextDept": "Aucun dépt de contexte"
       }
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -647,6 +647,7 @@
       "evalHasError": "Erreur",
       "evalHasCitationError": "Erreur de citation",
       "evalHarmful": "Nuisible",
+      "filterOptions": "Options de filtre",
       "showAdvanced": "Plus d'options de filtre"
     },
     "publicEval": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1173,16 +1173,9 @@
     "timeRangeTitle": "Obtenir les métriques d'utilisation et d'évaluation",
     "dashboard": {
       "title": "Résultats",
-      "usageMetrics": "Métriques d'utilisation",
       "totalSessions": "Total des sessions",
-      "inputTokens": "Jetons d'entrée",
-      "outputTokens": "Jetons de sortie",
+      "googleSearches": "Recherches Google",
       "totalQuestions": "Total des questions",
-      "sessionsByQuestionCount": {
-        "singleQuestion": "Sessions à une question",
-        "twoQuestions": "Sessions à deux questions",
-        "threeQuestions": "Sessions à trois questions"
-      },
       "answerTypes": {
         "normal": "Réponses GC",
         "clarifyingQuestion": "Questions de clarification",
@@ -1209,7 +1202,7 @@
       },
       "aiScored": {
         "title": "Évaluations IA",
-        "description": "Évaluations automatisées par IA basées sur les évaluations d'experts de questions similaires",
+        "description": "Évaluations automatisées par IA pour les questions sans évaluation partenaire",
         "total": "Total des questions évaluées",
         "correct": "Correct",
         "needsImprovement": "Nécessite une amélioration",
@@ -1226,6 +1219,36 @@
         "reason": "Raison",
         "otherYes": "Autre (oui)",
         "otherNo": "Autre (non)"
+      },
+      "sessions": {
+        "title": "Sessions"
+      },
+      "questions": {
+        "title": "Questions",
+        "firstQuestion": "1ère question",
+        "secondQuestion": "2e question",
+        "thirdOrMore": "3e question ou plus"
+      },
+      "accuracy": {
+        "title": "Résumé de l'exactitude",
+        "allEvaluations": "Toutes les évaluations",
+        "expertEvaluations": "Évaluations des experts",
+        "aiEvaluations": "Évaluations IA",
+        "totalEvaluated": "Total évalué",
+        "correct": "Correct",
+        "accuracyPct": "% d'exactitude"
+      },
+      "questionTypes": {
+        "title": "Types de questions"
+      },
+      "tokens": {
+        "title": "Jetons",
+        "totalInput": "Total des jetons d'entrée",
+        "contextInput": "Jetons d'entrée du contexte",
+        "answerInput": "Jetons d'entrée de la réponse",
+        "totalOutput": "Total des jetons de sortie",
+        "contextOutput": "Jetons de sortie du contexte",
+        "answerOutput": "Jetons de sortie de la réponse"
       },
       "byDepartment": {
         "title": "Répartition par département des évaluations d'experts",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -624,8 +624,8 @@
       "urlEn": "URL de référence (EN)",
       "urlFr": "URL de référence (FR)",
       "urlPlaceholder": "Filtrer par URL complète ou partielle",
-      "department": "Département",
-      "allDepartments": "Tous les départements",
+      "department": "Institution partenaire",
+      "allDepartments": "Toutes les institutions",
       "users": "Utilisateurs",
       "allUsers": "Tous",
       "publicUsers": "Public",
@@ -647,7 +647,7 @@
       "evalHasError": "Erreur",
       "evalHasCitationError": "Erreur de citation",
       "evalHarmful": "Nuisible",
-      "showAdvanced": "Voir plus de filtres"
+      "showAdvanced": "Plus d'options de filtre"
     },
     "publicEval": {
       "title": "Évaluation publique",
@@ -1255,7 +1255,8 @@
       "byDepartment": {
         "title": "Répartition par département des évaluations d'experts",
         "department": "Département",
-        "noContextDept": "Aucun dépt de contexte"
+        "noContextDept": "Aucun dépt de contexte",
+        "pctEvaluated": "% évalué"
       }
     }
   },


### PR DESCRIPTION
 Break giant first table into new set of tables per discussion with @jmealingcds 
 
 Backend (api/metrics/metrics-usage.js)
  - Keeps context and answer tokens separate through the pipeline, now returns 12 new fields: totalContextInputTokens, totalAnswerInputTokens, totalContextOutputTokens, totalAnswerOutputTokens plus their EN/FR variants.

  Frontend (MetricsDashboard.js)
  The single enormous "Usage metrics" table is gone,
  replaced with 5 focused tables:
  1. Sessions — total sessions EN/FR
  2. Questions — total questions + breakdown by position (1st/2nd/3rd), calculated from session data rather than session counts
  3. Accuracy summary — all/expert/AI evaluations with total evaluated, correct count, and accuracy % (compact summary before the full detail tables)
  4. Question types — GC answers, clarifying, pt-muni, not-gc
  5. Tokens — total input/output + context vs answer breakdown

  The existing expert eval, AI eval, public feedback,
   and department tables are unchanged and follow
  below.

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
