### PR TITLE
fix: french number formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,11 @@ const fmtPct = (n) => formatPercent(n, lang); // 45 % (fr) / 45% (en)
 
 - **`formatNumber(n, lang)`** — formats integers and large numbers with the correct thousands separator (`fr-CA` uses non-breaking space, `en-CA` uses comma). Handles `null`/`undefined` → `0`.
 - **`formatPercent(n, lang)`** — appends `%` with a non-breaking space before it in French (`45 %`), no space in English (`45%`). Takes an already-computed integer (0–100), not a fraction.
+- **`formatDecimal(n, lang, fractionDigits = 3)`** — formats a decimal number with locale-aware separators (`,` vs `.`) and a fixed number of decimal places. Pass-through for `null`/`undefined`/empty/non-numeric values.
 
 Rules:
 - Never use `+ '%'`, `'0%'`, or `'100%'` as literal strings in data displayed to users — always go through `fmtPct`.
+- Never use `n.toFixed(d)` or inline `Intl.NumberFormat` for decimal values displayed to users — always go through `formatDecimal`.
 - For DataTables columns with sorting enabled, pass raw numbers in the data object and use the `render: (d, type) => type === 'display' ? fmtN(d) : d` pattern so sorting operates on the raw value.
 - These helpers apply to dashboards, tables, batch lists, and any other UI that surfaces counts, totals, or percentages.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,25 @@ This reports:
 
 Parity gaps must be fixed before merging. Dead keys and duplicates are cleaned up incrementally — fix a few per PR rather than all at once.
 
+### Number and percentage formatting
+
+**This is an Official Languages requirement.** French and English have different conventions for numbers and percentages (`1 000` vs `1,000`; `45 %` vs `45%`). Any component or page that displays numeric data to users must format numbers and percentages using the shared helpers in `src/utils/numberFormat.js`:
+
+```js
+import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
+
+const fmtN = (n) => formatNumber(n, lang);   // 1 000 (fr) / 1,000 (en)
+const fmtPct = (n) => formatPercent(n, lang); // 45 % (fr) / 45% (en)
+```
+
+- **`formatNumber(n, lang)`** — formats integers and large numbers with the correct thousands separator (`fr-CA` uses non-breaking space, `en-CA` uses comma). Handles `null`/`undefined` → `0`.
+- **`formatPercent(n, lang)`** — appends `%` with a non-breaking space before it in French (`45 %`), no space in English (`45%`). Takes an already-computed integer (0–100), not a fraction.
+
+Rules:
+- Never use `+ '%'`, `'0%'`, or `'100%'` as literal strings in data displayed to users — always go through `fmtPct`.
+- For DataTables columns with sorting enabled, pass raw numbers in the data object and use the `render: (d, type) => type === 'display' ? fmtN(d) : d` pattern so sorting operates on the raw value.
+- These helpers apply to dashboards, tables, batch lists, and any other UI that surfaces counts, totals, or percentages.
+
 ### PR review checklist — official languages
 Every PR that touches UI components, pages, or locale files must be verified against these before merging.
 
@@ -63,6 +82,8 @@ Every PR that touches UI components, pages, or locale files must be verified aga
 - [ ] Every new `t('key')` call has a matching entry in **both** `en.json` and `fr.json`
 - [ ] `node scripts/find-dead-locale-keys.cjs` reports **0 parity gaps**
 - [ ] French translations are real translations — not copied English text or placeholders
+- [ ] All numbers displayed to users go through `formatNumber(n, lang)` — no raw `.toLocaleString()`, `toString()`, or unformatted numeric values
+- [ ] All percentages displayed to users go through `formatPercent(n, lang)` — no `+ '%'`, `'0%'`, or `'100%'` string literals
 
 **Flag but don't block:**
 - Sentence case is generally preferred for all text visible to users — note inconsistencies (e.g. mid-sentence capitals, ALL-CAPS emphasis) in review and fix opportunistically

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -4,6 +4,7 @@ import DataTable from 'datatables.net-react';
 import DT from 'datatables.net-dt';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
+import { formatNumber } from '../../utils/numberFormat.js';
 import EndUserFeedbackSection from '../metrics/EndUserFeedbackSection.js';
 import FilterPanel from './FilterPanel.js';
 import MetricsService from '../../services/MetricsService.js';
