### PR TITLE
fix: clear text input on search

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -588,6 +588,7 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
               ...(error.historySignature ? { historySignature: error.historySignature } : {})
             }
           ]);
+          clearInput();
           setIsLoading(false);
           return;
         } else {


### PR DESCRIPTION
Add clear input for ShortQueryValidation case. All other paths already had it:                            
                                                                                                                                             
  - Success → clearInput() ✓ (line 494)                                                                                                      
  - RedactionError → clearInput() ✓ (line 573)                                                                                               
  - Generic error → clearInput() ✓ (line 654)                                                                                                
  - ShortQueryValidation → was missing, now fixed                                                                                            
                                                                                                                                             
The character limit, session timeout (403), and service unavailable (503) paths still don't clear the input, those are intentional since  the user would want their text preserved to retry.