### PR TITLE
feat: add design instructions, css cleanup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,7 @@
 ## Environment notes
 - **React build restriction**: Files imported by frontend code (`src/`) must live inside `src/`. Never place shared config intended for UI components in `config/` (root) — use `src/config/` instead. Server-side code (`api/`, `agents/`, `services/`) can import from anywhere.
 - **Test runner**: This project uses **vitest**, not jest. Run tests with `npx vitest run <path>` (or `npm test` for all).
-- **CSS loading**: All app styles are loaded once in `src/App.js` (`global.css`, `admin.css`, `chat.css`). Never import these files in individual pages or components — they are already globally available. Do not move these imports to `index.js` either: `App.js` must load after `index.js`'s GCDS CSS (`gcds-utility.min.css` imports Lato/Noto Sans from Google Fonts) so that webpack resolves the stylesheets in the correct order. Moving app CSS into `index.js` alongside GCDS CSS breaks the GC Design System fonts.
-- **No inline styles**: Do not use inline `style={{...}}` attributes on elements. Add a CSS class instead. Inline styles are only acceptable when the value is genuinely dynamic and cannot be expressed as a class (e.g. a runtime-computed width or colour).
-- **No new CSS files**: Do not create additional CSS or CSS module files. Add new styles to the appropriate existing file (`global.css` for site-wide rules, `admin.css` for admin/auth pages, `chat.css` for the chat interface). A new file is only justified if it introduces a genuinely separate styling concern that cannot reasonably live in one of the three existing files — document the reason in a comment at the top of the file if you do create one.
+- **CSS/styling**: See [docs/coding-agent-docs/design-system.md](docs/coding-agent-docs/design-system.md) for all CSS and visual style rules.
 
 ## Do not edit prompts during unrelated coding work
 
@@ -143,6 +141,7 @@ Before starting work, read the relevant reference doc:
 - **Writing or running tests, local dev:** [docs/coding-agent-docs/testing-and-dev.md](docs/coding-agent-docs/testing-and-dev.md)
 - **Common task patterns (prompts, UI, scenarios, API):** [docs/coding-agent-docs/common-tasks.md](docs/coding-agent-docs/common-tasks.md)
 - **Dashboards & filters (exec/partner cards, `FilterPanel`, cross-dashboard filter logic, Chat/Eval/Metrics gotchas):** [docs/coding-agent-docs/dashboards.md](docs/coding-agent-docs/dashboards.md)
+- **CSS, styling, visual look and feel, GC Design System tokens:** [docs/coding-agent-docs/design-system.md](docs/coding-agent-docs/design-system.md)
 
 ## Database query safety
 
@@ -200,43 +199,6 @@ Notes:
 - Prefer putting logic in a hook before moving it to the page.
 - Keep utils pure (no React state/effects); move stateful logic to hooks.
 - If a hook/component/helper becomes cross-feature, promote it to a shared location and update imports.
-
-## CSS values
-
-Prefer GC Design System tokens over hardcoded values whenever a token exists for the property. This keeps the UI consistent with the design system and picks up theme changes automatically.
-
-Before writing a hardcoded value, check the token definitions in:
-- `node_modules/@cdssnc/gcds-utility/dist/gcds-utility.css` — colour palette, border-radius, focus, link, text tokens
-- `node_modules/@gcds-core/components/dist/gcds/gcds.css` — component-level tokens
-- GC DS CSS shortcuts: https://design-system.canada.ca/en/css-shortcuts/ — utility classes that can often replace one-off CSS rules entirely
-
-### Common token mappings
-
-| Hardcoded value | GC DS token |
-|---|---|
-| `#26374A` | `var(--gcds-color-blue-muted)` |
-| `#333` / `#333333` | `var(--gcds-text-primary)` |
-| `#43474e` | `var(--gcds-text-secondary)` |
-| `#284162` (link) | `var(--gcds-link-default)` |
-| `#0535d2` (link hover) | `var(--gcds-link-hover)` |
-| `#d3080c` (error red) | `var(--gcds-color-red-500)` |
-| `#0535d2` (focus) | `var(--gcds-focus-border)` |
-| `border-radius: 2px` | `var(--gcds-border-radius-sm)` |
-| `border-radius: 4-6px` | `var(--gcds-border-radius-md)` |
-
-```css
-/* Prefer */
-color: var(--gcds-text-primary);
-background-color: var(--gcds-color-blue-muted);
-border-radius: var(--gcds-border-radius-md);
-
-/* Avoid */
-color: #333;
-background-color: #26374A;
-border-radius: 4px;
-```
-
-Hardcoded values are acceptable when no GC DS token maps to the property, or when overriding a third-party component that requires a specific value. In those cases leave a short comment explaining why a token wasn't used so a designer can review it later.
 
 ## Key rules
 - Department abbreviations (abbrKey) are defined in `agents/prompts/scenarios/departments_EN.js` / `departments_FR.js` — never invent new ones