@@ -66,6 +67,7 @@ const initialMetricsState = {
 
 const MetricsDashboard = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
+  const fmtN = (n) => formatNumber(n, lang);
   const [metrics, setMetrics] = useState(initialMetricsState);
   const [loadingState, setLoadingState] = useState({
     usage: false,
@@ -223,38 +225,38 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.totalQuestions'),
-                      count: metrics.totalQuestions,
+                      count: fmtN(metrics.totalQuestions),
                       percentage: '100%',
-                      enCount: metrics.totalQuestionsEn,
+                      enCount: fmtN(metrics.totalQuestionsEn),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsEn / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.totalQuestionsFr,
+                      frCount: fmtN(metrics.totalQuestionsFr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsFr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.questions.firstQuestion'),
-                      count: metrics.totalConversations,
+                      count: fmtN(metrics.totalConversations),
                       percentage: metrics.totalQuestions ? Math.round((metrics.totalConversations / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.totalConversationsEn,
+                      enCount: fmtN(metrics.totalConversationsEn),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsEn / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.totalConversationsFr,
+                      frCount: fmtN(metrics.totalConversationsFr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsFr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.questions.secondQuestion'),
-                      count: secondQuestionTotal,
+                      count: fmtN(secondQuestionTotal),
                       percentage: metrics.totalQuestions ? Math.round((secondQuestionTotal / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: secondQuestionEn,
+                      enCount: fmtN(secondQuestionEn),
                       enPercentage: metrics.totalQuestions ? Math.round((secondQuestionEn / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: secondQuestionFr,
+                      frCount: fmtN(secondQuestionFr),
                       frPercentage: metrics.totalQuestions ? Math.round((secondQuestionFr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.questions.thirdOrMore'),
-                      count: metrics.sessionsByQuestionCount.threeQuestions.total,
+                      count: fmtN(metrics.sessionsByQuestionCount.threeQuestions.total),
                       percentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.total / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.sessionsByQuestionCount.threeQuestions.en,
+                      enCount: fmtN(metrics.sessionsByQuestionCount.threeQuestions.en),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.en / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.sessionsByQuestionCount.threeQuestions.fr,
+                      frCount: fmtN(metrics.sessionsByQuestionCount.threeQuestions.fr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.fr / metrics.totalQuestions) * 100) + '%' : '0%'
                     }
                   ]}
@@ -280,27 +282,27 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.accuracy.allEvaluations'),
-                      totalEvaluated: metrics.expertScored.total.total + metrics.aiScored.total.total,
+                      totalEvaluated: fmtN(metrics.expertScored.total.total + metrics.aiScored.total.total),
                       pctOfQuestions: metrics.totalQuestions ? Math.round(((metrics.expertScored.total.total + metrics.aiScored.total.total) / metrics.totalQuestions) * 100) + '%' : '-',
-                      hasAnswerError: metrics.expertScored.hasError.total + metrics.aiScored.hasError.total,
+                      hasAnswerError: fmtN(metrics.expertScored.hasError.total + metrics.aiScored.hasError.total),
                       accuracyPct: (metrics.expertScored.total.total + metrics.aiScored.total.total)
                         ? (100 - Math.round(((metrics.expertScored.hasError.total + metrics.aiScored.hasError.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100)) + '%'
                         : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.expertEvaluations'),
-                      totalEvaluated: metrics.expertScored.total.total,
+                      totalEvaluated: fmtN(metrics.expertScored.total.total),
                       pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.expertScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
-                      hasAnswerError: metrics.expertScored.hasError.total,
+                      hasAnswerError: fmtN(metrics.expertScored.hasError.total),
                       accuracyPct: metrics.expertScored.total.total
                         ? (100 - Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100)) + '%'
                         : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.aiEvaluations'),
-                      totalEvaluated: metrics.aiScored.total.total,
+                      totalEvaluated: fmtN(metrics.aiScored.total.total),
                       pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.aiScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
-                      hasAnswerError: metrics.aiScored.hasError.total,
+                      hasAnswerError: fmtN(metrics.aiScored.hasError.total),
                       accuracyPct: metrics.aiScored.total.total
                         ? (100 - Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100)) + '%'
                         : '0%'
@@ -325,11 +327,11 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.totalSessions'),
-                      count: metrics.totalConversations,
+                      count: fmtN(metrics.totalConversations),
                       percentage: '100%',
-                      enCount: metrics.totalConversationsEn,
+                      enCount: fmtN(metrics.totalConversationsEn),
                       enPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsEn / metrics.totalConversations) * 100) + '%' : '0%',
-                      frCount: metrics.totalConversationsFr,
+                      frCount: fmtN(metrics.totalConversationsFr),
                       frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
                     },
                   ]}
@@ -354,38 +356,38 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.answerTypes.normal'),
-                      count: metrics.answerTypes.normal.total,
+                      count: fmtN(metrics.answerTypes.normal.total),
                       percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.total / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.answerTypes.normal.en,
+                      enCount: fmtN(metrics.answerTypes.normal.en),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.en / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.answerTypes.normal.fr,
+                      frCount: fmtN(metrics.answerTypes.normal.fr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.fr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.clarifyingQuestion'),
-                      count: metrics.answerTypes['clarifying-question'].total,
+                      count: fmtN(metrics.answerTypes['clarifying-question'].total),
                       percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].total / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.answerTypes['clarifying-question'].en,
+                      enCount: fmtN(metrics.answerTypes['clarifying-question'].en),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].en / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.answerTypes['clarifying-question'].fr,
+                      frCount: fmtN(metrics.answerTypes['clarifying-question'].fr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.ptMuni'),
-                      count: metrics.answerTypes['pt-muni'].total,
+                      count: fmtN(metrics.answerTypes['pt-muni'].total),
                       percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].total / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.answerTypes['pt-muni'].en,
+                      enCount: fmtN(metrics.answerTypes['pt-muni'].en),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].en / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.answerTypes['pt-muni'].fr,
+                      frCount: fmtN(metrics.answerTypes['pt-muni'].fr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.notGc'),
-                      count: metrics.answerTypes['not-gc'].total,
+                      count: fmtN(metrics.answerTypes['not-gc'].total),
                       percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].total / metrics.totalQuestions) * 100) + '%' : '0%',
-                      enCount: metrics.answerTypes['not-gc'].en,
+                      enCount: fmtN(metrics.answerTypes['not-gc'].en),
                       enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].en / metrics.totalQuestions) * 100) + '%' : '0%',
-                      frCount: metrics.answerTypes['not-gc'].fr,
+                      frCount: fmtN(metrics.answerTypes['not-gc'].fr),
                       frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
                     }
                   ]}
@@ -411,65 +413,65 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.expertScored.total'),
-                      count: metrics.expertScored.total.total,
+                      count: fmtN(metrics.expertScored.total.total),
                       percentage: '100%',
-                      enCount: metrics.expertScored.total.en,
+                      enCount: fmtN(metrics.expertScored.total.en),
                       enPercentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.total.en / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.total.fr,
+                      frCount: fmtN(metrics.expertScored.total.fr),
                       frPercentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.total.fr / metrics.expertScored.total.total) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasError'),
