### PR TITLE
fix: bugs in storing times and in displaying

### DIFF
--- a/agents/graphs/DefaultWithVectorGraph.js
+++ b/agents/graphs/DefaultWithVectorGraph.js
@@ -45,14 +45,15 @@ const graph = new StateGraph(GraphState);
 
 graph.addNode('init', async (state) => {
   const startTime = Date.now();
-  // Emit node input log (fire-and-forget)
-  logGraphEvent('info', 'node:init input', state.chatId, {
+  // 'Starting <Graph>' must be logged before 'node:init input' — ChatViewer uses it as the timeline anchor.
+  await ServerLoggingService.info('Starting DefaultWithVectorGraph', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,
   });
 
-  await ServerLoggingService.info('Starting DefaultWithVectorGraph', state.chatId, {
+  // Emit node input log (fire-and-forget)
+  logGraphEvent('info', 'node:init input', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,

--- a/agents/graphs/GenericGraph.js
+++ b/agents/graphs/GenericGraph.js
@@ -44,13 +44,14 @@ const graph = new StateGraph(GraphState);
 
 graph.addNode('init', async (state) => {
   const startTime = Date.now();
-  logGraphEvent('info', 'node:init input', state.chatId, {
+  // 'Starting <Graph>' must be logged before 'node:init input' — ChatViewer uses it as the timeline anchor.
+  await ServerLoggingService.info('Starting GenericGraph', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,
   });
 
-  await ServerLoggingService.info('Starting GenericGraph', state.chatId, {
+  logGraphEvent('info', 'node:init input', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,

--- a/agents/graphs/InstantAndQAGraph.js
+++ b/agents/graphs/InstantAndQAGraph.js
@@ -45,13 +45,14 @@ const graph = new StateGraph(GraphState);
 
 graph.addNode('init', async (state) => {
   const startTime = Date.now();
-  logGraphEvent('info', 'node:init input', state.chatId, {
+  // 'Starting <Graph>' must be logged before 'node:init input' — ChatViewer uses it as the timeline anchor.
+  await ServerLoggingService.info('Starting InstantAndQAGraph', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,
   });
 
-  await ServerLoggingService.info('Starting InstantAndQAGraph', state.chatId, {
+  logGraphEvent('info', 'node:init input', state.chatId, {
     lang: state.lang,
     referringUrl: state.referringUrl,
     selectedAI: state.selectedAI,

--- a/src/utils/chatviewer/__tests__/chatViewer.test.js
+++ b/src/utils/chatviewer/__tests__/chatViewer.test.js
@@ -14,14 +14,14 @@ describe('buildStepTimeline', () => {
       { createdAt: '2026-05-07T10:00:00.700Z', message: 'node:verify output' },
       { createdAt: '2026-05-07T10:00:00.800Z', message: 'node:persist input' },
       { createdAt: '2026-05-07T10:00:00.900Z', message: 'node:persist output' },
-      { createdAt: '2026-05-07T10:00:00.950Z', message: 'Workflow complete', metadata: { totalResponseTime: 950 } },
+      { createdAt: '2026-05-07T10:00:00.950Z', message: 'Workflow complete', metadata: { totalResponseTime: 800 } },
     ];
 
     const timeline = buildStepTimeline(logs);
 
     expect(timeline.graphName).toBe('GenericGraph');
-    expect(timeline.totalMs).toBe(950);
-    expect(timeline.userPerceivedMs).toBe(850);
+    expect(timeline.totalMs).toBe(800);
+    expect(timeline.userPerceivedMs).toBe(800);
     expect(timeline.steps.map((step) => step.name)).toEqual(['init', 'answer', 'verify']);
 
     const answerStep = timeline.steps.find((step) => step.name === 'answer');

--- a/src/utils/chatviewer/chatViewer.js
+++ b/src/utils/chatviewer/chatViewer.js
@@ -160,10 +160,12 @@ export function buildStepTimeline(logs) {
   const verifyStep = steps.find((step) => step.name === 'verify');
   let userPerceivedMs = null;
 
-  if (totalMs != null && persistStep?.duration != null) {
-    userPerceivedMs = Math.max(0, totalMs - persistStep.duration);
+  if (persistStep?.startRel != null) {
+    userPerceivedMs = persistStep.startRel;
   } else if (verifyStep?.endRel != null) {
     userPerceivedMs = verifyStep.endRel;
+  } else if (totalMs != null) {
+    userPerceivedMs = totalMs;
   }
 
   return {


### PR DESCRIPTION
# Summary | Résumé

Response times are being logged in wrong order some of the time - have made them invariant (historical logs will still be incorrect) 
  Log reordering (3 graph files): state.startTime = Date.now() is still captured on line 1,
   before either log call, so the persisted responseTime field is byte-identical to before.
   **The reordered logs only affect the createdAt timestamps in the log queue — the queue is 
  FIFO, so swapping the call order swaps the timestamp order, which is exactly what
  buildStepTimeline needs.**               

  userPerceivedMs fix in chatViewer.js: Fallback chain persistStep.startRel →              
  verifyStep.endRel → totalMs covers:
  - Normal runs with persist node (uses persistStep.startRel — cleanly excludes persist    
  work)                                                                                    
  - Runs where persist log is missing (falls to verifyStep.endRel)
  - Runs with neither (uses totalMs)                                                       
                                                                                           
  persistStep is found from the full steps array before persist is filtered out for
  display, so accessing .startRel is safe.    
Table showing those times broken down by pipeline had separate bug as seen in image where percentages didn't add up 
<img width="911" height="749" alt="image" src="https://github.com/user-attachments/assets/5b593669-2306-477a-bd35-d8a6ccf5110c" />


---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