--- a/docs/coding-agent-docs/design-system.md
+++ b/docs/coding-agent-docs/design-system.md
@@ -1,0 +1,129 @@
+# Design System
+
+Read this before any task involving UI, CSS, styling, or visual look and feel.
+
+This project is styled with the **GC Design System (GCDS)** tokens, spacing, typography, and colours wherever possible. Deviations with custom values should have valid use cases, such as supporting a design not yet implemented from the Canada.ca Specifications, or addressing gaps required for the project.
+
+## CSS file structure
+
+All app styles are loaded once in `src/App.js`:
+
+- `global.css` — site-wide rules (layout, typography, shared components)
+- `admin.css` — admin and auth pages
+- `chat.css` — chat interface
+
+**Never import these files in individual pages or components** — they are already globally available. Do not move these imports to `index.js` either: `App.js` must load after `index.js`'s GCDS CSS (`gcds-utility.min.css` imports Lato/Noto Sans from Google Fonts) so that webpack resolves stylesheets in the correct order. Moving app CSS into `index.js` alongside GCDS CSS breaks the GC Design System fonts.
+
+**Do not create new CSS files.** Add new styles to the appropriate existing file above. A new file is only justified if it introduces a genuinely separate styling concern that cannot reasonably live in one of the three — document the reason in a comment at the top of the file if you do.
+
+## CSS cleanup
+
+The existing CSS files have accumulated custom classes that are scattered, inconsistently named, and underreused. Two rules govern how to handle this:
+
+1. **Don't create new problems.** Component classes can be comprehensive — a dashboard card or table row legitimately needs multiple properties together. The goal is not "one property per class" but to identify what's genuinely reusable and treat it like a utility. Common properties like a typography scale step, a border style, or a spacing value should be defined once and reused, not duplicated across component classes. Use descriptive, context-appropriate names (e.g. `.metric-label`, `.status-badge`) rather than presentational ones tied to a specific value (e.g. `.grey-text`, `.bold-14`). When writing any custom class, refer back to GC DS CSS shortcuts and tokens first — use a utility class or `var(--gcds-*)` token for as many property values as possible before reaching for a hardcoded value.
+
+2. **Don't fix old problems unless directly relevant.** Don't refactor existing classes as a side effect of unrelated work. The exception: if you spot a custom class that could serve the current task with a small, safe change (e.g. making it slightly more specific or utility-like), it's reasonable to improve it in place — but don't go further.
+
+**Stay scoped to the relevant file.** If the task touches the dashboard, only look at dashboard-related styles. Do not raise CSS issues in files outside the current PR's scope. If a user wants a CSS review on a specific page or file, they can request one explicitly.
+
+## No inline styles
+
+Do not use inline `style={{...}}` attributes on elements. Add a CSS class instead.
+
+Inline styles are only acceptable when the value is genuinely dynamic and cannot be expressed as a class (e.g. a runtime-computed width or colour).
+
+## Styling hierarchy
+
+When adding any style, follow this order — stop at the first option that works:
+
+1. **GC DS utility class** — covers the need with a single class, no new CSS required
+2. **GC DS token** — no utility class fits, but a `var(--gcds-*)` token covers the value
+3. **Hardcoded value** — no token exists; leave a short comment so a designer can review it later
+
+### CSS shortcuts vs. custom CSS with tokens
+
+The choice between applying utility classes directly in markup vs. writing a custom CSS class depends on complexity:
+
+- **Use CSS shortcuts** for simple, focused changes that need only a few styles — e.g. styling an `<a>` tag to look like a GC DS link, adding spacing to a label, setting a text colour. A handful of utility classes in the HTML is clean and sufficient.
+- **Use a custom CSS class with tokens** for design elements with many properties that need to be understood and maintained together — e.g. a chat message bubble, a dashboard stat card, a form panel. These belong in the CSS file as a named class so the full visual definition is in one place and can be reviewed as a whole. Don't split a complex component's styles between a custom class and scattered utility classes — keep it consolidated.
+
+**Typography is an exception to component bundling.** Font size adjustments (e.g. a small non-responsive label size for screen reader context) should be defined as standalone utility classes in the CSS file, not embedded inside component classes. This keeps typographic deviations minimal, named, and reusable — a card or badge can reference `.text-label-small` rather than each defining their own font size, making it easier to maintain consistency and review the full type scale in one place.
+
+## GC Design System tokens
+
+**Prefer GC DS tokens over hardcoded values** whenever a token exists for the property. This keeps the UI consistent with the design system and picks up theme changes automatically.
+
+Before writing a hardcoded value, check the token definitions in:
+
+- `node_modules/@cdssnc/gcds-utility/dist/gcds-utility.css` — colour palette, border-radius, focus, link, text tokens
+- `node_modules/@gcds-core/components/dist/gcds/gcds.css` — component-level tokens
+
+### Common token mappings
+
+| Hardcoded value | GC DS token |
+|---|---|
+| `#26374A` | `var(--gcds-color-blue-muted)` |
+| `#333` / `#333333` | `var(--gcds-text-primary)` |
+| `#43474e` | `var(--gcds-text-secondary)` |
+| `#284162` (link) | `var(--gcds-link-default)` |
+| `#0535d2` (link hover) | `var(--gcds-link-hover)` |
+| `#d3080c` (error red) | `var(--gcds-color-red-500)` |
+| `#0535d2` (focus — same hex, different semantic token) | `var(--gcds-focus-border)` |
+| `border-radius: 2px` | `var(--gcds-border-radius-sm)` |
+| `border-radius: 4px` | `var(--gcds-border-radius-md)` |
+
+```css
+/* Prefer */
+color: var(--gcds-text-primary);
+background-color: var(--gcds-color-blue-muted);
+border-radius: var(--gcds-border-radius-md);
+
+/* Avoid */
+color: #333;
+background-color: #26374A;
+border-radius: 4px;
+```
+
+Hardcoded values are acceptable when no GC DS token maps to the property, or when overriding a third-party component that requires a specific value. In those cases leave a short comment explaining why a token wasn't used so a designer can review it later.
+
+## Dashboard chart colours
+
+For admin dashboards, import shared colour constants — never hardcode chart hex values:
+
+```js
+import { COLOURS, QUALITY_COLOURS } from 'src/constants/dashboardColours.js';
+```
+
+Greys and borders used only for structural layout (not data encoding) may stay local.
+
+## GC DS utility classes
+
+Before writing any custom CSS, check whether a GCDS utility class already covers the need. The utility classes handle spacing, typography, colour, flex/grid layout, and more. Using them avoids new CSS and keeps the UI consistent.
+
+Reference: https://design-system.canada.ca/en/css-shortcuts/
+
+## CSS review
+
+When a designer requests a CSS review on a specific page or file, audit the relevant CSS and markup for the following. Report findings grouped by category — don't silently fix things, flag them for the designer to approve first.
+
+1. **Non-token values without rationale.** Any hardcoded colour, border-radius, or spacing value that has a GC DS token equivalent and no explanatory comment. Every deviation needs a stated reason.
+
+2. **Near-duplicate values that could consolidate.** Look for similar but not identical values used for the same purpose — e.g. `#333` and `#111` used as body text colours, or `#ccc` and `#ddd` both used as borders. Flag candidates for collapsing into a single token or variable.
+
+3. **Redundant padding and margin.** Nested elements where padding or margin cancels out or is applied at multiple levels unnecessarily. Note where the structure could be flattened or a single value would do.
+
+4. **Optimizations with minor visual impact.** Places where simplifying the CSS would have negligible visual change — e.g. removing a property that's already inherited, a redundant `display` declaration, or an overly specific selector.
+
+5. **Shared structure with a differing variable.** Component classes that are near-identical except for one value (e.g. two card classes identical except one has blue text and one has green). Flag these for consolidation: combine into a shared base class and extract the differing value as a modifier class or custom property, reducing duplication and file size.
+
+6. **HTML/CSS that could better use GC DS.** Markup or custom layout code that could be replaced by the GC DS grid system, spacing tokens, or utility classes — reducing custom CSS and aligning more closely with the design system.
+
+7. **`!important` declarations without a rationale comment.** Flag any `!important` that lacks an explanatory comment. `!important` is sometimes necessary to override third-party styles, but must be documented so future maintainers know why it's there and can remove it safely if the override is no longer needed.
+
+For each finding, include:
+- The class name(s) affected
+- The page(s) where those classes are visually rendered, so changes can be verified in the browser after implementation (e.g. "visible on `/en/admin/dashboard` — exec dashboard cards")
+
+## GCDS React components
+
+Prefer building UI elements with CSS shortcuts over GCDS React components. CSS shortcuts produce standard HTML elements that can be tracked with analytics; GCDS React components cannot yet. Avoid introducing new GCDS React components — existing usage can be backtracked as necessary.

