### PR TITLE
feat: styling, structuring html

### DIFF
--- a/src/components/admin/DashboardFilterBar.js
+++ b/src/components/admin/DashboardFilterBar.js
@@ -17,19 +17,24 @@ const lastNDaysStart = (n) => daysAgo(n - 1);
 // Shared filter bar for the exec and partner dashboards.
 // Owns department + date range; reports the selection to the parent via
 // onApply({ startDate, endDate, department }). department is '' for "all partners".
-// Fires onApply once on mount with the defaults (last 30 days, all partners).
-const DashboardFilterBar = ({ lang = 'en', loading = false, onApply }) => {
+// Fires onInitialLoad (if provided) or onApply once on mount with defaults
+// (last 30 days, all partners). Pass onInitialLoad separately when the parent
+// needs to distinguish the auto-load from an explicit user action.
+const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLoad }) => {
   const { t } = useTranslations(lang);
   const [department, setDepartment] = useState('');
   const [startDate, setStartDate] = useState(lastNDaysStart(30));
   const [endDate, setEndDate] = useState(today());
 
-  // Keep the latest onApply without retriggering the mount-load effect.
+  // Keep the latest callbacks without retriggering the mount-load effect.
   const onApplyRef = useRef(onApply);
   onApplyRef.current = onApply;
+  const onInitialLoadRef = useRef(onInitialLoad);
+  onInitialLoadRef.current = onInitialLoad;
 
   useEffect(() => {
-    onApplyRef.current({ startDate, endDate, department });
+    const cb = onInitialLoadRef.current || onApplyRef.current;
+    cb({ startDate, endDate, department });
     // Initial load only — subsequent loads are driven by the Apply button.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/admin/DashboardFilterBar.js
+++ b/src/components/admin/DashboardFilterBar.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { PARTNER_DEPARTMENTS } from '../../constants/partnerDepartments.js';
-import { COLOURS } from '../../constants/dashboardColours.js';
 
 const toISODate = (d) => d.toISOString().split('T')[0];
 const today = () => toISODate(new Date());
@@ -14,9 +13,6 @@ const daysAgo = (n) => {
 // FilterPanel date-range presets which use moment().subtract(N - 1, 'days').
 // So a 30-day window goes back 29 days, not 30.
 const lastNDaysStart = (n) => daysAgo(n - 1);
-
-const labelStyle = { display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4 };
-const inputStyle = { padding: '6px 10px', border: '1px solid #bdbdbd', borderRadius: 4, fontSize: 14 };
 
 // Shared filter bar for the exec and partner dashboards.
 // Owns department + date range; reports the selection to the parent via
@@ -43,28 +39,18 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply }) => {
   };
 
   return (
-    <div style={{
-      background: '#f5f7fa',
-      border: '1px solid #e0e0e0',
-      borderRadius: 8,
-      padding: '16px 20px',
-      marginBottom: 28,
-      display: 'flex',
-      alignItems: 'flex-end',
-      gap: 20,
-      flexWrap: 'wrap',
-    }}>
+    <div className="filter-bar">
       {/* Department */}
       <div>
-        <label htmlFor="dashboard-dept" style={labelStyle}>
+        <label htmlFor="dashboard-dept" className="filter-bar__label">
           {t('dashboardFilter.department')}
         </label>
         <select
           id="dashboard-dept"
+          className="filter-bar__select"
           value={department}
           onChange={e => setDepartment(e.target.value)}
           disabled={loading}
-          style={{ ...inputStyle, padding: '7px 12px', minWidth: 200 }}
         >
           <option value="">{t('dashboardFilter.allPartners')}</option>
           {PARTNER_DEPARTMENTS.map(d => <option key={d} value={d}>{d}</option>)}
@@ -73,50 +59,46 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply }) => {
 
       {/* Start date */}
       <div>
-        <label htmlFor="dashboard-start" style={labelStyle}>
+        <label htmlFor="dashboard-start" className="filter-bar__label">
           {t('dashboardFilter.startDate')}
         </label>
         <input
           id="dashboard-start"
           type="date"
+          className="filter-bar__input"
           value={startDate}
           max={endDate}
           onChange={e => setStartDate(e.target.value)}
           disabled={loading}
-          style={inputStyle}
         />
       </div>
 
       {/* End date */}
       <div>
-        <label htmlFor="dashboard-end" style={labelStyle}>
+        <label htmlFor="dashboard-end" className="filter-bar__label">
           {t('dashboardFilter.endDate')}
         </label>
         <input
           id="dashboard-end"
           type="date"
+          className="filter-bar__input"
           value={endDate}
           min={startDate}
           max={today()}
           onChange={e => setEndDate(e.target.value)}
           disabled={loading}
-          style={inputStyle}
         />
       </div>
 
       <button
+        className="filter-bar__apply"
         onClick={handleApply}
         disabled={loading || !startDate || !endDate}
-        style={{
-          padding: '7px 20px', background: COLOURS.brand, color: '#fff',
-          border: 'none', borderRadius: 4, fontSize: 14, fontWeight: 600,
-          cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.7 : 1,
-        }}
       >
         {t('dashboardFilter.apply')}
       </button>
 
-      {loading && <span style={{ fontSize: 13, color: '#888', alignSelf: 'center' }}>{t('dashboardFilter.loading')}</span>}
+      {loading && <span className="filter-bar__loading">{t('dashboardFilter.loading')}</span>}
     </div>
   );
 };

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -84,21 +84,21 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const hasResponseTime = (responseTime.count || 0) > 0;
 
   return (
-    <div style={{ fontFamily: 'inherit' }}>
+    <div>
       {/* Last 12 months summary — fixed window, independent of the filter below.
           Shows a loading state rather than zeroed cards while the (separate)
           year query is in flight. */}
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('execDashboard.last12Months')}
       </h2>
       {yearLoading ? (
-        <div style={{ color: '#888', textAlign: 'center', padding: '40px 0', fontSize: 14, marginBottom: 24 }}>
+        <div className="dashboard-loading">
           {t('common.loading')}
         </div>
       ) : (
         <>
           {/* Row 1: questions asked, expert evaluated, partner institutions */}
-          <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+          <div className="dashboard-row">
             <StatCard
               label={t('execDashboard.kpi.questionsAsked')}
               value={fmtN(yearQuestions)}
@@ -117,16 +117,17 @@ const ExecDashboard = ({ lang = 'en' }) => {
             />
           </div>
           {/* Row 2: accuracy donut (left) + satisfaction breakdown bar (right) */}
-          <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+          <div className="dashboard-row">
             <DonutCard
               title={t('execDashboard.charts.accuracyDonutTitle')}
               data={accuracyDonutData.length > 0 ? accuracyDonutData : [{ name: t('execDashboard.charts.noData'), value: 1 }]}
               colours={accuracyDonutData.length > 0 ? [COLOURS.correct, COLOURS.hasError] : [COLOURS.empty]}
               centreValue={yearAccuracyPct !== null ? fmtPct(yearAccuracyPct) : '—'}
               centreLabel={t('execDashboard.charts.accuracyCentre')}
+              centreColour={yearAccuracyPct !== null ? (yearAccuracyPct >= 50 ? COLOURS.correct : COLOURS.hasError) : undefined}
               lang={lang}
             />
-            <div style={{ flex: 2, minWidth: 320 }}>
+            <div className="dashboard-chart-wide">
               <HBarCard
                 title={t('execDashboard.charts.feedbackBreakdownTitle')}
                 subtitle={yearPfTotal > 0
@@ -145,12 +146,12 @@ const ExecDashboard = ({ lang = 'en' }) => {
 
       <DashboardFilterBar lang={lang} loading={loading} onApply={fetchMetrics} />
 
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('execDashboard.filteredPeriod')}
       </h2>
 
       {error && (
-        <div style={{ background: '#ffebee', border: '1px solid #ef9a9a', borderRadius: 6, padding: '12px 16px', marginBottom: 24, color: '#c62828' }}>
+        <div className="dashboard-error">
           {t('execDashboard.error')}
         </div>
       )}
@@ -160,7 +161,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
 
       {/* Satisfaction (helpful or not) breakdown — positives green, negatives red */}
       {feedbackReasonsData.length > 0 && (
-        <div style={{ marginBottom: 24 }}>
+        <div className="dashboard-section">
           <HBarCard
             title={t('execDashboard.charts.feedbackBreakdownTitle')}
             data={feedbackReasonsData}
@@ -171,7 +172,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
 
       {/* Top institutions by question volume (all institutions, not just partners) */}
       {departmentData.length > 0 && (
-        <div style={{ marginBottom: 24 }}>
+        <div className="dashboard-section">
           <HBarCard
             title={t('execDashboard.charts.departmentsTitle')}
             data={departmentData}
@@ -184,10 +185,10 @@ const ExecDashboard = ({ lang = 'en' }) => {
       {/* Operations metrics. Median response time is drawn from the technical
           metrics endpoint (ms, displayed in seconds); token totals come from
           the usage endpoint. */}
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('execDashboard.ops.title')}
       </h2>
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+      <div className="dashboard-row">
         <StatCard
           label={t('execDashboard.ops.medianResponseTime')}
           value={hasResponseTime
@@ -214,21 +215,23 @@ const ExecDashboard = ({ lang = 'en' }) => {
       </div>
 
       {/* Safety metrics */}
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('execDashboard.safety.title')}
       </h2>
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
-        <StatCard
-          label={t('execDashboard.kpi.harmful')}
-          value={fmtN(harmful.total)}
-          sub={t('execDashboard.kpi.harmfulSub')
-            .replace('{en}', fmtN(harmful.en))
-            .replace('{fr}', fmtN(harmful.fr))}
-        />
+      <div className="dashboard-row">
+        <div className="dashboard-col-third">
+          <StatCard
+            label={t('execDashboard.kpi.harmful')}
+            value={fmtN(harmful.total)}
+            sub={t('execDashboard.kpi.harmfulSub')
+              .replace('{en}', fmtN(harmful.en))
+              .replace('{fr}', fmtN(harmful.fr))}
+          />
+        </div>
       </div>
 
       {!loading && metrics.totalQuestions === 0 && !error && (
-        <p style={{ color: '#888', textAlign: 'center', padding: '40px 0' }}>
+        <p className="dashboard-no-data">
           {t('execDashboard.noData')}
         </p>
       )}

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -124,7 +124,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
               colours={accuracyDonutData.length > 0 ? [COLOURS.correct, COLOURS.hasError] : [COLOURS.empty]}
               centreValue={yearAccuracyPct !== null ? fmtPct(yearAccuracyPct) : '—'}
               centreLabel={t('execDashboard.charts.accuracyCentre')}
-              centreColour={yearAccuracyPct !== null ? (yearAccuracyPct >= 50 ? COLOURS.correct : COLOURS.hasError) : undefined}
+              centreColour={yearAccuracyPct !== null ? (yearAccuracyPct >= 80 ? COLOURS.correct : COLOURS.hasError) : undefined}
               lang={lang}
             />
             <div className="dashboard-chart-wide">
@@ -153,6 +153,13 @@ const ExecDashboard = ({ lang = 'en' }) => {
       {error && (
         <div className="dashboard-error">
           {t('execDashboard.error')}
+        </div>
+      )}
+
+      {!loading && metrics.totalQuestions === 0 && !error && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('execDashboard.noData')}
         </div>
       )}
 
@@ -230,11 +237,6 @@ const ExecDashboard = ({ lang = 'en' }) => {
         </div>
       </div>
 
-      {!loading && metrics.totalQuestions === 0 && !error && (
-        <p className="dashboard-no-data">
-          {t('execDashboard.noData')}
-        </p>
-      )}
     </div>
   );
 };

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { useDashboardMetrics } from '../../hooks/admin/useDashboardMetrics.js';
 import { buildFeedbackSplitData, buildFeedbackReasonsData } from '../../utils/dashboard/feedbackBreakdown.js';
@@ -16,6 +16,8 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const fmtPct = (n) => formatPercent(n, lang);
   const fmtSec = (ms) => formatDecimal((ms || 0) / 1000, lang, 1);
   const { metrics, loading, error, fetchMetrics } = useDashboardMetrics();
+  const hasFetched = useRef(false);
+  const handleFilterApply = (filters) => { hasFetched.current = true; fetchMetrics(filters); };
 
   // Separate, fixed last-12-months summary, independent of the filter below.
   // Fetched once on mount; the database only goes back to Oct 2025, which is
@@ -148,7 +150,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
         {t('execDashboard.filteredPeriod')}
       </h2>
 
-      <DashboardFilterBar lang={lang} loading={loading} onApply={fetchMetrics} />
+      <DashboardFilterBar lang={lang} loading={loading} onInitialLoad={fetchMetrics} onApply={handleFilterApply} />
 
       {error && (
         <div className="dashboard-error">
@@ -156,7 +158,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
         </div>
       )}
 
-      {!loading && metrics.totalQuestions === 0 && !error && (
+      {hasFetched.current && !loading && metrics.totalQuestions === 0 && !error && (
         <div className="dashboard-warning">
           <span className="dashboard-warning__icon" aria-hidden="true" />
           {t('execDashboard.noData')}

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -144,11 +144,11 @@ const ExecDashboard = ({ lang = 'en' }) => {
         </>
       )}
 
-      <DashboardFilterBar lang={lang} loading={loading} onApply={fetchMetrics} />
-
       <h2 className="dashboard-section-title">
         {t('execDashboard.filteredPeriod')}
       </h2>
+
+      <DashboardFilterBar lang={lang} loading={loading} onApply={fetchMetrics} />
 
       {error && (
         <div className="dashboard-error">

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -205,20 +205,27 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer size="xl" className="space-y-6">
-      <FilterPanel
-        lang={lang}
-        onApplyFilters={handleApplyFilters}
-        onClearFilters={handleClearFilters}
-        isVisible={true}
-        defaultUserType="public"
-      />
+      <div className="mb-600">
+        <FilterPanel
+          lang={lang}
+          onApplyFilters={handleApplyFilters}
+          onClearFilters={handleClearFilters}
+          isVisible={true}
+          defaultUserType="public"
+        />
+      </div>
+
+      {hasStartedLoading && !Object.values(loadingState).some(Boolean) && metrics.totalQuestions === 0 && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('common.noDataForFilters')}
+        </div>
+      )}
 
       {hasStartedLoading && (
         <GcdsContainer size="xl" className="bg-white shadow rounded-lg mb-600">
 
           <div className="p-4">
-            <h2 className="mt-400 mb-400">{t('metrics.dashboard.title')}</h2>
-
             {/* Table 1: Questions by position */}
             <SectionWrapper isLoading={loadingState.usage || loadingState.session} title={t('metrics.dashboard.questions.title')} error={errorState.usage || errorState.session}>
               <div className="bg-gray-50 p-4 rounded-lg">

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -87,7 +87,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
 
   return (
     <div>
-      <div ref={filterWrapRef}>
+      <div ref={filterWrapRef} className="mb-600">
         <FilterPanel
           lang={lang}
           onApplyFilters={handleApplyFilters}

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -21,7 +21,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   const handleApplyFilters = (filters) => {
     fetchMetrics(filters);
     if (hasAutoApplied.current) {
-      filterWrapRef.current?.querySelector('details')?.removeAttribute('open');
+      filterWrapRef.current?.querySelector('details')?.removeAttribute('open'); // relies on FilterPanel rendering a <details> element internally
     }
     hasAutoApplied.current = true;
   };
@@ -102,25 +102,32 @@ const PartnerDashboard = ({ lang = 'en' }) => {
         </div>
       )}
 
+      {!loading && metrics.totalQuestions === 0 && !error && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('partnerDashboard.noData')}
+        </div>
+      )}
+
       <h2 className="dashboard-section-title">{t('partnerDashboard.overviewTitle')}</h2>
 
       {/* KPI cards */}
       <div className="dashboard-row">
         <StatCard
-label={t('partnerDashboard.kpi.questionsAsked')}
+          label={t('partnerDashboard.kpi.questionsAsked')}
           value={fmtN(metrics.totalQuestions)}
           sub={t('partnerDashboard.kpi.questionsSub')
             .replace('{en}', fmtN(metrics.totalQuestionsEn))
             .replace('{fr}', fmtN(metrics.totalQuestionsFr))}
         />
         <StatCard
-label={t('partnerDashboard.kpi.evaluated')}
+          label={t('partnerDashboard.kpi.evaluated')}
           value={fmtN(expertTotal)}
           sub={t('partnerDashboard.kpi.evaluatedSub')
             .replace('{pct}', fmtPct(expertTotal > 0 && metrics.totalQuestions > 0 ? Math.round((expertTotal / metrics.totalQuestions) * 100) : 0))}
         />
         <StatCard
-label={t('partnerDashboard.kpi.accuracyRate')}
+          label={t('partnerDashboard.kpi.accuracyRate')}
           value={pctOrDash(totalAccuracy)}
           sub={showAccuracyByLang
             ? t('partnerDashboard.kpi.accuracySub')
@@ -147,7 +154,7 @@ label={t('partnerDashboard.kpi.accuracyRate')}
           />
         </div>
         <StatCard
-label={t('partnerDashboard.kpi.contentIssues')}
+          label={t('partnerDashboard.kpi.contentIssues')}
           value={fmtN(contentIssue.total)}
           sub={t('partnerDashboard.kpi.contentIssuesSub')
             .replace('{ni}', fmtN(contentIssue.needsImprovement))
@@ -196,7 +203,7 @@ label={t('partnerDashboard.kpi.contentIssues')}
       </h2>
       <div className="dashboard-row">
         <StatCard
-label={t('partnerDashboard.ops.medianResponseTime')}
+          label={t('partnerDashboard.ops.medianResponseTime')}
           value={hasResponseTime
             ? t('partnerDashboard.ops.responseTimeValue').replace('{n}', fmtSec(responseTime.median))
             : '—'}
@@ -205,14 +212,14 @@ label={t('partnerDashboard.ops.medianResponseTime')}
             : undefined}
         />
         <StatCard
-label={t('partnerDashboard.ops.inputTokens')}
+          label={t('partnerDashboard.ops.inputTokens')}
           value={fmtN(metrics.totalInputTokens)}
           sub={t('partnerDashboard.ops.tokensSub')
             .replace('{en}', fmtN(metrics.totalInputTokensEn))
             .replace('{fr}', fmtN(metrics.totalInputTokensFr))}
         />
         <StatCard
-label={t('partnerDashboard.ops.outputTokens')}
+          label={t('partnerDashboard.ops.outputTokens')}
           value={fmtN(metrics.totalOutputTokens)}
           sub={t('partnerDashboard.ops.tokensSub')
             .replace('{en}', fmtN(metrics.totalOutputTokensEn))
@@ -236,11 +243,6 @@ label={t('partnerDashboard.ops.outputTokens')}
         </div>
       </div>
 
-      {!loading && metrics.totalQuestions === 0 && !error && (
-        <p className="dashboard-no-data">
-          {t('partnerDashboard.noData')}
-        </p>
-      )}
     </div>
   );
 };

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { useDashboardMetrics } from '../../hooks/admin/useDashboardMetrics.js';
 import { buildQualityBarData, buildFeedbackSplitData, buildFeedbackReasonsData } from '../../utils/dashboard/feedbackBreakdown.js';
@@ -16,6 +16,15 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   const fmtSec = (ms) => formatDecimal((ms || 0) / 1000, lang, 1);
   const pctOrDash = (n) => (n !== null ? fmtPct(n) : '—');
   const { metrics, loading, error, fetchMetrics } = useDashboardMetrics();
+  const filterWrapRef = useRef(null);
+  const hasAutoApplied = useRef(false);
+  const handleApplyFilters = (filters) => {
+    fetchMetrics(filters);
+    if (hasAutoApplied.current) {
+      filterWrapRef.current?.querySelector('details')?.removeAttribute('open');
+    }
+    hasAutoApplied.current = true;
+  };
 
   // --- Derived data ---
 
@@ -74,43 +83,44 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   const hasResponseTime = (responseTime.count || 0) > 0;
 
   return (
-    <div style={{ fontFamily: 'inherit' }}>
-      <FilterPanel
-        lang={lang}
-        onApplyFilters={fetchMetrics}
-        onClearFilters={fetchMetrics}
-        isVisible={true}
-        autoApply={true}
-        applyDisabled={loading}
-        defaultUserType="all"
-      />
+    <div>
+      <div ref={filterWrapRef}>
+        <FilterPanel
+          lang={lang}
+          onApplyFilters={handleApplyFilters}
+          onClearFilters={fetchMetrics}
+          isVisible={true}
+          autoApply={true}
+          applyDisabled={loading}
+          defaultUserType="all"
+        />
+      </div>
 
       {error && (
-        <div style={{ background: '#ffebee', border: '1px solid #ef9a9a', borderRadius: 6, padding: '12px 16px', marginBottom: 24, color: '#c62828' }}>
+        <div className="dashboard-error">
           {t('partnerDashboard.error')}
         </div>
       )}
 
+      <h2 className="dashboard-section-title">{t('partnerDashboard.overviewTitle')}</h2>
+
       {/* KPI cards */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+      <div className="dashboard-row">
         <StatCard
-          uppercase
-          label={t('partnerDashboard.kpi.questionsAsked')}
+label={t('partnerDashboard.kpi.questionsAsked')}
           value={fmtN(metrics.totalQuestions)}
           sub={t('partnerDashboard.kpi.questionsSub')
             .replace('{en}', fmtN(metrics.totalQuestionsEn))
             .replace('{fr}', fmtN(metrics.totalQuestionsFr))}
         />
         <StatCard
-          uppercase
-          label={t('partnerDashboard.kpi.evaluated')}
+label={t('partnerDashboard.kpi.evaluated')}
           value={fmtN(expertTotal)}
           sub={t('partnerDashboard.kpi.evaluatedSub')
             .replace('{pct}', fmtPct(expertTotal > 0 && metrics.totalQuestions > 0 ? Math.round((expertTotal / metrics.totalQuestions) * 100) : 0))}
         />
         <StatCard
-          uppercase
-          label={t('partnerDashboard.kpi.accuracyRate')}
+label={t('partnerDashboard.kpi.accuracyRate')}
           value={pctOrDash(totalAccuracy)}
           sub={showAccuracyByLang
             ? t('partnerDashboard.kpi.accuracySub')
@@ -121,8 +131,8 @@ const PartnerDashboard = ({ lang = 'en' }) => {
       </div>
 
       {/* Answer-quality bar + content issues card */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
-        <div style={{ flex: 2, minWidth: 320 }}>
+      <div className="dashboard-row">
+        <div className="dashboard-chart-wide">
           <HBarCard
             title={t('partnerDashboard.charts.accuracyTitle')}
             subtitle={t('partnerDashboard.charts.accuracySubtitle')
@@ -137,8 +147,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
           />
         </div>
         <StatCard
-          uppercase
-          label={t('partnerDashboard.kpi.contentIssues')}
+label={t('partnerDashboard.kpi.contentIssues')}
           value={fmtN(contentIssue.total)}
           sub={t('partnerDashboard.kpi.contentIssuesSub')
             .replace('{ni}', fmtN(contentIssue.needsImprovement))
@@ -146,32 +155,27 @@ const PartnerDashboard = ({ lang = 'en' }) => {
         />
       </div>
 
-      {/* User-satisfaction donut + its helpful/not-helpful breakdown bar
-          (positives green, negatives red). The donut always shows; the bar
-          joins it on the same row when there are reasons to break down. */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
-        {feedbackReasonsData.length > 0 && (
-          <div style={{ flex: 2, minWidth: 320 }}>
-            <HBarCard
-              title={t('partnerDashboard.charts.feedbackBreakdownTitle')}
-              data={feedbackReasonsData}
-              lang={lang}
-            />
-          </div>
-        )}
+      {/* Satisfaction breakdown bar (shown when reason data exists) */}
+      {feedbackReasonsData.length > 0 && (
+        <div className="dashboard-section">
+          <HBarCard
+            title={t('partnerDashboard.charts.feedbackBreakdownTitle')}
+            data={feedbackReasonsData}
+            lang={lang}
+          />
+        </div>
+      )}
+
+      {/* User satisfaction donut + conversation length donut — equal width */}
+      <div className="dashboard-row">
         <DonutCard
-          title={t('partnerDashboard.charts.satisfactionTitle')}
+          title={t('partnerDashboard.charts.feedbackBreakdownTitle')}
           data={feedbackData.length > 0 ? feedbackData : [{ name: t('partnerDashboard.charts.noData'), value: 1 }]}
           colours={feedbackData.length > 0 ? [COLOURS.feedbackPositive, COLOURS.feedbackNegative] : [COLOURS.empty]}
           centreValue={satisfactionPct !== null ? fmtPct(satisfactionPct) : '—'}
           centreLabel={t('partnerDashboard.charts.satisfactionCentre').replace('{total}', fmtN(pfTotal))}
           lang={lang}
         />
-      </div>
-
-      {/* Conversation length. Centre figure is the total conversation count;
-          the slices break those down by number of questions asked. */}
-      <div style={{ marginBottom: 24 }}>
         <DonutCard
           title={t('partnerDashboard.charts.engagementTitle')}
           subtitle={t('partnerDashboard.charts.engagementSubtitle')}
@@ -187,13 +191,12 @@ const PartnerDashboard = ({ lang = 'en' }) => {
       {/* Operations metrics. Median response time is drawn from the technical
           metrics endpoint (ms, displayed in seconds); token totals come from
           the usage endpoint. */}
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('partnerDashboard.ops.title')}
       </h2>
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+      <div className="dashboard-row">
         <StatCard
-          uppercase
-          label={t('partnerDashboard.ops.medianResponseTime')}
+label={t('partnerDashboard.ops.medianResponseTime')}
           value={hasResponseTime
             ? t('partnerDashboard.ops.responseTimeValue').replace('{n}', fmtSec(responseTime.median))
             : '—'}
@@ -202,16 +205,14 @@ const PartnerDashboard = ({ lang = 'en' }) => {
             : undefined}
         />
         <StatCard
-          uppercase
-          label={t('partnerDashboard.ops.inputTokens')}
+label={t('partnerDashboard.ops.inputTokens')}
           value={fmtN(metrics.totalInputTokens)}
           sub={t('partnerDashboard.ops.tokensSub')
             .replace('{en}', fmtN(metrics.totalInputTokensEn))
             .replace('{fr}', fmtN(metrics.totalInputTokensFr))}
         />
         <StatCard
-          uppercase
-          label={t('partnerDashboard.ops.outputTokens')}
+label={t('partnerDashboard.ops.outputTokens')}
           value={fmtN(metrics.totalOutputTokens)}
           sub={t('partnerDashboard.ops.tokensSub')
             .replace('{en}', fmtN(metrics.totalOutputTokensEn))
@@ -220,22 +221,23 @@ const PartnerDashboard = ({ lang = 'en' }) => {
       </div>
 
       {/* Safety metrics */}
-      <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 12px', color: '#333' }}>
+      <h2 className="dashboard-section-title">
         {t('partnerDashboard.safety.title')}
       </h2>
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
-        <StatCard
-          uppercase
-          label={t('partnerDashboard.kpi.harmful')}
-          value={fmtN(harmful.total)}
-          sub={t('partnerDashboard.kpi.harmfulSub')
-            .replace('{en}', fmtN(harmful.en))
-            .replace('{fr}', fmtN(harmful.fr))}
-        />
+      <div className="dashboard-row">
+        <div className="dashboard-col-third">
+          <StatCard
+            label={t('partnerDashboard.kpi.harmful')}
+            value={fmtN(harmful.total)}
+            sub={t('partnerDashboard.kpi.harmfulSub')
+              .replace('{en}', fmtN(harmful.en))
+              .replace('{fr}', fmtN(harmful.fr))}
+          />
+        </div>
       </div>
 
       {!loading && metrics.totalQuestions === 0 && !error && (
-        <p style={{ color: '#888', textAlign: 'center', padding: '40px 0' }}>
+        <p className="dashboard-no-data">
           {t('partnerDashboard.noData')}
         </p>
       )}

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -105,7 +105,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
       {!loading && metrics.totalQuestions === 0 && !error && (
         <div className="dashboard-warning">
           <span className="dashboard-warning__icon" aria-hidden="true" />
-          {t('partnerDashboard.noData')}
+          {t('common.noDataForFilters')}
         </div>
       )}
 

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -102,7 +102,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
         </div>
       )}
 
-      {!loading && metrics.totalQuestions === 0 && !error && (
+      {hasAutoApplied.current && !loading && metrics.totalQuestions === 0 && !error && (
         <div className="dashboard-warning">
           <span className="dashboard-warning__icon" aria-hidden="true" />
           {t('common.noDataForFilters')}

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -17,13 +17,16 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   const pctOrDash = (n) => (n !== null ? fmtPct(n) : '—');
   const { metrics, loading, error, fetchMetrics } = useDashboardMetrics();
   const filterWrapRef = useRef(null);
-  const hasAutoApplied = useRef(false);
+  const autoApplyFired = useRef(false);
+  const hasUserApplied = useRef(false);
   const handleApplyFilters = (filters) => {
-    fetchMetrics(filters);
-    if (hasAutoApplied.current) {
+    if (autoApplyFired.current) {
+      // Second+ call is user-triggered: close the filter panel and mark as applied.
+      hasUserApplied.current = true;
       filterWrapRef.current?.querySelector('details')?.removeAttribute('open'); // relies on FilterPanel rendering a <details> element internally
     }
-    hasAutoApplied.current = true;
+    autoApplyFired.current = true;
+    fetchMetrics(filters);
   };
 
   // --- Derived data ---
@@ -102,7 +105,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
         </div>
       )}
 
-      {hasAutoApplied.current && !loading && metrics.totalQuestions === 0 && !error && (
+      {hasUserApplied.current && !loading && metrics.totalQuestions === 0 && !error && (
         <div className="dashboard-warning">
           <span className="dashboard-warning__icon" aria-hidden="true" />
           {t('common.noDataForFilters')}

--- a/src/components/admin/TechnicalMetricsDashboard.js
+++ b/src/components/admin/TechnicalMetricsDashboard.js
@@ -64,19 +64,26 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer size="xl" className="space-y-6">
-      <FilterPanel
-        lang={lang}
-        onApplyFilters={handleApplyFilters}
-        onClearFilters={handleClearFilters}
-        isVisible={true}
-        defaultUserType="public"
-      />
+      <div className="mb-600">
+        <FilterPanel
+          lang={lang}
+          onApplyFilters={handleApplyFilters}
+          onClearFilters={handleClearFilters}
+          isVisible={true}
+          defaultUserType="public"
+        />
+      </div>
+
+      {hasStartedLoading && !Object.values(loadingState).some(Boolean) && data.totalQuestions === 0 && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('common.noDataForFilters')}
+        </div>
+      )}
 
       {hasStartedLoading && (
         <GcdsContainer size="xl" className="bg-white shadow rounded-lg mb-600">
           <div className="p-4">
-            <h2 className="mt-400 mb-400">{t('technicalMetrics.dashboard.title')}</h2>
-
             <SectionWrapper
               isLoading={loadingState.technical}
               error={errorState.technical}

--- a/src/components/admin/dashboard/DonutCard.js
+++ b/src/components/admin/dashboard/DonutCard.js
@@ -1,24 +1,15 @@
 import React from 'react';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
-import { COLOURS } from '../../../constants/dashboardColours.js';
 import { formatNumber } from '../../../utils/numberFormat.js';
 
 // Donut (hollow pie) chart in a card, with a big figure floated in the centre.
 // `subtitle` and `footer` are optional; omit them for the plain variant.
 // `lang` drives locale-aware number formatting in the tooltip.
-const DonutCard = ({ title, subtitle, data, colours, centreValue, centreLabel, footer, height = 260, lang = 'en' }) => (
-  <div style={{
-    background: '#fff',
-    border: '1px solid #e0e0e0',
-    borderRadius: 8,
-    padding: '24px 16px',
-    flex: 1,
-    minWidth: 280,
-    boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
-  }}>
-    <div style={{ fontSize: 15, fontWeight: 600, marginBottom: subtitle ? 4 : 12, color: '#333' }}>{title}</div>
-    {subtitle && <div style={{ fontSize: 12, color: '#888', marginBottom: 12 }}>{subtitle}</div>}
-    <div style={{ position: 'relative' }}>
+const DonutCard = ({ title, subtitle, data, colours, centreValue, centreLabel, centreColour, footer, height = 260, lang = 'en' }) => (
+  <div className="dashboard-card donut-card">
+    <h3 className={`card-title${subtitle ? ' card-title--has-subtitle' : ''}`}>{title}</h3>
+    {subtitle && <p className="card-subtitle font-size-text-xsm-nr">{subtitle}</p>}
+    <div className="donut-card__chart-wrap">
       <ResponsiveContainer width="100%" height={height}>
         <PieChart>
           <Pie
@@ -38,22 +29,13 @@ const DonutCard = ({ title, subtitle, data, colours, centreValue, centreLabel, f
           <Legend iconType="circle" iconSize={10} />
         </PieChart>
       </ResponsiveContainer>
-      <div style={{
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -68%)',
-        textAlign: 'center',
-        pointerEvents: 'none',
-      }}>
-        <div style={{ fontSize: 28, fontWeight: 700, color: COLOURS.brand, lineHeight: 1 }}>{centreValue}</div>
-        <div style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{centreLabel}</div>
+      <div className="donut-card__centre">
+        <span className="donut-card__centre-value" style={centreColour ? { color: centreColour } : undefined}>{centreValue}</span>
+        <span className="donut-card__centre-label">{centreLabel}</span>
       </div>
     </div>
     {footer && (
-      <div style={{ textAlign: 'center', fontSize: 13, color: '#666', marginTop: 4, borderTop: '1px solid #f0f0f0', paddingTop: 10 }}>
-        {footer}
-      </div>
+      <p className="donut-card__footer font-size-text-xsm-nr">{footer}</p>
     )}
   </div>
 );

--- a/src/components/admin/dashboard/HBarCard.js
+++ b/src/components/admin/dashboard/HBarCard.js
@@ -12,31 +12,25 @@ import { formatNumber, formatPercent } from '../../../utils/numberFormat.js';
 const HBarCard = ({ title, subtitle, data, height, colour = COLOURS.brand, percent = false, noDataLabel = '', lang = 'en' }) => {
   const fmtVal = (v) => (percent ? formatPercent(v, lang) : formatNumber(v, lang));
   return (
-    <div style={{
-      background: '#fff',
-      border: '1px solid #e0e0e0',
-      borderRadius: 8,
-      padding: '24px 16px',
-      boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
-    }}>
-      <div style={{ fontSize: 15, fontWeight: 600, marginBottom: subtitle ? 4 : 16, color: '#333' }}>{title}</div>
-      {subtitle && <div style={{ fontSize: 12, color: '#888', marginBottom: 16 }}>{subtitle}</div>}
+    <div className="dashboard-card hbar-card">
+      <h3 className={`card-title${subtitle ? ' card-title--has-subtitle' : ''}`}>{title}</h3>
+      {subtitle && <p className="card-subtitle font-size-text-xsm-nr">{subtitle}</p>}
       {data.length === 0 ? (
-        <div style={{ height: height || 200, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontSize: 13 }}>
+        <div className="hbar-card__no-data font-size-text-xsm-nr" style={{ height: height || 200 }}>
           {noDataLabel}
         </div>
       ) : (
         <ResponsiveContainer width="100%" height={height || Math.max(200, data.length * 40)}>
           <BarChart data={data} layout="vertical" margin={{ left: 8, right: 44, top: 4, bottom: 4 }}>
             <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-            <XAxis type="number" domain={percent ? [0, 100] : undefined} tickFormatter={percent ? fmtVal : undefined} tick={{ fontSize: 12 }} />
-            <YAxis type="category" dataKey="name" width={160} interval={0} tick={{ fontSize: 12 }} />
+            <XAxis type="number" domain={percent ? [0, 100] : undefined} tickFormatter={percent ? fmtVal : undefined} tick={{ fontSize: 16 }} />
+            <YAxis type="category" dataKey="name" width={160} interval={0} tick={{ fontSize: 16 }} />
             <Tooltip formatter={(value) => fmtVal(value)} />
             <Bar dataKey="value" fill={colour} radius={[0, 4, 4, 0]}>
               {data.map((entry) => (
                 <Cell key={entry.name} fill={entry.colour || colour} />
               ))}
-              <LabelList dataKey="value" position="right" formatter={fmtVal} style={{ fontSize: 12, fill: '#333' }} />
+              <LabelList dataKey="value" position="right" formatter={fmtVal} style={{ fontSize: 16, fill: '#333' }} />
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/src/components/admin/dashboard/KpiRow.js
+++ b/src/components/admin/dashboard/KpiRow.js
@@ -36,7 +36,7 @@ const KpiRow = ({ metrics, t, lang = 'en' }) => {
   const pctOrDash = (n) => (n !== null ? fmtPct(n) : '—');
   const k = deriveKpis(metrics);
   return (
-    <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+    <div className="dashboard-row">
       <StatCard
         label={t('execDashboard.kpi.questionsAsked')}
         value={fmtN(k.totalQuestions)}

--- a/src/components/admin/dashboard/StatCard.js
+++ b/src/components/admin/dashboard/StatCard.js
@@ -1,28 +1,10 @@
 import React from 'react';
-import { COLOURS } from '../../../constants/dashboardColours.js';
 
-// KPI stat card: a label, one big number, and an optional sub-line.
-// `uppercase` renders the label in caps with wider tracking (partner dashboard
-// style); the default is the plainer exec dashboard style.
-const StatCard = ({ label, value, sub, uppercase = false }) => (
-  <div style={{
-    background: '#fff',
-    border: '1px solid #e0e0e0',
-    borderRadius: 8,
-    padding: '24px 28px',
-    flex: 1,
-    minWidth: 160,
-    boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
-  }}>
-    <div style={{
-      fontSize: 13,
-      color: '#666',
-      marginBottom: 6,
-      textTransform: uppercase ? 'uppercase' : 'none',
-      letterSpacing: uppercase ? '0.05em' : '0.02em',
-    }}>{label}</div>
-    <div style={{ fontSize: 42, fontWeight: 700, color: COLOURS.brand, lineHeight: 1 }}>{value}</div>
-    {sub && <div style={{ fontSize: 13, color: '#888', marginTop: 6 }}>{sub}</div>}
+const StatCard = ({ label, value, sub }) => (
+  <div className="dashboard-card stat-card">
+    <h3 className="stat-card__label">{label}</h3>
+    <p className="stat-card__value">{value}</p>
+    {sub && <p className="stat-card__sub font-size-text-xsm-nr">{sub}</p>}
   </div>
 );
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -703,6 +703,7 @@
     "chatDashboard": {
       "title": "Chat dashboard",
       "description": "Filter chat interactions and explore details in the table below.",
+      "timeRangeTitle": "Get chat interactions for the selected period",
       "loading": "Loading chats...",
       "error": "Unable to load chat data.",
       "noResults": "Apply filters to load chat interactions.",
@@ -759,6 +760,7 @@
     "evalDashboard": {
       "title": "Evaluation dashboard",
       "description": "Filter evaluations and explore details in the table below.",
+      "timeRangeTitle": "Get evaluations for the selected period",
       "loading": "Loading evaluations...",
       "error": "Unable to load evaluation data.",
       "resultsSummary": "Total matching evaluations: {count}",
@@ -788,6 +790,7 @@
     "autoEvalDashboard": {
       "title": "Auto-evaluation dashboard",
       "description": "Filter auto-evaluations and explore details in the table below.",
+      "timeRangeTitle": "Get auto-evaluations for the selected period",
       "loading": "Loading evaluations...",
       "error": "Unable to load evaluation data.",
       "resultsSummary": "Total matching evaluations: {count}",
@@ -1060,7 +1063,8 @@
     "error": "Error",
     "yes": "Yes",
     "no": "No",
-    "na": "N/A"
+    "na": "N/A",
+    "noDataForFilters": "No data found for the selected filters."
   },
   "eval": {
     "metric": "Metric",
@@ -1251,7 +1255,6 @@
     "title": "Partner dashboard",
     "overviewTitle": "Overview",
     "error": "Failed to load data. Please try again.",
-    "noData": "No data found for the selected filters.",
     "kpi": {
       "questionsAsked": "Questions asked",
       "questionsSub": "EN: {en} · FR: {fr}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1270,7 +1270,6 @@
     "charts": {
       "accuracyTitle": "Answer quality (expert + AI evaluation)",
       "accuracySubtitle": "{total} evaluations · Expert: {expert} · AI: {ai}",
-      "satisfactionTitle": "User satisfaction",
       "satisfactionCentre": "of {total} responses",
       "feedbackBreakdownTitle": "Satisfaction (helpful or not) breakdown",
       "engagementTitle": "Conversation length",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1226,7 +1226,7 @@
     },
     "charts": {
       "accuracyDonutTitle": "Answer accuracy",
-      "accuracyCentre": "accurate",
+      "accuracyCentre": "accuracy",
       "accurate": "Accurate",
       "hasError": "Has answer error",
       "feedbackBreakdownTitle": "Satisfaction (helpful or not) breakdown",
@@ -1249,6 +1249,8 @@
   },
   "partnerDashboard": {
     "title": "Partner dashboard",
+    "overviewTitle": "Overview",
+    "showFilters": "Show filters",
     "error": "Failed to load data. Please try again.",
     "noData": "No data found for the selected filters.",
     "kpi": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1250,7 +1250,6 @@
   "partnerDashboard": {
     "title": "Partner dashboard",
     "overviewTitle": "Overview",
-    "showFilters": "Show filters",
     "error": "Failed to load data. Please try again.",
     "noData": "No data found for the selected filters.",
     "kpi": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1226,7 +1226,7 @@
     },
     "charts": {
       "accuracyDonutTitle": "Exactitude des réponses",
-      "accuracyCentre": "exactes",
+      "accuracyCentre": "précision",
       "accurate": "Exactes",
       "hasError": "Contient une erreur",
       "feedbackBreakdownTitle": "Répartition de la satisfaction (utile ou non)",
@@ -1249,6 +1249,8 @@
   },
   "partnerDashboard": {
     "title": "Tableau de bord partenaire",
+    "overviewTitle": "Vue d'ensemble",
+    "showFilters": "Afficher les filtres",
     "error": "Échec du chargement des données. Veuillez réessayer.",
     "noData": "Aucune donnée trouvée pour les filtres sélectionnés.",
     "kpi": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1270,7 +1270,6 @@
     "charts": {
       "accuracyTitle": "Qualité des réponses (évaluation experte et IA)",
       "accuracySubtitle": "{total} évaluations · Expert : {expert} · IA : {ai}",
-      "satisfactionTitle": "Satisfaction des utilisateurs",
       "satisfactionCentre": "sur {total} réponses",
       "feedbackBreakdownTitle": "Répartition de la satisfaction (utile ou non)",
       "engagementTitle": "Longueur des conversations",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1250,7 +1250,6 @@
   "partnerDashboard": {
     "title": "Tableau de bord partenaire",
     "overviewTitle": "Vue d'ensemble",
-    "showFilters": "Afficher les filtres",
     "error": "Échec du chargement des données. Veuillez réessayer.",
     "noData": "Aucune donnée trouvée pour les filtres sélectionnés.",
     "kpi": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -703,6 +703,7 @@
     "chatDashboard": {
       "title": "Tableau de bord de chat",
       "description": "Filtrez les interactions de chat et explorez les détails dans le tableau ci-dessous.",
+      "timeRangeTitle": "Obtenir les interactions de clavardage pour la période sélectionnée",
       "loading": "Chargement des chats...",
       "error": "Impossible de charger les données de chat.",
       "noResults": "Appliquez des filtres pour charger les interactions de chat.",
@@ -759,6 +760,7 @@
     "evalDashboard": {
       "title": "Tableau de bord des évaluations",
       "description": "Filtrez les évaluations et explorez les détails dans le tableau ci-dessous.",
+      "timeRangeTitle": "Obtenir les évaluations pour la période sélectionnée",
       "loading": "Chargement des évaluations...",
       "error": "Impossible de charger les données d'évaluation.",
       "resultsSummary": "Total des évaluations correspondantes : {count}",
@@ -788,6 +790,7 @@
     "autoEvalDashboard": {
       "title": "Tableau de bord des évaluations automatiques",
       "description": "Filtrez les évaluations automatiques et explorez les détails dans le tableau ci-dessous.",
+      "timeRangeTitle": "Obtenir les auto-évaluations pour la période sélectionnée",
       "loading": "Chargement des évaluations...",
       "error": "Impossible de charger les données d'évaluation.",
       "resultsSummary": "Total des évaluations correspondantes : {count}",
@@ -1060,7 +1063,8 @@
     "error": "Erreur",
     "yes": "Oui",
     "no": "Non",
-    "na": "S.O."
+    "na": "S.O.",
+    "noDataForFilters": "Aucune donnée trouvée pour les filtres sélectionnés."
   },
   "eval": {
     "metric": "Métrique",
@@ -1251,7 +1255,6 @@
     "title": "Tableau de bord partenaire",
     "overviewTitle": "Vue d'ensemble",
     "error": "Échec du chargement des données. Veuillez réessayer.",
-    "noData": "Aucune donnée trouvée pour les filtres sélectionnés.",
     "kpi": {
       "questionsAsked": "Questions posées",
       "questionsSub": "EN : {en} · FR : {fr}",

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -151,9 +151,10 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
         </GcdsText>
       </nav>
 
-      <p className="mb-0 small-text">{t('admin.autoEvalDashboard.description', 'Filter auto-evaluations and explore details in the table below.')}</p>
-
-      <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} />
+      <h2 className="mt-400 mb-400">{t('admin.autoEvalDashboard.timeRangeTitle')}</h2>
+      <div className="mb-600">
+        <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} />
+      </div>
 
       {loading && (
         <div className="loading-overlay" role="status" aria-live="polite">
@@ -165,6 +166,13 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
       )}
 
       {error && (<div className="mt-400 error" role="alert">{t('admin.autoEvalDashboard.error', 'Unable to load eval data.')} {String(error)}</div>)}
+
+      {hasAppliedFilters && !loading && !error && recordsTotal === 0 && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('common.noDataForFilters')}
+        </div>
+      )}
 
       {hasAppliedFilters && (
         <div className="mt-200">

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -295,16 +295,15 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         </GcdsText>
       </nav>
 
-      <p className="mb-0 small-text">
-        {t('admin.chatDashboard.description', 'Filter chat interactions and explore details in the table below.')}
-      </p>
-
-      <FilterPanel
-        lang={lang}
-        onApplyFilters={(filters) => { handleApplyFilters(filters); }}
-        onClearFilters={handleClearFilters}
-        isVisible={true}
-      />
+      <h2 className="mt-400 mb-400">{t('admin.chatDashboard.timeRangeTitle')}</h2>
+      <div className="mb-600">
+        <FilterPanel
+          lang={lang}
+          onApplyFilters={(filters) => { handleApplyFilters(filters); }}
+          onClearFilters={handleClearFilters}
+          isVisible={true}
+        />
+      </div>
 
       {loading && (
         <div className="loading-overlay" role="status" aria-live="polite">
@@ -321,10 +320,11 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         </div>
       )}
 
-      {!loading && !error && recordsFiltered === 0 && recordsTotal === 0 && (
-        <p className="chat-dashboard-no-results">
-          {t('admin.chatDashboard.noResults', 'Apply filters to load chat interactions.')}
-        </p>
+      {hasAppliedFilters && !loading && !error && recordsTotal === 0 && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('common.noDataForFilters')}
+        </div>
       )}
 
       {hasAppliedFilters && (

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -175,9 +175,10 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         </GcdsText>
       </nav>
 
-      <p className="mb-0 small-text">{t('admin.evalDashboard.description', 'Filter evaluations and explore details in the table below.')}</p>
-
-      <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} />
+      <h2 className="mt-400 mb-400">{t('admin.evalDashboard.timeRangeTitle')}</h2>
+      <div className="mb-600">
+        <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} />
+      </div>
 
       {loading && (
         <div className="loading-overlay" role="status" aria-live="polite">
@@ -189,6 +190,13 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       )}
 
       {error && (<div className="mt-400 error" role="alert">{t('admin.evalDashboard.error', 'Unable to load eval data.')} {String(error)}</div>)}
+
+      {hasAppliedFilters && !loading && !error && recordsTotal === 0 && (
+        <div className="dashboard-warning">
+          <span className="dashboard-warning__icon" aria-hidden="true" />
+          {t('common.noDataForFilters')}
+        </div>
+      )}
 
       {hasAppliedFilters && (
         <div className="mt-200">

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -543,3 +543,181 @@
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
+/* =================================================================
+   Partner + Exec dashboards — layout, cards, and sub-components
+   ================================================================= */
+
+.dashboard-row {
+  display: flex;
+  gap: var(--gcds-spacing-200);
+  margin-bottom: var(--gcds-spacing-300);
+  flex-wrap: wrap;
+}
+
+.dashboard-section {
+  margin-bottom: var(--gcds-spacing-300);
+}
+
+.dashboard-chart-wide {
+  flex: 2;
+  min-width: 320px;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-chart-wide > * {
+  flex: 1;
+}
+
+.dashboard-col-third {
+  flex: 0 0 calc((100% - (var(--gcds-spacing-200) * 2)) / 3);
+  max-width: calc((100% - (var(--gcds-spacing-200) * 2)) / 3);
+}
+
+.dashboard-section-title {
+  font: var(--gcds-font-h4);
+  margin: 0 0 var(--gcds-spacing-150);
+  color: #333;
+}
+
+@media only screen and (width < 48em) {
+  .dashboard-section-title {
+    font: var(--gcds-font-h4-mobile);
+  }
+}
+
+.dashboard-error {
+  background: #ffebee;
+  border: 1px solid #ef9a9a;
+  border-radius: 6px;
+  padding: var(--gcds-spacing-150) var(--gcds-spacing-200);
+  margin-bottom: var(--gcds-spacing-300);
+  color: #c62828;
+}
+
+.dashboard-no-data {
+  color: var(--gcds-color-grayscale-700);
+  text-align: center;
+  padding: var(--gcds-spacing-500) 0;
+}
+
+.dashboard-loading {
+  color: var(--gcds-color-grayscale-700);
+  text-align: center;
+  padding: var(--gcds-spacing-500) 0;
+  margin-bottom: var(--gcds-spacing-300);
+}
+
+/* Base card chrome — shared by StatCard, DonutCard, and HBarCard */
+.dashboard-card {
+  background: #fff;
+  border: 1px solid var(--gcds-color-grayscale-100);
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+/* ---- StatCard ---- */
+
+.stat-card {
+  flex: 1;
+  min-width: 160px;
+  padding: var(--gcds-spacing-300) var(--gcds-spacing-350);
+}
+
+.stat-card__label {
+  font-size: var(--gcds-font-sizes-h6);
+  color: var(--gcds-color-grayscale-700);
+  margin: 0 0 var(--gcds-spacing-75);
+  font-weight: var(--gcds-font-weights-semibold);
+}
+
+.stat-card__value {
+  font-size: 42px;
+  font-weight: 700;
+  color: #1565c0;
+  line-height: 1;
+  margin: var(--gcds-spacing-150) 0;
+}
+
+.stat-card__sub {
+  color: var(--gcds-color-grayscale-700);
+  margin: var(--gcds-spacing-75) 0 0;
+}
+
+/* ---- DonutCard ---- */
+
+.donut-card {
+  flex: 1;
+  min-width: 280px;
+  padding: var(--gcds-spacing-300) var(--gcds-spacing-200);
+}
+
+.card-title {
+  font-size: var(--gcds-font-sizes-h6);
+  color: var(--gcds-color-grayscale-700);
+  margin: 0 0 var(--gcds-spacing-200);
+  font-weight: var(--gcds-font-weights-semibold);
+}
+
+.card-title--has-subtitle {
+  margin-bottom: var(--gcds-spacing-50);
+}
+
+.card-subtitle {
+  color: var(--gcds-color-grayscale-700);
+  margin: 0 0 var(--gcds-spacing-200);
+}
+
+.donut-card .recharts-legend-item-text {
+  color: var(--gcds-color-grayscale-700) !important;
+}
+
+.donut-card__chart-wrap {
+  position: relative;
+}
+
+.donut-card__centre {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -68%);
+  text-align: center;
+  pointer-events: none;
+}
+
+.donut-card__centre-value {
+  display: block;
+  font-size: 28px;
+  font-weight: 700;
+  color: #1565c0;
+  line-height: 1;
+}
+
+.donut-card__centre-label {
+  display: block;
+  font-size: 14px;
+  color: var(--gcds-color-grayscale-700);
+  margin-top: var(--gcds-spacing-25);
+}
+
+.donut-card__footer {
+  text-align: center;
+  color: var(--gcds-color-grayscale-700);
+  margin: var(--gcds-spacing-50) 0 0;
+  border-top: 1px solid var(--gcds-color-grayscale-100);
+  padding-top: var(--gcds-spacing-125);
+}
+
+/* ---- HBarCard ---- */
+
+.hbar-card {
+  padding: var(--gcds-spacing-300) var(--gcds-spacing-200);
+}
+
+.hbar-card__no-data {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--gcds-color-grayscale-700);
+}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -596,10 +596,49 @@
   color: #c62828;
 }
 
-.dashboard-no-data {
-  color: var(--gcds-color-grayscale-700);
-  text-align: center;
-  padding: var(--gcds-spacing-500) 0;
+.dashboard-warning {
+  display: grid;
+  grid-template-columns: var(--gcds-notice-icon-width) auto;
+  gap: var(--gcds-notice-icon-gap);
+  align-items: center;
+  color: var(--gcds-notice-text);
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: var(--gcds-spacing-300);
+  padding: var(--gcds-spacing-200) 0;
+}
+
+.dashboard-warning__icon {
+  position: relative;
+  display: block;
+  align-self: stretch;
+  width: var(--gcds-notice-border-width);
+  min-height: 52px;
+  margin: 0 auto;
+  background: linear-gradient(
+    to bottom,
+    var(--gcds-notice-danger-text) 0 calc(50% - 1.1rem),
+    transparent calc(50% - 1.1rem) calc(50% + 1.1rem),
+    var(--gcds-notice-danger-text) calc(50% + 1.1rem) 100%
+  );
+}
+
+.dashboard-warning__icon::before {
+  content: '!';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--gcds-notice-danger-text);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.75rem;
 }
 
 .dashboard-loading {
@@ -720,4 +759,62 @@
   align-items: center;
   justify-content: center;
   color: var(--gcds-color-grayscale-700);
+}
+
+/* ---- DashboardFilterBar ---- */
+
+.filter-bar {
+  background: #f5f7fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: var(--gcds-spacing-200) var(--gcds-spacing-250);
+  margin-bottom: var(--gcds-spacing-175);
+  display: flex;
+  align-items: flex-end;
+  gap: var(--gcds-spacing-250);
+  flex-wrap: wrap;
+}
+
+.filter-bar__label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: var(--gcds-spacing-50);
+}
+
+.filter-bar__input {
+  padding: 6px 10px;
+  border: 1px solid #bdbdbd;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.filter-bar__select {
+  padding: 7px 12px;
+  border: 1px solid #bdbdbd;
+  border-radius: 4px;
+  font-size: 14px;
+  min-width: 200px;
+}
+
+.filter-bar__apply {
+  padding: 7px var(--gcds-spacing-250);
+  background: #1565c0;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.filter-bar__apply:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.filter-bar__loading {
+  font-size: 13px;
+  color: var(--gcds-color-grayscale-700);
+  align-self: center;
 }

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -602,7 +602,7 @@
   gap: var(--gcds-notice-icon-gap);
   align-items: center;
   color: var(--gcds-notice-text);
-  font-size: 1rem;
+  font-size: var(--gcds-font-sizes-text-small);
   line-height: 1.5;
   margin-bottom: var(--gcds-spacing-300);
   padding: var(--gcds-spacing-200) 0;

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -140,18 +140,6 @@
   font-weight: bold;
 }
 
-/* font size overrides; working to incorporate still */
-
-.font-size-text-xsm-nr {
-  font-size: 16px !important;
-  line-height: 1.5em;
-}
-
-.font-size-text-xxs-nr {
-  font-size: 14px !important;
-  line-height: 1.2em;
-
-}
 
 .citation-divider {
   border: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,6 +7,17 @@
   outline: none;
 }
 
+/* Custom non-responsive font sizes */
+.font-size-text-xsm-nr {
+  font-size: 1rem !important; /* 16px */
+  line-height: 1.5em;
+}
+
+.font-size-text-xxs-nr {
+  font-size: 0.875rem !important; /* 14px */
+  line-height: 1.2em;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
Dashboard styling refactor — Partner & Executive dashboards

  CSS
  - Extracted all inline styles from dashboard components into a new dashboard section in admin.css, using GCDS
  tokens for colour, typography, and spacing throughout
  - Added shared card classes (dashboard-card, stat-card, donut-card, hbar-card, card-title, card-subtitle) used
  by both dashboards
  - Added dashboard-warning component class for the no-data state
  - Moved non-responsive font-size utilities (font-size-text-xsm-nr, font-size-text-xxs-nr) from chat.css into
  global.css
  - All font sizes adjusted on dashboard charts

  Semantic HTML
  - StatCard, DonutCard, HBarCard now use `<h3>, <p>, <span> `instead of `<div> `for text content

  Layout
  - Partner: satisfaction + conversation length donuts share a 50/50 row
  - Both dashboards: harmful card constrained to 1/3 width (dashboard-col-third)
  - Exec: answer accuracy donut and satisfaction bar chart are equal height

  Behaviour
  - Partner dashboard filter panel opens by default and auto-collapses after the first user-triggered apply
  (scoped to PartnerDashboard only, no changes to shared FilterPanel)
  - Partner and Exec dashboards show a no-data warning only after a fetch returns empty results — suppressed on
  initial page load
  - Exec accuracy donut centre value colour reflects accuracy status (green if ≥ 80%, red otherwise)

  Locale
  - Added partnerDashboard.overviewTitle ("Overview" / "Vue d'ensemble")
  - Updated execDashboard.charts.accuracyCentre label to "accuracy" / "précision"
  - Consolidated no-data message to common.noDataForFilters across all dashboards (removed
  partnerDashboard.noData)
  - Removed dead key partnerDashboard.charts.satisfactionTitle