-                      count: metrics.expertScored.hasError.total,
+                      count: fmtN(metrics.expertScored.hasError.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.hasError.en,
+                      enCount: fmtN(metrics.expertScored.hasError.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.hasError.fr,
+                      frCount: fmtN(metrics.expertScored.hasError.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.harmful'),
-                      count: metrics.expertScored.harmful.total,
+                      count: fmtN(metrics.expertScored.harmful.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.harmful.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.harmful.en,
+                      enCount: fmtN(metrics.expertScored.harmful.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.harmful.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.harmful.fr,
+                      frCount: fmtN(metrics.expertScored.harmful.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.harmful.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasContentIssue'),
-                      count: metrics.expertScored.hasContentIssue.total,
+                      count: fmtN(metrics.expertScored.hasContentIssue.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasContentIssue.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.hasContentIssue.en,
+                      enCount: fmtN(metrics.expertScored.hasContentIssue.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasContentIssue.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.hasContentIssue.fr,
+                      frCount: fmtN(metrics.expertScored.hasContentIssue.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasContentIssue.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.correct'),
-                      count: metrics.expertScored.correct.total,
+                      count: fmtN(metrics.expertScored.correct.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.correct.en,
+                      enCount: fmtN(metrics.expertScored.correct.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.correct.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.correct.fr,
+                      frCount: fmtN(metrics.expertScored.correct.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.correct.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.needsImprovement'),
-                      count: metrics.expertScored.needsImprovement.total,
+                      count: fmtN(metrics.expertScored.needsImprovement.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.needsImprovement.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.needsImprovement.en,
+                      enCount: fmtN(metrics.expertScored.needsImprovement.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.needsImprovement.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.needsImprovement.fr,
+                      frCount: fmtN(metrics.expertScored.needsImprovement.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.needsImprovement.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasCitationError'),
-                      count: metrics.expertScored.hasCitationError.total,
+                      count: fmtN(metrics.expertScored.hasCitationError.total),
                       percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasCitationError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.expertScored.hasCitationError.en,
+                      enCount: fmtN(metrics.expertScored.hasCitationError.en),
                       enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasCitationError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.expertScored.hasCitationError.fr,
+                      frCount: fmtN(metrics.expertScored.hasCitationError.fr),
                       frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasCitationError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
                     }
                   ]}
@@ -503,47 +505,47 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   data={[
                     {
                       metric: t('metrics.dashboard.aiScored.total'),
-                      count: metrics.aiScored.total.total,
+                      count: fmtN(metrics.aiScored.total.total),
                       percentage: '100%',
-                      enCount: metrics.aiScored.total.en,
+                      enCount: fmtN(metrics.aiScored.total.en),
                       enPercentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.total.en / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.total.fr,
+                      frCount: fmtN(metrics.aiScored.total.fr),
                       frPercentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.total.fr / metrics.aiScored.total.total) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.hasError'),
-                      count: metrics.aiScored.hasError.total,
+                      count: fmtN(metrics.aiScored.hasError.total),
                       percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.aiScored.hasError.en,
+                      enCount: fmtN(metrics.aiScored.hasError.en),
                       enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.hasError.fr,
+                      frCount: fmtN(metrics.aiScored.hasError.fr),
                       frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.correct'),
-                      count: metrics.aiScored.correct.total,
+                      count: fmtN(metrics.aiScored.correct.total),
                       percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.aiScored.correct.en,
+                      enCount: fmtN(metrics.aiScored.correct.en),
                       enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.correct.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.correct.fr,
+                      frCount: fmtN(metrics.aiScored.correct.fr),
                       frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.correct.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.needsImprovement'),
-                      count: metrics.aiScored.needsImprovement.total,
+                      count: fmtN(metrics.aiScored.needsImprovement.total),
                       percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.needsImprovement.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.aiScored.needsImprovement.en,
+                      enCount: fmtN(metrics.aiScored.needsImprovement.en),
                       enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.needsImprovement.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.needsImprovement.fr,
+                      frCount: fmtN(metrics.aiScored.needsImprovement.fr),
                       frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.needsImprovement.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.hasCitationError'),
-                      count: metrics.aiScored.hasCitationError.total,
+                      count: fmtN(metrics.aiScored.hasCitationError.total),
                       percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasCitationError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
-                      enCount: metrics.aiScored.hasCitationError.en,
+                      enCount: fmtN(metrics.aiScored.hasCitationError.en),
                       enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasCitationError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
-                      frCount: metrics.aiScored.hasCitationError.fr,
+                      frCount: fmtN(metrics.aiScored.hasCitationError.fr),
                       frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasCitationError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
                     }
                   ]}
@@ -588,10 +590,10 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                   }))}
                   columns={[
                     { title: t('metrics.dashboard.byDepartment.department'), data: 'department' },
-                    { title: t('metrics.dashboard.totalQuestions'), data: 'totalQuestions' },
-                    { title: t('metrics.dashboard.expertScored.total'), data: 'expertScoredTotal' },
+                    { title: t('metrics.dashboard.totalQuestions'), data: 'totalQuestions', render: (d, type) => type === 'display' ? fmtN(d) : d },
+                    { title: t('metrics.dashboard.expertScored.total'), data: 'expertScoredTotal', render: (d, type) => type === 'display' ? fmtN(d) : d },
                     { title: t('metrics.dashboard.byDepartment.pctEvaluated'), data: 'expertScoredPct' },
-                    { title: t('metrics.dashboard.expertScored.hasError'), data: 'expertScoredHasError' },
+                    { title: t('metrics.dashboard.expertScored.hasError'), data: 'expertScoredHasError', render: (d, type) => type === 'display' ? fmtN(d) : d },
                     { title: t('metrics.dashboard.accuracy.accuracyPct'), data: 'expertScoredAccuracyPct' }
                   ]}
                   options={{

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -4,7 +4,7 @@ import DataTable from 'datatables.net-react';
 import DT from 'datatables.net-dt';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
-import { formatNumber } from '../../utils/numberFormat.js';
+import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
 import EndUserFeedbackSection from '../metrics/EndUserFeedbackSection.js';
 import FilterPanel from './FilterPanel.js';
 import MetricsService from '../../services/MetricsService.js';
@@ -68,6 +68,7 @@ const initialMetricsState = {
 const MetricsDashboard = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const fmtN = (n) => formatNumber(n, lang);
+  const fmtPct = (n) => formatPercent(n, lang);
   const [metrics, setMetrics] = useState(initialMetricsState);
   const [loadingState, setLoadingState] = useState({
     usage: false,
@@ -226,38 +227,38 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.totalQuestions'),
                       count: fmtN(metrics.totalQuestions),
-                      percentage: '100%',
+                      percentage: fmtPct(100),
                       enCount: fmtN(metrics.totalQuestionsEn),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsEn / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.totalQuestionsEn / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.totalQuestionsFr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.totalQuestionsFr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.totalQuestionsFr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.questions.firstQuestion'),
                       count: fmtN(metrics.totalConversations),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.totalConversations / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.totalConversations / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.totalConversationsEn),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsEn / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.totalConversationsEn / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.totalConversationsFr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.totalConversationsFr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.totalConversationsFr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.questions.secondQuestion'),
                       count: fmtN(secondQuestionTotal),
-                      percentage: metrics.totalQuestions ? Math.round((secondQuestionTotal / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((secondQuestionTotal / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(secondQuestionEn),
-                      enPercentage: metrics.totalQuestions ? Math.round((secondQuestionEn / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((secondQuestionEn / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(secondQuestionFr),
-                      frPercentage: metrics.totalQuestions ? Math.round((secondQuestionFr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((secondQuestionFr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.questions.thirdOrMore'),
                       count: fmtN(metrics.sessionsByQuestionCount.threeQuestions.total),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.sessionsByQuestionCount.threeQuestions.total / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.sessionsByQuestionCount.threeQuestions.en),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.sessionsByQuestionCount.threeQuestions.en / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.sessionsByQuestionCount.threeQuestions.fr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.sessionsByQuestionCount.threeQuestions.fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.sessionsByQuestionCount.threeQuestions.fr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     }
                   ]}
                   columns={[
@@ -283,29 +284,29 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.accuracy.allEvaluations'),
                       totalEvaluated: fmtN(metrics.expertScored.total.total + metrics.aiScored.total.total),
-                      pctOfQuestions: metrics.totalQuestions ? Math.round(((metrics.expertScored.total.total + metrics.aiScored.total.total) / metrics.totalQuestions) * 100) + '%' : '-',
+                      pctOfQuestions: metrics.totalQuestions ? fmtPct(Math.round(((metrics.expertScored.total.total + metrics.aiScored.total.total) / metrics.totalQuestions) * 100)) : '-',
                       hasAnswerError: fmtN(metrics.expertScored.hasError.total + metrics.aiScored.hasError.total),
                       accuracyPct: (metrics.expertScored.total.total + metrics.aiScored.total.total)
-                        ? (100 - Math.round(((metrics.expertScored.hasError.total + metrics.aiScored.hasError.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100)) + '%'
-                        : '0%'
+                        ? fmtPct(100 - Math.round(((metrics.expertScored.hasError.total + metrics.aiScored.hasError.total) / (metrics.expertScored.total.total + metrics.aiScored.total.total)) * 100))
+                        : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.expertEvaluations'),
                       totalEvaluated: fmtN(metrics.expertScored.total.total),
-                      pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.expertScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
+                      pctOfQuestions: metrics.totalQuestions ? fmtPct(Math.round((metrics.expertScored.total.total / metrics.totalQuestions) * 100)) : '-',
                       hasAnswerError: fmtN(metrics.expertScored.hasError.total),
                       accuracyPct: metrics.expertScored.total.total
-                        ? (100 - Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100)) + '%'
-                        : '0%'
+                        ? fmtPct(100 - Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100))
+                        : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.accuracy.aiEvaluations'),
                       totalEvaluated: fmtN(metrics.aiScored.total.total),
-                      pctOfQuestions: metrics.totalQuestions ? Math.round((metrics.aiScored.total.total / metrics.totalQuestions) * 100) + '%' : '-',
+                      pctOfQuestions: metrics.totalQuestions ? fmtPct(Math.round((metrics.aiScored.total.total / metrics.totalQuestions) * 100)) : '-',
                       hasAnswerError: fmtN(metrics.aiScored.hasError.total),
                       accuracyPct: metrics.aiScored.total.total
-                        ? (100 - Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100)) + '%'
-                        : '0%'
+                        ? fmtPct(100 - Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100))
+                        : fmtPct(0)
                     }
                   ]}
                   columns={[
@@ -328,11 +329,11 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.totalSessions'),
                       count: fmtN(metrics.totalConversations),
-                      percentage: '100%',
+                      percentage: fmtPct(100),
                       enCount: fmtN(metrics.totalConversationsEn),
-                      enPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsEn / metrics.totalConversations) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalConversations ? fmtPct(Math.round((metrics.totalConversationsEn / metrics.totalConversations) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.totalConversationsFr),
-                      frPercentage: metrics.totalConversations ? Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalConversations ? fmtPct(Math.round((metrics.totalConversationsFr / metrics.totalConversations) * 100)) : fmtPct(0)
                     },
                   ]}
                   columns={[
@@ -357,38 +358,38 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.answerTypes.normal'),
                       count: fmtN(metrics.answerTypes.normal.total),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes.normal.total / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.answerTypes.normal.en),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes.normal.en / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.answerTypes.normal.fr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes.normal.fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes.normal.fr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.clarifyingQuestion'),
                       count: fmtN(metrics.answerTypes['clarifying-question'].total),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['clarifying-question'].total / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.answerTypes['clarifying-question'].en),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['clarifying-question'].en / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.answerTypes['clarifying-question'].fr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['clarifying-question'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['clarifying-question'].fr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.ptMuni'),
                       count: fmtN(metrics.answerTypes['pt-muni'].total),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['pt-muni'].total / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.answerTypes['pt-muni'].en),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['pt-muni'].en / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.answerTypes['pt-muni'].fr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['pt-muni'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['pt-muni'].fr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.answerTypes.notGc'),
                       count: fmtN(metrics.answerTypes['not-gc'].total),
-                      percentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].total / metrics.totalQuestions) * 100) + '%' : '0%',
+                      percentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['not-gc'].total / metrics.totalQuestions) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.answerTypes['not-gc'].en),
-                      enPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].en / metrics.totalQuestions) * 100) + '%' : '0%',
+                      enPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['not-gc'].en / metrics.totalQuestions) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.answerTypes['not-gc'].fr),
-                      frPercentage: metrics.totalQuestions ? Math.round((metrics.answerTypes['not-gc'].fr / metrics.totalQuestions) * 100) + '%' : '0%'
+                      frPercentage: metrics.totalQuestions ? fmtPct(Math.round((metrics.answerTypes['not-gc'].fr / metrics.totalQuestions) * 100)) : fmtPct(0)
                     }
                   ]}
                   columns={[
@@ -414,65 +415,65 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.expertScored.total'),
                       count: fmtN(metrics.expertScored.total.total),
-                      percentage: '100%',
+                      percentage: fmtPct(100),
                       enCount: fmtN(metrics.expertScored.total.en),
-                      enPercentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.total.en / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.total.en / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.total.fr),
-                      frPercentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.total.fr / metrics.expertScored.total.total) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.total.fr / metrics.expertScored.total.total) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasError'),
                       count: fmtN(metrics.expertScored.hasError.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.hasError.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.hasError.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.hasError.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.hasError.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.hasError.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.harmful'),
                       count: fmtN(metrics.expertScored.harmful.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.harmful.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.harmful.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.harmful.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.harmful.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.harmful.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.harmful.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.harmful.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.harmful.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasContentIssue'),
                       count: fmtN(metrics.expertScored.hasContentIssue.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasContentIssue.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.hasContentIssue.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.hasContentIssue.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasContentIssue.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.hasContentIssue.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.hasContentIssue.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasContentIssue.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.hasContentIssue.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.correct'),
                       count: fmtN(metrics.expertScored.correct.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.correct.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.correct.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.correct.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.correct.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.correct.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.correct.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.correct.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.needsImprovement'),
                       count: fmtN(metrics.expertScored.needsImprovement.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.needsImprovement.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.needsImprovement.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.needsImprovement.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.needsImprovement.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.needsImprovement.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.needsImprovement.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.needsImprovement.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.needsImprovement.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.expertScored.hasCitationError'),
                       count: fmtN(metrics.expertScored.hasCitationError.total),
-                      percentage: metrics.expertScored.total.total ? Math.round((metrics.expertScored.hasCitationError.total / metrics.expertScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.expertScored.total.total ? fmtPct(Math.round((metrics.expertScored.hasCitationError.total / metrics.expertScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.expertScored.hasCitationError.en),
-                      enPercentage: metrics.expertScored.total.en ? Math.round((metrics.expertScored.hasCitationError.en / metrics.expertScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.expertScored.total.en ? fmtPct(Math.round((metrics.expertScored.hasCitationError.en / metrics.expertScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.expertScored.hasCitationError.fr),
-                      frPercentage: metrics.expertScored.total.fr ? Math.round((metrics.expertScored.hasCitationError.fr / metrics.expertScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.expertScored.total.fr ? fmtPct(Math.round((metrics.expertScored.hasCitationError.fr / metrics.expertScored.total.fr) * 100)) : fmtPct(0)
                     }
                   ]}
                   columns={[
@@ -506,47 +507,47 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.aiScored.total'),
                       count: fmtN(metrics.aiScored.total.total),
-                      percentage: '100%',
+                      percentage: fmtPct(100),
                       enCount: fmtN(metrics.aiScored.total.en),
-                      enPercentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.total.en / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      enPercentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.total.en / metrics.aiScored.total.total) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.aiScored.total.fr),
-                      frPercentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.total.fr / metrics.aiScored.total.total) * 100) + '%' : '0%'
+                      frPercentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.total.fr / metrics.aiScored.total.total) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.hasError'),
                       count: fmtN(metrics.aiScored.hasError.total),
-                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.hasError.total / metrics.aiScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.aiScored.hasError.en),
-                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.aiScored.total.en ? fmtPct(Math.round((metrics.aiScored.hasError.en / metrics.aiScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.aiScored.hasError.fr),
-                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.aiScored.total.fr ? fmtPct(Math.round((metrics.aiScored.hasError.fr / metrics.aiScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.correct'),
                       count: fmtN(metrics.aiScored.correct.total),
-                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.correct.total / metrics.aiScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.aiScored.correct.en),
-                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.correct.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.aiScored.total.en ? fmtPct(Math.round((metrics.aiScored.correct.en / metrics.aiScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.aiScored.correct.fr),
-                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.correct.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.aiScored.total.fr ? fmtPct(Math.round((metrics.aiScored.correct.fr / metrics.aiScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.needsImprovement'),
                       count: fmtN(metrics.aiScored.needsImprovement.total),
-                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.needsImprovement.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.needsImprovement.total / metrics.aiScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.aiScored.needsImprovement.en),
-                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.needsImprovement.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.aiScored.total.en ? fmtPct(Math.round((metrics.aiScored.needsImprovement.en / metrics.aiScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.aiScored.needsImprovement.fr),
-                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.needsImprovement.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.aiScored.total.fr ? fmtPct(Math.round((metrics.aiScored.needsImprovement.fr / metrics.aiScored.total.fr) * 100)) : fmtPct(0)
                     },
                     {
                       metric: t('metrics.dashboard.aiScored.hasCitationError'),
                       count: fmtN(metrics.aiScored.hasCitationError.total),
-                      percentage: metrics.aiScored.total.total ? Math.round((metrics.aiScored.hasCitationError.total / metrics.aiScored.total.total) * 100) + '%' : '0%',
+                      percentage: metrics.aiScored.total.total ? fmtPct(Math.round((metrics.aiScored.hasCitationError.total / metrics.aiScored.total.total) * 100)) : fmtPct(0),
                       enCount: fmtN(metrics.aiScored.hasCitationError.en),
-                      enPercentage: metrics.aiScored.total.en ? Math.round((metrics.aiScored.hasCitationError.en / metrics.aiScored.total.en) * 100) + '%' : '0%',
+                      enPercentage: metrics.aiScored.total.en ? fmtPct(Math.round((metrics.aiScored.hasCitationError.en / metrics.aiScored.total.en) * 100)) : fmtPct(0),
                       frCount: fmtN(metrics.aiScored.hasCitationError.fr),
-                      frPercentage: metrics.aiScored.total.fr ? Math.round((metrics.aiScored.hasCitationError.fr / metrics.aiScored.total.fr) * 100) + '%' : '0%'
+                      frPercentage: metrics.aiScored.total.fr ? fmtPct(Math.round((metrics.aiScored.hasCitationError.fr / metrics.aiScored.total.fr) * 100)) : fmtPct(0)
                     }
                   ]}
                   columns={[
@@ -584,9 +585,9 @@ const MetricsDashboard = ({ lang = 'en' }) => {
                     department: (!department || department === 'Unknown') ? t('metrics.dashboard.byDepartment.noContextDept') : department,
                     totalQuestions: data.total,
                     expertScoredTotal: data.expertScored.total,
-                    expertScoredPct: data.total ? Math.round((data.expertScored.total / data.total) * 100) + '%' : '0%',
+                    expertScoredPct: data.total ? fmtPct(Math.round((data.expertScored.total / data.total) * 100)) : fmtPct(0),
                     expertScoredHasError: data.expertScored.hasError,
-                    expertScoredAccuracyPct: data.expertScored.total ? (100 - Math.round((data.expertScored.hasError / data.expertScored.total) * 100)) + '%' : '-'
+                    expertScoredAccuracyPct: data.expertScored.total ? fmtPct(100 - Math.round((data.expertScored.hasError / data.expertScored.total) * 100)) : '-'
                   }))}
                   columns={[
                     { title: t('metrics.dashboard.byDepartment.department'), data: 'department' },

--- a/src/components/admin/TechnicalMetricsDashboard.js
+++ b/src/components/admin/TechnicalMetricsDashboard.js
@@ -4,6 +4,7 @@ import DataTable from 'datatables.net-react';
 import DT from 'datatables.net-dt';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
+import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
 import FilterPanel from './FilterPanel.js';
 import { useTechnicalMetrics } from '../../hooks/admin/useTechnicalMetrics.js';
 
@@ -20,10 +21,10 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
     loadingState,
   } = useTechnicalMetrics();
 
-  const fmtNum = (n) => (n ?? 0).toLocaleString(lang === 'fr' ? 'fr-CA' : 'en-CA');
+  const fmtNum = (n) => formatNumber(n, lang);
   const fmtMs = (n) => (n == null ? '–' : fmtNum(n));
   const fmtTokens = (n) => fmtNum(Math.round((n ?? 0) / 1000)) + 'K';
-  const fmtPct = (num, denom) => (denom ? `${Math.round((num / denom) * 100)}%` : '0%');
+  const fmtPct = (num, denom) => denom ? formatPercent(Math.round((num / denom) * 100), lang) : formatPercent(0, lang);
 
   const SectionWrapper = ({ children, isLoading, title, error, note }) => (
     <div className="mb-600 relative">
@@ -168,7 +169,7 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.tokens.totalInput'),
                       count: fmtTokens(data.totalInputTokens),
-                      percentage: '100%',
+                      percentage: formatPercent(100, lang),
                       enCount: fmtTokens(data.totalInputTokensEn),
                       enPercentage: fmtPct(data.totalInputTokensEn, data.totalInputTokens),
                       frCount: fmtTokens(data.totalInputTokensFr),
@@ -195,7 +196,7 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
                     {
                       metric: t('metrics.dashboard.tokens.totalOutput'),
                       count: fmtTokens(data.totalOutputTokens),
-                      percentage: '100%',
+                      percentage: formatPercent(100, lang),
                       enCount: fmtTokens(data.totalOutputTokensEn),
                       enPercentage: fmtPct(data.totalOutputTokensEn, data.totalOutputTokens),
                       frCount: fmtTokens(data.totalOutputTokensFr),

--- a/src/components/batch/BatchList.js
+++ b/src/components/batch/BatchList.js
@@ -6,6 +6,7 @@ import DT from 'datatables.net-dt';
 import { GcdsButton } from '@gcds-core/components-react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
+import { formatNumber } from '../../utils/numberFormat.js';
 import BatchService from '../../services/BatchService.js';
 
 DataTable.use(DT);
@@ -163,7 +164,7 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
               const failed = Number(stats.failed || 0);
               const finished = Number(stats.finished ?? processed + failed);
               if (totalsCell) {
-                totalsCell.innerText = t('batch.list.totalsLabel').replace('{finished}', finished).replace('{total}', total);
+                totalsCell.innerText = t('batch.list.totalsLabel').replace('{finished}', formatNumber(finished, lang)).replace('{total}', formatNumber(total, lang));
               }
             } catch (e) {
               // ignore totals rendering errors

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -602,7 +602,7 @@ const ChatInterface = ({
                           t={t}
                         />
                         <DownloadPanel message={message} t={t} />
-                        <EvalPanel message={message} t={t} />
+                        <EvalPanel message={message} t={t} lang={lang} />
                       </div>
                     </>
                   )}

--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -26,7 +26,7 @@ const renderChatLink = (chatId) => {
   );
 };
 
-const EvalPanel = ({ message, t }) => {
+const EvalPanel = ({ message, t, lang = 'en' }) => {
   // Show panel in review mode as requested (no longer hidden)
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -124,7 +124,10 @@ const EvalPanel = ({ message, t }) => {
     if (v === null || typeof v === 'undefined' || v === '') return v;
     const n = Number(v);
     if (Number.isNaN(n)) return v;
-    return n.toFixed(3);
+    return new Intl.NumberFormat(lang === 'fr' ? 'fr-CA' : 'en-CA', {
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3,
+    }).format(n);
   };
 
   // Translation helper: if the translator returns the raw key (meaning missing),

--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { GcdsDetails, GcdsButton } from '@gcds-core/components-react';
 import EvaluationService from '../../../services/EvaluationService.js';
+import { formatDecimal } from '../../../utils/numberFormat.js';
 
 const formatDate = (d) => {
   if (!d) return '';
@@ -120,15 +121,7 @@ const EvalPanel = ({ message, t, lang = 'en' }) => {
         : evalObj?.noMatchReasonMsg || t('eval.noMatchReasonTypes.unknown', 'Unknown'))
     : '';
 
-  const fmt = (v) => {
-    if (v === null || typeof v === 'undefined' || v === '') return v;
-    const n = Number(v);
-    if (Number.isNaN(n)) return v;
-    return new Intl.NumberFormat(lang === 'fr' ? 'fr-CA' : 'en-CA', {
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    }).format(n);
-  };
+  const fmt = (v) => formatDecimal(v, lang);
 
   // Translation helper: if the translator returns the raw key (meaning missing),
   // fall back to an alternate key or provided default string.

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -3,7 +3,7 @@ import { GcdsText } from '@gcds-core/components-react';
 import DataTable from 'datatables.net-react';
 import { SCORE_TO_KEY, FEEDBACK_OPTIONS } from '../../constants/UserFeedbackOptions.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
-import { formatNumber } from '../../utils/numberFormat.js';
+import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
 import enLocale from '../../locales/en.json';
 import frLocale from '../../locales/fr.json';
 
@@ -73,6 +73,7 @@ const NO_OTHER_SCORE = FEEDBACK_OPTIONS.NO.find(o => o.id === 'other').score;
 
 const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
   const fmtN = (n) => formatNumber(n, lang);
+  const fmtPct = (n) => formatPercent(n, lang);
   const rawYesReasons = metrics.publicFeedbackReasons?.yes || {};
   const rawNoReasons = metrics.publicFeedbackReasons?.no || {};
 
@@ -110,29 +111,29 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
             {
               metric: t('metrics.dashboard.userScored.total'),
               count: fmtN(metrics.publicFeedbackTotals.totalQuestionsWithFeedback),
-              percentage: '100%',
+              percentage: fmtPct(100),
               enCount: fmtN(metrics.publicFeedbackTotals.enYes + metrics.publicFeedbackTotals.enNo),
-              enPercentage: '100%',
+              enPercentage: fmtPct(100),
               frCount: fmtN(metrics.publicFeedbackTotals.frYes + metrics.publicFeedbackTotals.frNo),
-              frPercentage: '100%'
+              frPercentage: fmtPct(100)
             },
             {
               metric: t('metrics.dashboard.userScored.helpful'),
               count: fmtN(metrics.publicFeedbackTotals.yes),
-              percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.yes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
+              percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.yes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0),
               enCount: fmtN(metrics.publicFeedbackTotals.enYes),
-              enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.enYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
+              enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.enYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0),
               frCount: fmtN(metrics.publicFeedbackTotals.frYes),
-              frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.frYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%'
+              frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.frYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0)
             },
             {
               metric: t('metrics.dashboard.userScored.unhelpful'),
               count: fmtN(metrics.publicFeedbackTotals.no),
-              percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.no / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
+              percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.no / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0),
               enCount: fmtN(metrics.publicFeedbackTotals.enNo),
-              enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.enNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
+              enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.enNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0),
               frCount: fmtN(metrics.publicFeedbackTotals.frNo),
-              frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.frNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%'
+              frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? fmtPct(Math.round((metrics.publicFeedbackTotals.frNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100)) : fmtPct(0)
             }
           ]}
           columns={[

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -3,6 +3,7 @@ import { GcdsText } from '@gcds-core/components-react';
 import DataTable from 'datatables.net-react';
 import { SCORE_TO_KEY, FEEDBACK_OPTIONS } from '../../constants/UserFeedbackOptions.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
+import { formatNumber } from '../../utils/numberFormat.js';
 import enLocale from '../../locales/en.json';
 import frLocale from '../../locales/fr.json';
 
@@ -71,6 +72,7 @@ const YES_OTHER_SCORE = FEEDBACK_OPTIONS.YES.find(o => o.id === 'other').score;
 const NO_OTHER_SCORE = FEEDBACK_OPTIONS.NO.find(o => o.id === 'other').score;
 
 const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
+  const fmtN = (n) => formatNumber(n, lang);
   const rawYesReasons = metrics.publicFeedbackReasons?.yes || {};
   const rawNoReasons = metrics.publicFeedbackReasons?.no || {};
 
@@ -107,29 +109,29 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
           data={[
             {
               metric: t('metrics.dashboard.userScored.total'),
-              count: metrics.publicFeedbackTotals.totalQuestionsWithFeedback,
+              count: fmtN(metrics.publicFeedbackTotals.totalQuestionsWithFeedback),
               percentage: '100%',
-              enCount: metrics.publicFeedbackTotals.enYes + metrics.publicFeedbackTotals.enNo,
+              enCount: fmtN(metrics.publicFeedbackTotals.enYes + metrics.publicFeedbackTotals.enNo),
               enPercentage: '100%',
-              frCount: metrics.publicFeedbackTotals.frYes + metrics.publicFeedbackTotals.frNo,
+              frCount: fmtN(metrics.publicFeedbackTotals.frYes + metrics.publicFeedbackTotals.frNo),
               frPercentage: '100%'
             },
             {
               metric: t('metrics.dashboard.userScored.helpful'),
-              count: metrics.publicFeedbackTotals.yes,
+              count: fmtN(metrics.publicFeedbackTotals.yes),
               percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.yes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
-              enCount: metrics.publicFeedbackTotals.enYes,
+              enCount: fmtN(metrics.publicFeedbackTotals.enYes),
               enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.enYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
-              frCount: metrics.publicFeedbackTotals.frYes,
+              frCount: fmtN(metrics.publicFeedbackTotals.frYes),
               frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.frYes / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%'
             },
             {
               metric: t('metrics.dashboard.userScored.unhelpful'),
-              count: metrics.publicFeedbackTotals.no,
+              count: fmtN(metrics.publicFeedbackTotals.no),
               percentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.no / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
-              enCount: metrics.publicFeedbackTotals.enNo,
+              enCount: fmtN(metrics.publicFeedbackTotals.enNo),
               enPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.enNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%',
-              frCount: metrics.publicFeedbackTotals.frNo,
+              frCount: fmtN(metrics.publicFeedbackTotals.frNo),
               frPercentage: metrics.publicFeedbackTotals.totalQuestionsWithFeedback ? Math.round((metrics.publicFeedbackTotals.frNo / metrics.publicFeedbackTotals.totalQuestionsWithFeedback) * 100) + '%' : '0%'
             }
           ]}
@@ -157,11 +159,11 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
             data={tableData}
             columns={[
               { title: t('metrics.dashboard.userScored.reason'), data: 'label' },
-              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.enCount')}`, data: 'yesEn' },
-              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.frCount')}`, data: 'yesFr' },
-              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.enCount')}`, data: 'noEn' },
-              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.frCount')}`, data: 'noFr' },
-              { title: t('metrics.dashboard.count'), data: 'total' }
+              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.enCount')}`, data: 'yesEn', render: (d) => fmtN(d) },
+              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.frCount')}`, data: 'yesFr', render: (d) => fmtN(d) },
+              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.enCount')}`, data: 'noEn', render: (d) => fmtN(d) },
+              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.frCount')}`, data: 'noFr', render: (d) => fmtN(d) },
+              { title: t('metrics.dashboard.count'), data: 'total', render: (d) => fmtN(d) }
             ]}
             options={{
               paging: false,

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -160,11 +160,11 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
             data={tableData}
             columns={[
               { title: t('metrics.dashboard.userScored.reason'), data: 'label' },
-              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.enCount')}`, data: 'yesEn', render: (d) => fmtN(d) },
-              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.frCount')}`, data: 'yesFr', render: (d) => fmtN(d) },
-              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.enCount')}`, data: 'noEn', render: (d) => fmtN(d) },
-              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.frCount')}`, data: 'noFr', render: (d) => fmtN(d) },
-              { title: t('metrics.dashboard.count'), data: 'total', render: (d) => fmtN(d) }
+              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.enCount')}`, data: 'yesEn', render: (d, type) => type === 'display' ? fmtN(d) : d },
+              { title: `${t('metrics.dashboard.userScored.helpful')} ${t('metrics.dashboard.frCount')}`, data: 'yesFr', render: (d, type) => type === 'display' ? fmtN(d) : d },
+              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.enCount')}`, data: 'noEn', render: (d, type) => type === 'display' ? fmtN(d) : d },
+              { title: `${t('metrics.dashboard.userScored.unhelpful')} ${t('metrics.dashboard.frCount')}`, data: 'noFr', render: (d, type) => type === 'display' ? fmtN(d) : d },
+              { title: t('metrics.dashboard.count'), data: 'total', render: (d, type) => type === 'display' ? fmtN(d) : d }
             ]}
             options={{
               paging: false,

--- a/src/pages/DatabasePage.js
+++ b/src/pages/DatabasePage.js
@@ -6,6 +6,7 @@ import DataStoreService from '../services/DataStoreService.js';
 import BatchService from '../services/BatchService.js';
 import streamSaver from 'streamsaver';
 import { useTranslations } from '../hooks/useTranslations.js';
+import { formatNumber } from '../utils/numberFormat.js';
 
 const DatabasePage = ({ lang }) => {
   const { t } = useTranslations(lang);
@@ -491,7 +492,7 @@ const DatabasePage = ({ lang }) => {
               {Object.entries(tableCounts).map(([table, count]) => (
                 <tr key={table}>
                   <td style={{ paddingRight: 16 }}>{t(`admin.database.collections.${table.toLowerCase()}`) || table}</td>
-                  <td style={{ textAlign: 'right' }}>{count}</td>
+                  <td style={{ textAlign: 'right' }}>{formatNumber(count, lang)}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/utils/numberFormat.js
+++ b/src/utils/numberFormat.js
@@ -1,0 +1,9 @@
+const formatters = {};
+
+export function formatNumber(n, lang) {
+  const locale = lang === 'fr' ? 'fr-CA' : 'en-CA';
+  if (!formatters[locale]) {
+    formatters[locale] = new Intl.NumberFormat(locale);
+  }
+  return formatters[locale].format(n ?? 0);
+}

--- a/src/utils/numberFormat.js
+++ b/src/utils/numberFormat.js
@@ -12,3 +12,18 @@ export function formatPercent(n, lang) {
   const sep = lang === 'fr' ? ' ' : '';
   return `${n ?? 0}${sep}%`;
 }
+
+export function formatDecimal(n, lang, fractionDigits = 3) {
+  if (n === null || typeof n === 'undefined' || n === '') return n;
+  const num = Number(n);
+  if (Number.isNaN(num)) return n;
+  const locale = lang === 'fr' ? 'fr-CA' : 'en-CA';
+  const key = `${locale}-${fractionDigits}`;
+  if (!formatters[key]) {
+    formatters[key] = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+  }
+  return formatters[key].format(num);
+}

--- a/src/utils/numberFormat.js
+++ b/src/utils/numberFormat.js
@@ -7,3 +7,8 @@ export function formatNumber(n, lang) {
   }
   return formatters[locale].format(n ?? 0);
 }
+
+export function formatPercent(n, lang) {
+  const sep = lang === 'fr' ? ' ' : '';
+  return `${n ?? 0}${sep}%`;
+}


### PR DESCRIPTION
Adds a shared src/utils/numberFormat.js utility with three helpers:

- formatNumber(n, lang) for locale-aware thousands separators (1 000 FR / 1,000 EN)
- formatPercent(n, lang) for locale-aware percent symbols (45 % FR / 45% EN)
- formatDecimal(n, lang, fractionDigits) for locale-aware decimal formatting. 

Applies these helpers across all numeric, percentage, and decimal values displayed in MetricsDashboard, EndUserFeedbackSection, BatchList, and EvalPanel. Threads lang through ChatInterface → EvalPanel to enable locale-aware decimal formatting of eval scores. DataTable columns with sortable numeric data use the render: (d, type) => type ===  'display' ? fmtN(d) : d pattern to preserve numeric sort order. 

Documents all three helpers and their usage rules in AGENTS.md.