--- a/docs/coding-agent-docs/design-system.md
+++ b/docs/coding-agent-docs/design-system.md
@@ -47,7 +47,7 @@ The choice between applying utility classes directly in markup vs. writing a cus
 - **Use CSS shortcuts** for simple, focused changes that need only a few styles — e.g. styling an `<a>` tag to look like a GC DS link, adding spacing to a label, setting a text colour. A handful of utility classes in the HTML is clean and sufficient.
 - **Use a custom CSS class with tokens** for design elements with many properties that need to be understood and maintained together — e.g. a chat message bubble, a dashboard stat card, a form panel. These belong in the CSS file as a named class so the full visual definition is in one place and can be reviewed as a whole. Don't split a complex component's styles between a custom class and scattered utility classes — keep it consolidated.
 
-**Typography is an exception to component bundling.** Font size adjustments (e.g. a small non-responsive label size for screen reader context) should be defined as standalone utility classes in the CSS file, not embedded inside component classes. This keeps typographic deviations minimal, named, and reusable — a card or badge can reference `.text-label-small` rather than each defining their own font size, making it easier to maintain consistency and review the full type scale in one place.
+**Typography is an exception to component bundling.** Font size adjustments (e.g. a small non-responsive label size for mobile context) should be defined as standalone utility classes in the CSS file, not embedded inside component classes. This keeps typographic deviations minimal, named, and reusable — a card or badge can reference `.text-label-small` or `.text-label-small-nr` (nr = non-responsive) rather than each defining their own font size, making it easier to maintain consistency and review the full type scale in one place. Custom sizes must be minimal and strategic — solving a specific problem, not accumulating ad hoc. They should form a coherent sub-scale that respects the GC DS sizing rhythm — stepping in consistent increments that align with the design system's existing type scale (e.g. 14, 16, 18px) rather than a scatter of arbitrary values. The smallest size in the set should have a non-responsive variant so it doesn't become unreadably small on mobile.
 
 ## GC Design System tokens
 
