### PR TITLE
Add retry for search to prevent premature close

### DIFF
--- a/agents/tools/__tests__/googleContextSearch.test.js
+++ b/agents/tools/__tests__/googleContextSearch.test.js
@@ -27,8 +27,9 @@ describe('googleContextSearch', () => {
     const error = new Error(
       'Invalid response body while trying to fetch https://customsearch.googleapis.com/customsearch/v1?cx=engine-id&q=SCIS%20definition&key=secret123&lr=lang_en: Premature close'
     );
-    listMock.mockRejectedValueOnce(error);
+    listMock.mockRejectedValue(error);
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = await contextSearch('SCIS definition', 'en');
 
@@ -42,5 +43,39 @@ describe('googleContextSearch', () => {
     expect(JSON.stringify(loggedPayload)).not.toContain('secret123');
 
     consoleSpy.mockRestore();
+  });
+
+  it('retries on a transient "Premature close" error and then succeeds', async () => {
+    const transientError = new Error(
+      'Invalid response body while trying to fetch https://customsearch.googleapis.com/customsearch/v1?key=secret123: Premature close'
+    );
+    listMock
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            { link: 'https://canada.ca/a', title: 'A', snippet: 'snippet a' },
+          ],
+        },
+      });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await contextSearch('child benefits rural', 'en');
+
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe('google');
+    expect(result.results).toContain('https://canada.ca/a');
+    expect(result.results).not.toContain('Search failed:');
+  });
+
+  it('does not retry on a non-transient error', async () => {
+    const clientError = Object.assign(new Error('Request failed'), { code: 400 });
+    listMock.mockRejectedValue(clientError);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await contextSearch('child benefits rural', 'en');
+
+    expect(listMock).toHaveBeenCalledTimes(1);
+    expect(result.results).toContain('Search failed:');
   });
 });

--- a/agents/tools/googleContextSearch.js
+++ b/agents/tools/googleContextSearch.js
@@ -22,6 +22,42 @@ function sanitizeErrorForLogging(error) {
     };
 }
 
+const MAX_SEARCH_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 250;
+
+/**
+ * Transient transport/network failures (e.g. node-fetch "Premature close" from a
+ * dropped keep-alive socket, connection resets, timeouts, 5xx) are worth retrying;
+ * client errors (4xx, missing config) are not.
+ */
+function isRetryableSearchError(error) {
+    if (!error) return false;
+
+    const status = error.status ?? error.code ?? error.response?.status;
+    if (typeof status === 'number' && status >= 500) return true;
+
+    const code = String(error.code ?? '').toUpperCase();
+    const retryableCodes = [
+        'ECONNRESET',
+        'ETIMEDOUT',
+        'ECONNREFUSED',
+        'EPIPE',
+        'ENOTFOUND',
+        'EAI_AGAIN',
+        'ERR_STREAM_PREMATURE_CLOSE',
+    ];
+    if (retryableCodes.includes(code)) return true;
+
+    const message = String(error.message ?? '').toLowerCase();
+    return (
+        message.includes('premature close') ||
+        message.includes('socket hang up') ||
+        message.includes('network socket disconnected')
+    );
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 
 /**
  * Extracts search results from Google Custom Search API response.
@@ -75,7 +111,23 @@ const contextSearch = async (query, lang) => {
             searchOptions.lr = lang.toLowerCase().startsWith('fr') ? 'lang_fr' : 'lang_en';
         }
 
-        const res = await customsearch.cse.list(searchOptions);
+        let res;
+        for (let attempt = 1; attempt <= MAX_SEARCH_ATTEMPTS; attempt++) {
+            try {
+                res = await customsearch.cse.list(searchOptions);
+                break;
+            } catch (attemptError) {
+                if (attempt >= MAX_SEARCH_ATTEMPTS || !isRetryableSearchError(attemptError)) {
+                    throw attemptError;
+                }
+                console.warn(
+                    `Google search attempt ${attempt} failed with a transient error, retrying:`,
+                    maskSecretValue(attemptError.message)
+                );
+                await sleep(RETRY_BASE_DELAY_MS * attempt);
+            }
+        }
+
         const results = res.data;
         const extractedResults = extractSearchResults(results);
         return {


### PR DESCRIPTION
  The sporadic "Premature close" blips were a transient socket condition (Google
  dropping a reused keep-alive connection), not anything we shipped — and not the undici
  bump, since this path uses node-fetch 2, not global fetch. A single failure used to
  feed "Search failed" straight to the LLM; now it transparently retries, so these blips
  should largely disappear from answers.

  One note: the backoff uses real setTimeout, so a genuine all-attempts-failure now
  takes ~750ms longer before falling back. That's the intended tradeoff, but flagging it
  in case you'd want a tighter delay.

# Summary | Résumé

> (https://github.com/cds-snc/ai-answers/issues/1467)

---
Correctness — looks solid

  - Retry loop terminates correctly. On the final attempt the if (attempt >= 
  MAX_SEARCH_ATTEMPTS ...) branch re-throws, so res can never be read while undefined —
  the loop always either breaks with a value or throws into the outer catch. No
  infinite-loop or undefined-deref path.
  - Failure fallback preserved. Exhausted retries / non-retryable errors fall through to
  the existing catch, so the masked "Search failed: …" contract is unchanged.
  - Classifier is reasonable. isRetryableSearchError covers the actual symptom (message
  "premature close", code ERR_STREAM_PREMATURE_CLOSE) plus the usual transient socket
  codes and 5xx.

  Security — no new issues, and a couple of good defensive choices

  1. No secret leakage in the new log line. The added console.warn(... 
  maskSecretValue(attemptError.message)) runs the message through the same key=
  redactor, and it logs only message (not stack), so the API key can't surface there.
  The terminal path still uses sanitizeErrorForLogging. ✅
  2. No quota/rate-limit amplification — this is the important one. Retries fire only on
  5xx and network errors. Google returns 429 / 403 rateLimitExceeded for quota
  exhaustion, which is not >= 500 and not in the code list — so a quota or rate-limit
  condition won't be retried and you won't hammer the API (or burn 3× quota) when you're
  already being throttled. Good call, intentional or not.
  3. Retry budget is bounded. Max 3 attempts, linear backoff 250ms→500ms (~750ms worst
  case). query is user/LLM-controlled, but there's no unbounded loop and no per-input
  cost multiplier beyond the fixed cap, so no DoS-by-input vector. ✅
  4. No new SSRF/injection surface — q is still passed through the googleapis client
  (URL-encoded); the URL isn't constructed from user input here.

  Worth flagging (not blocking)

  - Added latency on failures. A terminal failure now takes ~750ms longer before
  returning. contextSearch runs as a LangGraph tool call — if the node or model
  invocation has a tight timeout, slower failures could occasionally bump into it. Low
  risk given the small budget, but keep it in mind if you see search calls timing out at
  the graph level rather than just "Search failed".
  - Minor style: error.status ?? error.code ?? error.response?.status folds status and
  code into one variable; harmless because the typeof status === 'number' guard gates
  the >= 500 check, but it reads a little odd.
  - Log noise: each transient blip now emits a console.warn. That's a net positive for
  observability, just expect to see them.

  Verdict: correct, and it slightly improves the security posture (no new secret
  exposure, deliberately avoids retrying rate-limit responses). Nothing I'd block on.
