### PR TITLE
fix: bug in label normalization

### DIFF
--- a/src/components/batch/BatchUpload.js
+++ b/src/components/batch/BatchUpload.js
@@ -89,8 +89,12 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
         // Parse CSV to entries and prepare items for server-side BatchItem creation
         const entries = processCSV(text);
 
+        if (!entries.length) {
+          throw new Error(t('batch.upload.error.noValidRows'));
+        }
+
         // Only keep fields needed: question variants and URLs
-        const questionKeys = ['REDACTEDQUESTION', 'QUESTION', 'PROBLEMDETAILS', 'REDACTED QUESTION'];
+        const questionKeys = ['REDACTEDQUESTION'];
         const items = entries.map((e, idx) => {
           const original = {};
           questionKeys.forEach((key) => {
@@ -191,7 +195,7 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
         .map((row) => {
           const entry = {};
           headers.forEach((header, index) => {
-            const key = (header === 'PROBLEM DETAILS' || header === 'PROBLEMDETAILS' || header === 'REDACTED QUESTION')
+            const key = (header === 'PROBLEM DETAILS' || header === 'PROBLEMDETAILS' || header === 'REDACTED QUESTION' || header === 'QUESTION')
               ? 'REDACTEDQUESTION'
               : header;
             entry[key] = String(row[index] ?? '').trim();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -268,6 +268,7 @@
         "noFile": "Please select a file first.",
         "nameRequired": "Please enter a batch name.",
         "invalidFile": "Invalid file type. Please upload a .csv file.",
+        "noValidRows": "No valid rows found in the CSV. Check that the question column header is one of: Problem Details, Question, Redacted Question.",
         "readFailed": "Failed to read the file. Please try uploading again.",
         "saveFailed": "Failed to save batch to server. Please try again."
       }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -268,6 +268,7 @@
         "noFile": "Veuillez sélectionner un fichier d'abord.",
         "nameRequired": "Veuillez entrer un nom de lot.",
         "invalidFile": "Type de fichier non valide. Veuillez télécharger un fichier .csv.",
+        "noValidRows": "Aucune ligne valide trouvée dans le fichier CSV. Vérifiez que l'en-tête de la colonne de questions est l'un des suivants : Problem Details, Question, Redacted Question.",
         "readFailed": "Impossible de lire le fichier. Veuillez réessayer de le télécharger.",
         "saveFailed": "Impossible d'enregistrer le lot sur le serveur. Veuillez réessayer."
       }


### PR DESCRIPTION
# Summary | Résumé

Batches fail if question column label is 'Question' or 'QUESTION' even though supposed to work. Was missing from normalization. Also wasn't producing error message. 

---
 Root cause: processCSV normalizes 
  PROBLEM DETAILS, PROBLEMDETAILS,  
  and REDACTED QUESTION to the key  
  REDACTEDQUESTION, but not         
  QUESTION. Rows with a QUESTION  
  column were stored under the key  
  QUESTION, then silently dropped by
   .filter((entry) =>
  entry['REDACTEDQUESTION']) at line
   201.

  Fix: Added || header ===          
  'QUESTION' to the normalization
  condition (line 194), so Question,
   QUESTION, etc. all become      
  REDACTEDQUESTION after          
  .toUpperCase(). Also simplified
  questionKeys to just
  ['REDACTEDQUESTION'] since all
  variants now normalize to that one
   key before the items are built.

The silent failure path was:
  processCSV returned [] (no      
  exception), handleUpload had no
  guard for an empty result, so it
  happily persisted a batch with    
  zero items and reset the form
  looking like success.             
                                  
  The error now fires from          
  handleUpload before touching the
  server, lands in the existing     
  catch (err) block that sets     
  setError(detail), and shows in the
   {error && ...} div already in the
   form. No new UI wiring needed.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