@@ -85,6 +85,8 @@ border-radius: 4px;
 ```
 
 Hardcoded values are acceptable when no GC DS token maps to the property, or when overriding a third-party component that requires a specific value. In those cases leave a short comment explaining why a token wasn't used so a designer can review it later.
+
+The same rhythm principle applies to colours. If additional shades are needed beyond what GC DS provides — for example, to achieve proper contrast ratios for charts or to fill out a data set with enough distinct colours — follow the GC DS colour scale's existing tone and stepping pattern rather than introducing unrelated values. A custom shade should feel like a natural step within the palette (e.g. one stop darker than an existing token) and serve a specific, justified purpose such as a hover state or accessible contrast pair.
 
 ## Dashboard chart colours
 


### PR DESCRIPTION

Added docs/coding-agent-docs/design-system.md — a new reference doc for Claude to follow when doing any UI,
  CSS, or styling work on the project.

  The doc covers:

  - The project's alignment with GC Design System (GCDS) tokens, spacing, typography, and colours, with the
  Canada.ca Specifications as the broader reference
  - CSS file structure and loading rules (global.css, admin.css, chat.css)
  - No inline styles rule
  - A styling hierarchy: utility class first, then tokens, then hardcoded values with a rationale comment
  - When to use CSS shortcuts vs custom CSS classes (shortcuts for simple, few-property changes; custom
  classes for complex components like cards or chat boxes that need all their styles in one place)
  - Typography as a utility exception — custom font sizes should be standalone reusable classes, not bundled
  inside component classes, and must follow the GC DS sizing rhythm as a coherent sub-scale
  - The same rhythm principle applied to colours — custom shades added for contrast or data sets should step
  naturally within the GC DS palette
  - GC DS token reference with a common mapping table
  - Dashboard chart colour constants
  - A note to avoid introducing new GCDS React components (existing usage can be backtracked; CSS shortcuts
  are preferred to maintain analytics tracking)
  - CSS cleanup rules: don't create new problems, don't fix old ones unless directly relevant, stay scoped to
  the file in context
  - A CSS review protocol for when a designer requests one — covering non-token values, near-duplicate
  values, redundant spacing, optimizations, consolidation opportunities, GC DS usage improvements, and
  !important declarations without rationale. Each finding includes the affected classes and pages to verify
  visually.
  
  AGENTS.md was updated to remove the CSS rules that were previously inline and replace them with a pointer
  to this new file, which is now listed in the reference docs section alongside the other coding agent docs.