### PR TITLE
fix: expert evaluation and partner count, calendar apply bttn

### DIFF
--- a/api/metrics/metrics-expert-feedback.js
+++ b/api/metrics/metrics-expert-feedback.js
@@ -41,7 +41,9 @@ function buildExpertFeedbackPipeline(dateFilter, extraFilters = [], departmentFi
         },
         // Apply department filter after context lookup
         ...(departmentFilter.length > 0 ? [{ $match: { $and: departmentFilter } }] : []),
-        { $match: { expertFeedback: { $ne: null } } },
+        // Exclude blank ExpertFeedback records created solely by the neverStale flag
+        // (those have totalScore: null because no human scored the interaction).
+        { $match: { expertFeedback: { $ne: null }, 'expertFeedback.totalScore': { $ne: null } } },
         {
             $addFields: {
                 category: getPartnerEvalAggregationExpression('$expertFeedback'),

--- a/docs/coding-agent-docs/dashboards.md
+++ b/docs/coding-agent-docs/dashboards.md
@@ -94,7 +94,7 @@ metrics.totalInputTokens / totalInputTokensEn / totalInputTokensFr   // from usa
 metrics.totalOutputTokens / totalOutputTokensEn / totalOutputTokensFr // from usage
 metrics.responseTime.{ count, median, p90, p95, max, maxChatId }    // ms, from technical
 metrics.sessionsByQuestionCount.{singleQuestion,twoQuestions,threeQuestions}.total
-metrics.byDepartment[dept].{ total, expertScored.total }
+metrics.byDepartment[dept].{ total, expertScored.total }  // total = interactions (questions), not conversations
 metrics.expertScored.<cat>.{ total, en, fr }   // cat: total, correct, needsImprovement,
                                                 //      hasError, hasCitationError, harmful, hasContentIssue
 metrics.aiScored.<cat>.{ total, en, fr }        // same cats EXCEPT no hasContentIssue

--- a/docs/coding-agent-docs/dashboards.md
+++ b/docs/coding-agent-docs/dashboards.md
@@ -107,6 +107,17 @@ metrics.blockedQueries.<type>.{ total, en, fr } // from metrics-blocked; type: t
                                                 //   unsupportedLanguage, plus a `total` bucket
 ```
 
+### What each metric counts
+
+Most metrics count at the **interaction level** (one per question asked):
+`totalQuestions`, `expertScored`, `aiScored`, `publicFeedback`, `byDepartment.total`, and `byDepartmentCount` (institutions with questions) all count interactions. A 3-question TBS session counts as 3 toward TBS's total.
+
+Two metrics count at the **chat (conversation) level** — intentionally:
+- **`totalConversations`** — distinct Chat IDs; measures unique conversations.
+- **`sessionsByQuestionCount`** — groups by Chat ID to show session depth (how many questions per conversation). Chat-level grouping is correct here.
+
+Nothing else should count at the Chat ID level. If you add a new metric that aggregates from `Chat` without `$unwind`ing interactions, verify the counting unit is intentional.
+
 Expert metrics come from `api/metrics/metrics-expert-feedback.js`, AI from
 `metrics-ai-eval.js`, public feedback from `metrics-public-feedback.js`. Token
 totals come from `metrics-usage.js`; `responseTime` (ms percentiles) from

--- a/src/components/admin/DashboardFilterBar.js
+++ b/src/components/admin/DashboardFilterBar.js
@@ -54,7 +54,11 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
           id="dashboard-dept"
           className="filter-bar__select"
           value={department}
-          onChange={e => setDepartment(e.target.value)}
+          onChange={e => {
+            const newDept = e.target.value;
+            setDepartment(newDept);
+            if (startDate && endDate) onApply({ startDate, endDate, department: newDept });
+          }}
           disabled={loading}
         >
           <option value="">{t('dashboardFilter.allPartners')}</option>

--- a/src/components/admin/DashboardFilterBar.js
+++ b/src/components/admin/DashboardFilterBar.js
@@ -54,11 +54,7 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
           id="dashboard-dept"
           className="filter-bar__select"
           value={department}
-          onChange={e => {
-            const newDept = e.target.value;
-            setDepartment(newDept);
-            if (startDate && endDate) onApply({ startDate, endDate, department: newDept });
-          }}
+          onChange={e => setDepartment(e.target.value)}
           disabled={loading}
         >
           <option value="">{t('dashboardFilter.allPartners')}</option>

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -10,7 +10,6 @@ import HBarCard from './dashboard/HBarCard.js';
 import DivergingBarCard from './dashboard/DivergingBarCard.js';
 import { COLOURS } from '../../constants/dashboardColours.js';
 import { BLOCK_QUERY_TYPES } from '../../constants/blockedQueryTypes.js';
-import { PARTNER_DEPARTMENTS } from '../../constants/partnerDepartments.js';
 import { formatNumber, formatPercent, formatDecimal } from '../../utils/numberFormat.js';
 
 const ExecDashboard = ({ lang = 'en' }) => {
@@ -48,8 +47,9 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const yearQuestions = yearMetrics.totalQuestions || 0;
   const yearExpertTotal = yearMetrics.expertScored?.total?.total || 0;
   const yearEvaluatedPct = yearExpertTotal > 0 && yearQuestions > 0 ? Math.round((yearExpertTotal / yearQuestions) * 100) : 0;
-  // Partner count — departments with at least 1 expert evaluation.
-  const yearPartnerCount = PARTNER_DEPARTMENTS.length;
+  // Partner count — departments with at least 1 question asked.
+  const yearPartnerCount = Object.values(yearMetrics.byDepartment || {})
+    .filter(d => (d.total || 0) > 0).length;
 
   // Row 2 left: accuracy donut. Only "has answer error" counts against accuracy
   // (citation issues / needs-improvement do not); combines expert + AI evals.

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -48,7 +48,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const yearExpertTotal = yearMetrics.expertScored?.total?.total || 0;
   const yearEvaluatedPct = yearExpertTotal > 0 && yearQuestions > 0 ? Math.round((yearExpertTotal / yearQuestions) * 100) : 0;
   // Partner count — departments with at least 1 question asked.
-  const yearPartnerCount = Object.values(yearMetrics.byDepartment || {})
+  const byDepartmentCount = Object.values(yearMetrics.byDepartment || {})
     .filter(d => (d.total || 0) > 0).length;
 
   // Row 2 left: accuracy donut. Only "has answer error" counts against accuracy
@@ -152,7 +152,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
             />
             <StatCard
               label={t('execDashboard.kpi.partnerCount')}
-              value={fmtN(yearPartnerCount)}
+              value={fmtN(byDepartmentCount)}
             />
           </div>
           {/* Row 2: accuracy donut (left) + satisfaction breakdown bar (right).

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -47,7 +47,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const yearQuestions = yearMetrics.totalQuestions || 0;
   const yearExpertTotal = yearMetrics.expertScored?.total?.total || 0;
   const yearEvaluatedPct = yearExpertTotal > 0 && yearQuestions > 0 ? Math.round((yearExpertTotal / yearQuestions) * 100) : 0;
-  // Partner count — departments with at least 1 question asked.
+  // Department count — departments with at least 1 question asked.
   const byDepartmentCount = Object.values(yearMetrics.byDepartment || {})
     .filter(d => (d.total || 0) > 0).length;
 

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -10,6 +10,7 @@ import HBarCard from './dashboard/HBarCard.js';
 import DivergingBarCard from './dashboard/DivergingBarCard.js';
 import { COLOURS } from '../../constants/dashboardColours.js';
 import { BLOCK_QUERY_TYPES } from '../../constants/blockedQueryTypes.js';
+import { PARTNER_DEPARTMENTS } from '../../constants/partnerDepartments.js';
 import { formatNumber, formatPercent, formatDecimal } from '../../utils/numberFormat.js';
 
 const ExecDashboard = ({ lang = 'en' }) => {
@@ -48,8 +49,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const yearExpertTotal = yearMetrics.expertScored?.total?.total || 0;
   const yearEvaluatedPct = yearExpertTotal > 0 && yearQuestions > 0 ? Math.round((yearExpertTotal / yearQuestions) * 100) : 0;
   // Partner count — departments with at least 1 expert evaluation.
-  const yearPartnerCount = Object.values(yearMetrics.byDepartment || {})
-    .filter(d => (d.expertScored?.total || 0) > 0).length;
+  const yearPartnerCount = PARTNER_DEPARTMENTS.length;
 
   // Row 2 left: accuracy donut. Only "has answer error" counts against accuracy
   // (citation issues / needs-improvement do not); combines expert + AI evals.

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -263,9 +263,24 @@ const FilterPanel = ({
   ];
 
   const handleApply = () => {
-    // Parse local datetime strings and convert to UTC ISO strings for backend
-    const startObj = parseDateTimeLocal(dateRange.startDate);
-    const endObj = parseDateTimeLocal(dateRange.endDate);
+    // Prefer the picker's live state over React state: the picker tracks the
+    // user's calendar selection in real-time, so dates are correct even when
+    // the user chose a custom range without clicking Apply inside the calendar.
+    const picker = dateRangePickerInstance.current;
+    const startDateStr = picker
+      ? formatDateTimeLocal(picker.startDate.toDate())
+      : dateRange.startDate;
+    const endDateStr = picker
+      ? formatDateTimeLocal(picker.endDate.toDate())
+      : dateRange.endDate;
+
+    // Sync React state so the input reflects the applied dates if they changed.
+    if (startDateStr !== dateRange.startDate || endDateStr !== dateRange.endDate) {
+      setDateRange({ startDate: startDateStr, endDate: endDateStr });
+    }
+
+    const startObj = parseDateTimeLocal(startDateStr);
+    const endObj = parseDateTimeLocal(endDateStr);
 
     const filters = {
       startDate: startObj ? startObj.toISOString() : undefined,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1264,7 +1264,7 @@
       "questionsSub": "EN: {en} · FR: {fr}",
       "accuracyRate": "Accuracy rate",
       "accuracySub": "EN: {en} · FR: {fr}",
-      "partnerCount": "Partner institutions",
+      "partnerCount": "Institutions with questions",
       "harmful": "Harmful",
       "harmfulSub": "EN: {en} · FR: {fr}"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1264,7 +1264,7 @@
       "questionsSub": "EN : {en} · FR : {fr}",
       "accuracyRate": "Taux d'exactitude",
       "accuracySub": "EN : {en} · FR : {fr}",
-      "partnerCount": "Institutions partenaires",
+      "partnerCount": "Institutions avec des questions",
       "harmful": "Nuisible",
       "harmfulSub": "EN : {en} · FR : {fr}"
     },

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -372,6 +372,12 @@
   background: #e5e7eb;
 }
 
+/* Hide the daterangepicker's own Apply button — the FilterPanel's Apply button
+   reads from the picker instance directly, so the in-calendar Apply is redundant. */
+.daterangepicker .applyBtn {
+  display: none;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .filter-grid {


### PR DESCRIPTION
 - Expert evaluated count (inflated) — api/metrics/metrics-expert-feedback.js: added
  'expertFeedback.totalScore': { $ne: null } to the pipeline filter so interactions where "Never Stale" was
  toggled (creating a blank ExpertFeedback record with all null scores) are no longer counted as expert
  evaluations.
  - Date range filter (stale dates) — src/components/admin/FilterPanel.js: "Apply filters" now reads the
  date range directly from the daterangepicker instance's live state instead of React state, which only
  updated after the user clicked "Apply" inside the calendar popup. Skipping that step no longer sends stale
  default dates.
  - Partner count now Dept count (dynamic) — src/components/admin/ExecDashboard.js: yearPartnerCount is now byDepartmentCount derived from byDepartment data (departments with at least 1 question asked) rather than evaluation activity, so the count reflects actual usage across institutions regardless of whether any interactions were evaluated.
  - Daterangepicker Apply button — src/styles/admin.css: hides the picker's built-in Apply button since the
  filter bar's own Apply button now reads from the picker instance directly, making the in-calendar Apply
  redundant.