### PR TITLE
Get progress icon to work-on-Akamai

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -255,6 +255,7 @@ gcds-container:first-of-type {
   width: 1em;
   height: 4em;
   animation-delay: -0.16s;
+  transform-origin: center;
 }
 .loading-animation:before,
 .loading-animation:after {
@@ -266,6 +267,7 @@ gcds-container:first-of-type {
   width: 1em;
   height: 4em;
   animation: escaleY 1s infinite ease-in-out;
+  transform-origin: center;
 }
 .loading-animation:before {
   left: -2em;
@@ -276,12 +278,10 @@ gcds-container:first-of-type {
   0%,
   80%,
   100% {
-    box-shadow: 0 0;
-    height: 4em;
+    transform: scaleY(1);
   }
   40% {
-    box-shadow: 0 -2em;
-    height: 5em;
+    transform: scaleY(1.25) translateY(-1em);
   }
 }
 


### PR DESCRIPTION
The keyframes now animate transform (compositor-thread)
  instead of height/box-shadow (main-thread). If the main thread is
  being blocked during the SSE wait, the bars should now keep moving
  where they previously froze.

# Summary | Résumé

> Progress icon isn't moving because of Akamai SSE - trying this instead. 