### PR TITLE
chore(tests): follow-up to #1303 - Vitest shuffle configuration

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -35,6 +35,10 @@ export default defineConfig({
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
       'tests/e2e/**'
-    ]
+    ],
+    sequence: {
+      shuffle: true, // Run tests in random order to catch tests that rely on execution order or leaked state
+      // seed: 12345, // Optionally set a fixed seed for reproducibility of test order when shuffling is enabled
+    },
   }
 });


### PR DESCRIPTION
Follow-up to #1303

This PR enables test shuffling in the Vitest configuration to discover inter-test dependencies and improve confidence in test isolation. It also clarifies test ordering and reproducibility, including optional seed usage (currently commented out).

# Testing

I executed ```npm test``` several times to ensure tests were shuffled and completed successfully.
