### PR TITLE
Feat/citation link aria

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -10,6 +10,7 @@ import SessionService from '../../services/SessionService.js';
 import AuthService from '../../services/AuthService.js';
 import { AVAILABLE_MODELS } from '../../config/workflows.js';
 import { safeHttpHref } from '../../utils/safeUrl.js';
+import { buildAriaLabel } from '../../utils/citationAriaLabel.js';
 // Utility functions go here, before the component
 const decodeHTMLEntities = (text) => {
   const entities = {
@@ -735,6 +736,7 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
                       href={safeHttpHref(displayUrl)}
                       target="_blank"
                       rel="noopener noreferrer"
+                      aria-label={buildAriaLabel(displayUrl, lang) || undefined}
                       className={isMobile && displayUrl.length > 40 ? 'long-url-mobile' : ''}
                       onClick={() => {
                         try {
@@ -765,7 +767,6 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
                             return (
                               <>
                                 {displayUrl}
-                                <span className="sr-only"> ({safeT('homepage.chat.input.opensInNewTab')})</span>
                                 <svg
                                   width="12"
                                   height="12"
@@ -794,7 +795,6 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
                             return (
                               <>
                                 {displayUrl}
-                                <span className="sr-only"> ({safeT('homepage.chat.input.opensInNewTab')})</span>
                                 <svg
                                   width="12"
                                   height="12"
@@ -821,7 +821,6 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
                               {beforeWrap.replace(/-/g, '\u2011')}
                               <span style={{ whiteSpace: 'nowrap' }}>
                                 {insideWrap}
-                                <span className="sr-only"> ({safeT('homepage.chat.input.opensInNewTab')})</span>
                                 <svg
                                   width="12"
                                   height="12"

--- a/src/config/citationDomainRegistry.js
+++ b/src/config/citationDomainRegistry.js
@@ -1,0 +1,17 @@
+// Bilingual registry of known GC hostnames to their department names.
+// Used by buildAriaLabel (src/utils/citationAriaLabel.js) as a Tier 2 fallback
+// when URL path segments are opaque or numeric.
+// Add entries here as new high-traffic domains appear in citation results.
+export const DOMAIN_REGISTRY = {
+  'canada.ca': {
+    en: 'Government of Canada',
+    fr: 'Gouvernement du Canada',
+  },
+  'sac-isc.gc.ca': {
+    en: 'Indigenous Services Canada',
+    fr: 'Services aux Autochtones Canada',
+  },
+
+
+
+};

--- a/src/config/citationDomainRegistry.js
+++ b/src/config/citationDomainRegistry.js
@@ -11,7 +11,8 @@ export const DOMAIN_REGISTRY = {
     en: 'Indigenous Services Canada',
     fr: 'Services aux Autochtones Canada',
   },
-
-
-
+  // Add further GC domains here as they appear in citation results.
+  // Each entry needs both 'en' and 'fr' department names.
+  // Only needed for domains with opaque or numeric URL paths — domains with
+  // readable slugs (e.g. travel.gc.ca) are handled automatically by Tier 1.
 };

--- a/src/config/citationDomainRegistry.js
+++ b/src/config/citationDomainRegistry.js
@@ -16,3 +16,21 @@ export const DOMAIN_REGISTRY = {
   // Only needed for domains with opaque or numeric URL paths — domains with
   // readable slugs (e.g. travel.gc.ca) are handled automatically by Tier 1.
 };
+
+// Slug registry — optional extension for Tier 1.
+//
+// The generic slug converter (sentence case, hyphens → spaces) works well for
+// most GC URLs but cannot recover conjunctions, commas, or acronyms that were
+// dropped when the URL slug was created. If a high-traffic slug produces a
+// misleading or incomplete label, add it here and check it in extractSlugLabel
+// before falling back to the generic conversion.
+//
+// Example entry (not yet wired up — add import + lookup in citationAriaLabel.js
+// when the first real case warrants it):
+//
+// export const SLUG_REGISTRY = {
+//   'immigration-refugees-citizenship': {
+//     en: 'Immigration, Refugees and Citizenship',
+//     fr: 'Immigration, Réfugiés et Citoyenneté',
+//   },
+// };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,8 +90,7 @@
         "loadingHint": "AI can make mistakes, always check your answer.",
         "referringPage": "Page you were on:",
         "referringURL": "Referring URL:",
-        "disclaimer": "AI can make mistakes, check the answer or ask a follow-up question below.",
-        "opensInNewTab": "opens in new tab"
+        "disclaimer": "AI can make mistakes, check the answer or ask a follow-up question below."
       },
       "textarea": {
         "title": "Ask your question here.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -90,8 +90,7 @@
         "loadingHint": "L'IA peut faire des erreurs, vérifiez toujours la réponse.",
         "referringPage": "Page où vous étiez :",
         "referringURL": "URL de référence :",
-        "disclaimer": "L'IA peut faire des erreurs, vérifiez la réponse ou posez une question de suivi ci-dessous.",
-        "opensInNewTab": "s'ouvre dans un nouvel onglet"
+        "disclaimer": "L'IA peut faire des erreurs, vérifiez la réponse ou posez une question de suivi ci-dessous."
       },
       "textarea": {
         "title": "Posez votre question ici.",

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -6,43 +6,43 @@ describe('buildAriaLabel', () => {
     it('derives label from last readable slug (en)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/benefits/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
     });
 
     it('derives label from last readable slug (fr) — sentence case', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
-      ).toBe("Gouvernement du Canada — Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet)");
+      ).toBe("Gouvernement du Canada — Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
     });
 
     it('strips locale prefix segments', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/immigration-refugees-citizenship.html', 'en')
-      ).toBe('Government of Canada — Immigration Refugees Citizenship — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Immigration Refugees Citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
     });
 
     it('strips file extension before title-casing', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/child-family-services.html', 'en')
-      ).toBe('Government of Canada — Child Family Services — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Child Family Services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
     });
 
     it('strips www. from hostname in the label', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
     });
 
     it('converts underscores to spaces', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
-      ).toBe('Government of Canada — Cpp Retirement Pension — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Cpp Retirement Pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
     });
 
     it('decodes percent-encoded path characters (C3)', () => {
       expect(
         buildAriaLabel('https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html', 'fr')
-      ).toBe("Gouvernement du Canada — Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet)");
+      ).toBe("Gouvernement du Canada — Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet) https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html");
     });
   });
 
@@ -50,13 +50,13 @@ describe('buildAriaLabel', () => {
     it('uses registry for purely numeric path (en)', () => {
       expect(
         buildAriaLabel('https://sac-isc.gc.ca/en/12345', 'en')
-      ).toBe('Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab)');
+      ).toBe('Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab) https://sac-isc.gc.ca/en/12345');
     });
 
     it('returns "Government of Canada — canada.ca" for opaque canada.ca path', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/12345', 'en')
-      ).toBe('Government of Canada — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — canada.ca (opens in new tab) https://canada.ca/en/12345');
     });
   });
 
@@ -64,19 +64,19 @@ describe('buildAriaLabel', () => {
     it('prefixes Government of Canada for unregistered gc.ca domain (en)', () => {
       expect(
         buildAriaLabel('https://travel.gc.ca/en/98765', 'en')
-      ).toBe('Government of Canada — travel.gc.ca (opens in new tab)');
+      ).toBe('Government of Canada — travel.gc.ca (opens in new tab) https://travel.gc.ca/en/98765');
     });
 
     it('prefixes Government of Canada for unregistered gc.ca domain (fr)', () => {
       expect(
         buildAriaLabel('https://voyage.gc.ca/fr/98765', 'fr')
-      ).toBe("Gouvernement du Canada — voyage.gc.ca (s'ouvre dans un nouvel onglet)");
+      ).toBe("Gouvernement du Canada — voyage.gc.ca (s'ouvre dans un nouvel onglet) https://voyage.gc.ca/fr/98765");
     });
 
     it('falls back gracefully for indigenous-language paths', () => {
       expect(
         buildAriaLabel('https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553', 'en')
-      ).toBe('Government of Canada — rcaanc-cirnac.gc.ca (opens in new tab)');
+      ).toBe('Government of Canada — rcaanc-cirnac.gc.ca (opens in new tab) https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553');
     });
   });
 
@@ -92,13 +92,13 @@ describe('buildAriaLabel', () => {
     it('defaults lang to en when omitted', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/12345')
-      ).toBe('Government of Canada — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — canada.ca (opens in new tab) https://canada.ca/en/12345');
     });
 
     it('handles protocol-relative URLs (C1)', () => {
       expect(
         buildAriaLabel('//canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
     });
   });
 });

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { buildAriaLabel } from '../citationAriaLabel.js';
+
+describe('buildAriaLabel', () => {
+  describe('Tier 1 — readable slug', () => {
+    it('derives label from last readable slug (en)', () => {
+      expect(
+        buildAriaLabel('https://www.canada.ca/en/services/benefits/employment-insurance.html', 'en')
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+    });
+
+    it('derives label from last readable slug (fr)', () => {
+      expect(
+        buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
+      ).toBe("Gouvernement du Canada — Assurance Emploi — canada.ca (s'ouvre dans un nouvel onglet)");
+    });
+
+    it('strips locale prefix segments', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/en/immigration-refugees-citizenship.html', 'en')
+      ).toBe('Government of Canada — Immigration Refugees Citizenship — canada.ca (opens in new tab)');
+    });
+
+    it('strips file extension before title-casing', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/en/services/child-family-services.html', 'en')
+      ).toBe('Government of Canada — Child Family Services — canada.ca (opens in new tab)');
+    });
+
+    it('strips www. from hostname in the label', () => {
+      expect(
+        buildAriaLabel('https://www.canada.ca/en/services/employment-insurance.html', 'en')
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+    });
+
+    it('converts underscores to spaces', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
+      ).toBe('Government of Canada — Cpp Retirement Pension — canada.ca (opens in new tab)');
+    });
+  });
+
+  describe('Tier 2 — domain registry fallback', () => {
+    it('uses registry for purely numeric path (en)', () => {
+      expect(
+        buildAriaLabel('https://sac-isc.gc.ca/en/12345', 'en')
+      ).toBe('Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab)');
+    });
+
+    it('returns "Government of Canada — canada.ca" for opaque canada.ca path', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/en/12345', 'en')
+      ).toBe('Government of Canada — canada.ca (opens in new tab)');
+    });
+  });
+
+  describe('Tier 3 — unregistered domain with opaque path', () => {
+    it('returns domain + opens-in-new-tab only (en)', () => {
+      expect(
+        buildAriaLabel('https://travel.gc.ca/en/98765', 'en')
+      ).toBe('travel.gc.ca (opens in new tab)');
+    });
+
+    it('returns domain + opens-in-new-tab only (fr)', () => {
+      expect(
+        buildAriaLabel('https://voyage.gc.ca/fr/98765', 'fr')
+      ).toBe("voyage.gc.ca (s'ouvre dans un nouvel onglet)");
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for malformed URL', () => {
+      expect(buildAriaLabel('not-a-url', 'en')).toBe('');
+    });
+
+    it('returns empty string for empty string input', () => {
+      expect(buildAriaLabel('', 'en')).toBe('');
+    });
+
+    it('defaults lang to en when omitted', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/en/12345')
+      ).toBe('Government of Canada — canada.ca (opens in new tab)');
+    });
+
+
+  });
+});

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -6,43 +6,43 @@ describe('buildAriaLabel', () => {
     it('derives label from last readable slug (en)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/benefits/employment-insurance.html', 'en')
-      ).toBe('Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
+      ).toBe('Employment insurance — canada dot ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
     });
 
     it('derives label from last readable slug (fr)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
-      ).toBe("Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
+      ).toBe("Assurance emploi — canada dot ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
     });
 
     it('strips locale prefix segments', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/immigration-refugees-citizenship.html', 'en')
-      ).toBe('Immigration refugees citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
+      ).toBe('Immigration refugees citizenship — canada dot ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
     });
 
     it('strips file extension before slug conversion', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/child-family-services.html', 'en')
-      ).toBe('Child family services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
+      ).toBe('Child family services — canada dot ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
     });
 
     it('strips www. from hostname in the label', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
+      ).toBe('Employment insurance — canada dot ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
     });
 
     it('converts underscores to spaces', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
-      ).toBe('Cpp retirement pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
+      ).toBe('Cpp retirement pension — canada dot ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
     });
 
     it('decodes percent-encoded path characters (C3)', () => {
       expect(
         buildAriaLabel('https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html', 'fr')
-      ).toBe("Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet) https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html");
+      ).toBe("Bénéfices emploi — canada dot ca (s'ouvre dans un nouvel onglet) https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html");
     });
   });
 
@@ -50,13 +50,13 @@ describe('buildAriaLabel', () => {
     it('uses registry for purely numeric path (en)', () => {
       expect(
         buildAriaLabel('https://sac-isc.gc.ca/en/12345', 'en')
-      ).toBe('Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab) https://sac-isc.gc.ca/en/12345');
+      ).toBe('Government of Canada — Indigenous Services Canada — sac-isc dot gc dot ca (opens in new tab) https://sac-isc.gc.ca/en/12345');
     });
 
     it('returns "Government of Canada — canada.ca" for opaque canada.ca path', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/12345', 'en')
-      ).toBe('Government of Canada — canada.ca (opens in new tab) https://canada.ca/en/12345');
+      ).toBe('Government of Canada — canada dot ca (opens in new tab) https://canada.ca/en/12345');
     });
   });
 
@@ -64,19 +64,19 @@ describe('buildAriaLabel', () => {
     it('prefixes Government of Canada for unregistered gc.ca domain (en)', () => {
       expect(
         buildAriaLabel('https://travel.gc.ca/en/98765', 'en')
-      ).toBe('Government of Canada — travel.gc.ca (opens in new tab) https://travel.gc.ca/en/98765');
+      ).toBe('Government of Canada — travel dot gc dot ca (opens in new tab) https://travel.gc.ca/en/98765');
     });
 
     it('prefixes Government of Canada for unregistered gc.ca domain (fr)', () => {
       expect(
         buildAriaLabel('https://voyage.gc.ca/fr/98765', 'fr')
-      ).toBe("Gouvernement du Canada — voyage.gc.ca (s'ouvre dans un nouvel onglet) https://voyage.gc.ca/fr/98765");
+      ).toBe("Gouvernement du Canada — voyage dot gc dot ca (s'ouvre dans un nouvel onglet) https://voyage.gc.ca/fr/98765");
     });
 
     it('falls back gracefully for indigenous-language paths', () => {
       expect(
         buildAriaLabel('https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553', 'en')
-      ).toBe('Government of Canada — rcaanc-cirnac.gc.ca (opens in new tab) https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553');
+      ).toBe('Government of Canada — rcaanc-cirnac dot gc dot ca (opens in new tab) https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553');
     });
   });
 
@@ -92,13 +92,13 @@ describe('buildAriaLabel', () => {
     it('defaults lang to en when omitted', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/12345')
-      ).toBe('Government of Canada — canada.ca (opens in new tab) https://canada.ca/en/12345');
+      ).toBe('Government of Canada — canada dot ca (opens in new tab) https://canada.ca/en/12345');
     });
 
     it('handles protocol-relative URLs (C1)', () => {
       expect(
         buildAriaLabel('//canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Employment insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
+      ).toBe('Employment insurance — canada dot ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
     });
   });
 });

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -6,43 +6,43 @@ describe('buildAriaLabel', () => {
     it('derives label from last readable slug (en)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/benefits/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
+      ).toBe('Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
     });
 
     it('derives label from last readable slug (fr)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
-      ).toBe("Gouvernement du Canada — Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
+      ).toBe("Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
     });
 
     it('strips locale prefix segments', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/immigration-refugees-citizenship.html', 'en')
-      ).toBe('Government of Canada — Immigration refugees citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
+      ).toBe('Immigration refugees citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
     });
 
     it('strips file extension before slug conversion', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/child-family-services.html', 'en')
-      ).toBe('Government of Canada — Child family services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
+      ).toBe('Child family services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
     });
 
     it('strips www. from hostname in the label', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
+      ).toBe('Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
     });
 
     it('converts underscores to spaces', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
-      ).toBe('Government of Canada — Cpp retirement pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
+      ).toBe('Cpp retirement pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
     });
 
     it('decodes percent-encoded path characters (C3)', () => {
       expect(
         buildAriaLabel('https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html', 'fr')
-      ).toBe("Gouvernement du Canada — Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet) https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html");
+      ).toBe("Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet) https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html");
     });
   });
 
@@ -98,7 +98,7 @@ describe('buildAriaLabel', () => {
     it('handles protocol-relative URLs (C1)', () => {
       expect(
         buildAriaLabel('//canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
+      ).toBe('Employment insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
     });
   });
 });

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -9,10 +9,10 @@ describe('buildAriaLabel', () => {
       ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
     });
 
-    it('derives label from last readable slug (fr)', () => {
+    it('derives label from last readable slug (fr) — sentence case', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
-      ).toBe("Gouvernement du Canada — Assurance Emploi — canada.ca (s'ouvre dans un nouvel onglet)");
+      ).toBe("Gouvernement du Canada — Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet)");
     });
 
     it('strips locale prefix segments', () => {
@@ -38,6 +38,12 @@ describe('buildAriaLabel', () => {
         buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
       ).toBe('Government of Canada — Cpp Retirement Pension — canada.ca (opens in new tab)');
     });
+
+    it('decodes percent-encoded path characters (C3)', () => {
+      expect(
+        buildAriaLabel('https://canada.ca/fr/services/b%C3%A9n%C3%A9fices-emploi.html', 'fr')
+      ).toBe("Gouvernement du Canada — Bénéfices emploi — canada.ca (s'ouvre dans un nouvel onglet)");
+    });
   });
 
   describe('Tier 2 — domain registry fallback', () => {
@@ -54,17 +60,23 @@ describe('buildAriaLabel', () => {
     });
   });
 
-  describe('Tier 3 — unregistered domain with opaque path', () => {
-    it('returns domain + opens-in-new-tab only (en)', () => {
+  describe('Tier 3 — unregistered GC domain', () => {
+    it('prefixes Government of Canada for unregistered gc.ca domain (en)', () => {
       expect(
         buildAriaLabel('https://travel.gc.ca/en/98765', 'en')
-      ).toBe('travel.gc.ca (opens in new tab)');
+      ).toBe('Government of Canada — travel.gc.ca (opens in new tab)');
     });
 
-    it('returns domain + opens-in-new-tab only (fr)', () => {
+    it('prefixes Government of Canada for unregistered gc.ca domain (fr)', () => {
       expect(
         buildAriaLabel('https://voyage.gc.ca/fr/98765', 'fr')
-      ).toBe("voyage.gc.ca (s'ouvre dans un nouvel onglet)");
+      ).toBe("Gouvernement du Canada — voyage.gc.ca (s'ouvre dans un nouvel onglet)");
+    });
+
+    it('falls back gracefully for indigenous-language paths', () => {
+      expect(
+        buildAriaLabel('https://www.rcaanc-cirnac.gc.ca/oji/1654808101029/1654808142553', 'en')
+      ).toBe('Government of Canada — rcaanc-cirnac.gc.ca (opens in new tab)');
     });
   });
 
@@ -83,6 +95,10 @@ describe('buildAriaLabel', () => {
       ).toBe('Government of Canada — canada.ca (opens in new tab)');
     });
 
-
+    it('handles protocol-relative URLs (C1)', () => {
+      expect(
+        buildAriaLabel('//canada.ca/en/services/employment-insurance.html', 'en')
+      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab)');
+    });
   });
 });

--- a/src/utils/__tests__/citationAriaLabel.test.js
+++ b/src/utils/__tests__/citationAriaLabel.test.js
@@ -6,10 +6,10 @@ describe('buildAriaLabel', () => {
     it('derives label from last readable slug (en)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/benefits/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
+      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html');
     });
 
-    it('derives label from last readable slug (fr) — sentence case', () => {
+    it('derives label from last readable slug (fr)', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html', 'fr')
       ).toBe("Gouvernement du Canada — Assurance emploi — canada.ca (s'ouvre dans un nouvel onglet) https://www.canada.ca/fr/services/prestations/ae/assurance-emploi.html");
@@ -18,25 +18,25 @@ describe('buildAriaLabel', () => {
     it('strips locale prefix segments', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/immigration-refugees-citizenship.html', 'en')
-      ).toBe('Government of Canada — Immigration Refugees Citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
+      ).toBe('Government of Canada — Immigration refugees citizenship — canada.ca (opens in new tab) https://canada.ca/en/immigration-refugees-citizenship.html');
     });
 
-    it('strips file extension before title-casing', () => {
+    it('strips file extension before slug conversion', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/child-family-services.html', 'en')
-      ).toBe('Government of Canada — Child Family Services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
+      ).toBe('Government of Canada — Child family services — canada.ca (opens in new tab) https://canada.ca/en/services/child-family-services.html');
     });
 
     it('strips www. from hostname in the label', () => {
       expect(
         buildAriaLabel('https://www.canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
+      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/employment-insurance.html');
     });
 
     it('converts underscores to spaces', () => {
       expect(
         buildAriaLabel('https://canada.ca/en/services/cpp_retirement_pension.html', 'en')
-      ).toBe('Government of Canada — Cpp Retirement Pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
+      ).toBe('Government of Canada — Cpp retirement pension — canada.ca (opens in new tab) https://canada.ca/en/services/cpp_retirement_pension.html');
     });
 
     it('decodes percent-encoded path characters (C3)', () => {
@@ -98,7 +98,7 @@ describe('buildAriaLabel', () => {
     it('handles protocol-relative URLs (C1)', () => {
       expect(
         buildAriaLabel('//canada.ca/en/services/employment-insurance.html', 'en')
-      ).toBe('Government of Canada — Employment Insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
+      ).toBe('Government of Canada — Employment insurance — canada.ca (opens in new tab) //canada.ca/en/services/employment-insurance.html');
     });
   });
 });

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -1,0 +1,102 @@
+import { DOMAIN_REGISTRY } from '../config/citationDomainRegistry.js';
+
+// Static bilingual strings — kept inline rather than in locale files because
+// this is a pure utility with no React context. These strings are stable; if
+// they ever need to change, update both EN and FR variants here together.
+const STRINGS = {
+  en: {
+    opensInNewTab: '(opens in new tab)',
+    govCa: 'Government of Canada',
+  },
+  fr: {
+    opensInNewTab: "(s'ouvre dans un nouvel onglet)",
+    govCa: 'Gouvernement du Canada',
+  },
+};
+
+// Path segments that carry no meaningful label information.
+// Locale prefixes (en/fr/eng/fra) are included here.
+// After stripping file extensions, SharePoint/Drupal defaults (default, index)
+// are also meaningless.
+const SKIP_SEGMENTS = new Set(['en', 'fr', 'eng', 'fra', 'default', 'index']);
+
+// Segments that look like identifiers rather than readable slugs.
+const OPAQUE_PATTERNS = [
+  /^\d+$/, // purely numeric: /12345/
+  /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i, // UUID
+  /^pages$/i, // SharePoint /Pages/
+  /^node$/i,  // Drupal /node/
+];
+
+function isOpaque(segment) {
+  return OPAQUE_PATTERNS.some(p => p.test(segment));
+}
+
+// Derives a human-readable label from URL path segments, or returns null if
+// no readable slug is found.
+function extractSlugLabel(pathname) {
+  const segments = pathname
+    .split('/')
+    .map(s => s.replace(/\.[a-z]{2,5}$/i, '')) // strip file extension
+    .filter(s => s && !SKIP_SEGMENTS.has(s.toLowerCase()))
+    .filter(s => !isOpaque(s));
+
+  if (segments.length === 0) return null;
+
+  const last = segments[segments.length - 1];
+
+  // Must contain at least one letter — rules out any remaining numeric-only values
+  if (!/[a-zA-Z]/.test(last)) return null;
+
+  // Title-case: hyphens and underscores become word separators
+  return last
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Builds a descriptive aria-label for a GC citation link.
+//
+// Tier 1 — readable slug in path:
+//   "Government of Canada — Employment Insurance — canada.ca (opens in new tab)"
+// Tier 2 — opaque/numeric path, domain in registry:
+//   "Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab)"
+// Tier 3 — unknown domain, opaque path (domain-only fallback):
+//   "unknown-dept.gc.ca (opens in new tab)"
+//
+// WCAG 2.5.3 note: the aria-label differs from the visible link text (raw URL).
+// This is intentional — 2.5.3 targets speech-input activation of named controls,
+// not descriptive overlays on URLs — but flag for accessibility audit if needed.
+export function buildAriaLabel(url, lang = 'en') {
+  const s = STRINGS[lang];
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return '';
+  }
+
+  // Strip www. prefix so registry lookups work for both www.canada.ca and canada.ca
+  const hostname = parsed.hostname.replace(/^www\./, '');
+
+  // Tier 1: readable path slug
+  const slugLabel = extractSlugLabel(parsed.pathname);
+  if (slugLabel) {
+    return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab}`;
+  }
+
+  // Tier 2: domain in registry
+  const deptName = DOMAIN_REGISTRY[hostname]?.[lang];
+  if (deptName) {
+    // When the registry name for this domain IS "Government of Canada" (canada.ca
+    // with an opaque path), avoid repeating it: "Government of Canada — canada.ca"
+    // rather than "Government of Canada — Government of Canada — canada.ca".
+    if (deptName === s.govCa) {
+      return `${s.govCa} — ${hostname} ${s.opensInNewTab}`;
+    }
+    return `${s.govCa} — ${deptName} — ${hostname} ${s.opensInNewTab}`;
+  }
+
+  // Tier 3: unknown domain, opaque path — domain + "opens in new tab" only
+  return `${hostname} ${s.opensInNewTab}`;
+}

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -42,20 +42,19 @@ function isGcDomain(hostname) {
     hostname.endsWith('.gc.ca');
 }
 
-// Converts a slug string to a readable label.
-// EN: title-case (each word capitalised — appropriate for program/page names).
-// FR: sentence case (first word only — French typographic convention).
-function toReadableLabel(slug, lang) {
+// Converts a slug string to a readable label using sentence case.
+// Casing has no effect on screen readers since this is only used in aria-label.
+// Note: if this were ever rendered as visible text (see Option 1 above), proper
+// program-name capitalisation would need to be solved — e.g. "Employment Insurance"
+// and "CPP" have official forms a slug transform cannot reliably reproduce.
+function toReadableLabel(slug) {
   const words = slug.replace(/[-_]/g, ' ');
-  if (lang === 'fr') {
-    return words.charAt(0).toUpperCase() + words.slice(1);
-  }
-  return words.replace(/\b\w/g, c => c.toUpperCase());
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 // Derives a human-readable label from URL path segments, or returns null if
 // no readable slug is found.
-function extractSlugLabel(pathname, lang) {
+function extractSlugLabel(pathname) {
   const rawSegments = pathname
     .split('/')
     .map(s => s.replace(/\.[a-z]{2,5}$/i, '')) // strip file extension
@@ -81,7 +80,7 @@ function extractSlugLabel(pathname, lang) {
   // Must contain at least one letter — rules out any remaining numeric-only values
   if (!/[a-zA-Z]/.test(last)) return null;
 
-  return toReadableLabel(last, lang);
+  return toReadableLabel(last);
 }
 
 // Builds a descriptive aria-label for a GC citation link.
@@ -140,7 +139,7 @@ export function buildAriaLabel(url, lang = 'en') {
   }
 
   // Tier 1: readable path slug
-  const slugLabel = extractSlugLabel(pathname, lang);
+  const slugLabel = extractSlugLabel(pathname);
   if (slugLabel) {
     return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab} ${url}`;
   }

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -138,10 +138,10 @@ export function buildAriaLabel(url, lang = 'en') {
     pathname = parsed.pathname;
   }
 
-  // Tier 1: readable path slug
+  // Tier 1: readable path slug — no govCa prefix, the domain already signals GC origin
   const slugLabel = extractSlugLabel(pathname);
   if (slugLabel) {
-    return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab} ${url}`;
+    return `${slugLabel} — ${hostname} ${s.opensInNewTab} ${url}`;
   }
 
   // Tier 2: domain in registry

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -87,20 +87,32 @@ function extractSlugLabel(pathname, lang) {
 // Builds a descriptive aria-label for a GC citation link.
 //
 // Tier 1 — readable slug in path:
-//   "Government of Canada — Employment Insurance — canada.ca (opens in new tab)"
+//   "Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://…"
 // Tier 2 — opaque/numeric path, domain in registry:
-//   "Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab)"
+//   "Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab) https://…"
 // Tier 3 — unregistered GC domain with opaque path:
-//   "Government of Canada — travel.gc.ca (opens in new tab)"
+//   "Government of Canada — travel.gc.ca (opens in new tab) https://…"
 // Tier 3 — non-GC domain (unexpected; upstream validation should prevent this):
-//   "example.com (opens in new tab)"
+//   "example.com (opens in new tab) https://…"
+//
+// Accessibility approach:
+//   WCAG 2.4.4 (Link Purpose): the descriptive prefix ("Government of Canada —
+//   Employment Insurance") gives screen reader users meaningful link context without
+//   reading surrounding text.
+//
+//   WCAG 2.5.3 (Label in Name): voice-control users activate links by speaking what
+//   they see. The visible text is the raw URL, so the raw URL is appended at the end
+//   of the aria-label — after "(opens in new tab)" — so voice control can match it.
+//   Screen reader users hear the descriptive prefix first and can move on before the
+//   raw URL is announced.
+//
+//   Alternative considered (Option 1): render the derived label as the visible link
+//   text and use a sr-only span for "(opens in new tab)". This satisfies both 2.4.4
+//   and 2.5.3 cleanly but hides the raw URL from sighted users, reducing destination
+//   transparency on a government service. Revisit if design requirements change.
 //
 // C7 note: Tier 1 prepends "Government of Canada" to any domain with a readable
 // slug. This relies on upstream URL validation ensuring only GC URLs reach here.
-//
-// WCAG 2.5.3 note: the aria-label differs from the visible link text (raw URL).
-// This is intentional — 2.5.3 targets speech-input activation of named controls,
-// not descriptive overlays on URLs — but flag for accessibility audit if needed.
 export function buildAriaLabel(url, lang = 'en') {
   const s = STRINGS[lang];
 
@@ -130,7 +142,7 @@ export function buildAriaLabel(url, lang = 'en') {
   // Tier 1: readable path slug
   const slugLabel = extractSlugLabel(pathname, lang);
   if (slugLabel) {
-    return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab}`;
+    return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab} ${url}`;
   }
 
   // Tier 2: domain in registry
@@ -140,9 +152,9 @@ export function buildAriaLabel(url, lang = 'en') {
     // with an opaque path), avoid repeating it: "Government of Canada — canada.ca"
     // rather than "Government of Canada — Government of Canada — canada.ca".
     if (deptName === s.govCa) {
-      return `${s.govCa} — ${hostname} ${s.opensInNewTab}`;
+      return `${s.govCa} — ${hostname} ${s.opensInNewTab} ${url}`;
     }
-    return `${s.govCa} — ${deptName} — ${hostname} ${s.opensInNewTab}`;
+    return `${s.govCa} — ${deptName} — ${hostname} ${s.opensInNewTab} ${url}`;
   }
 
   // Tier 3: always prefix GC domains with "Government of Canada" so something
@@ -150,8 +162,8 @@ export function buildAriaLabel(url, lang = 'en') {
   // not produce a readable slug — including indigenous language paths and any
   // other language prefix not covered by SKIP_SEGMENTS.
   if (isGcDomain(hostname)) {
-    return `${s.govCa} — ${hostname} ${s.opensInNewTab}`;
+    return `${s.govCa} — ${hostname} ${s.opensInNewTab} ${url}`;
   }
 
-  return `${hostname} ${s.opensInNewTab}`;
+  return `${hostname} ${s.opensInNewTab} ${url}`;
 }

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -128,6 +128,9 @@ export function buildAriaLabel(url, lang = 'en') {
 
   // Strip www. prefix so registry lookups work for both www.canada.ca and canada.ca
   const hostname = parsed.hostname.replace(/^www\./, '');
+  // Spoken form for screen readers: "canada dot ca" rather than relying on each
+  // reader's punctuation-handling to expand the dot correctly.
+  const spokenHostname = hostname.replace(/\./g, ' dot ');
 
   // C3: decode percent-encoded path characters (e.g. %C3%A9 → é) so slug labels
   // are readable. Falls back to the raw encoded form if decoding fails.
@@ -141,7 +144,7 @@ export function buildAriaLabel(url, lang = 'en') {
   // Tier 1: readable path slug — no govCa prefix, the domain already signals GC origin
   const slugLabel = extractSlugLabel(pathname);
   if (slugLabel) {
-    return `${slugLabel} — ${hostname} ${s.opensInNewTab} ${url}`;
+    return `${slugLabel} — ${spokenHostname} ${s.opensInNewTab} ${url}`;
   }
 
   // Tier 2: domain in registry
@@ -151,9 +154,9 @@ export function buildAriaLabel(url, lang = 'en') {
     // with an opaque path), avoid repeating it: "Government of Canada — canada.ca"
     // rather than "Government of Canada — Government of Canada — canada.ca".
     if (deptName === s.govCa) {
-      return `${s.govCa} — ${hostname} ${s.opensInNewTab} ${url}`;
+      return `${s.govCa} — ${spokenHostname} ${s.opensInNewTab} ${url}`;
     }
-    return `${s.govCa} — ${deptName} — ${hostname} ${s.opensInNewTab} ${url}`;
+    return `${s.govCa} — ${deptName} — ${spokenHostname} ${s.opensInNewTab} ${url}`;
   }
 
   // Tier 3: always prefix GC domains with "Government of Canada" so something
@@ -161,8 +164,8 @@ export function buildAriaLabel(url, lang = 'en') {
   // not produce a readable slug — including indigenous language paths and any
   // other language prefix not covered by SKIP_SEGMENTS.
   if (isGcDomain(hostname)) {
-    return `${s.govCa} — ${hostname} ${s.opensInNewTab} ${url}`;
+    return `${s.govCa} — ${spokenHostname} ${s.opensInNewTab} ${url}`;
   }
 
-  return `${hostname} ${s.opensInNewTab} ${url}`;
+  return `${spokenHostname} ${s.opensInNewTab} ${url}`;
 }

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -3,6 +3,9 @@ import { DOMAIN_REGISTRY } from '../config/citationDomainRegistry.js';
 // Static bilingual strings — kept inline rather than in locale files because
 // this is a pure utility with no React context. These strings are stable; if
 // they ever need to change, update both EN and FR variants here together.
+//
+// C8 note: lang is expected to be 'en' or 'fr' only — this app's two official
+// languages. Passing any other value will produce undefined behaviour.
 const STRINGS = {
   en: {
     opensInNewTab: '(opens in new tab)',
@@ -32,26 +35,53 @@ function isOpaque(segment) {
   return OPAQUE_PATTERNS.some(p => p.test(segment));
 }
 
+// Returns true for GC-owned domains (.gc.ca and canada.ca including subdomains).
+function isGcDomain(hostname) {
+  return hostname === 'canada.ca' ||
+    hostname.endsWith('.canada.ca') ||
+    hostname.endsWith('.gc.ca');
+}
+
+// Converts a slug string to a readable label.
+// EN: title-case (each word capitalised — appropriate for program/page names).
+// FR: sentence case (first word only — French typographic convention).
+function toReadableLabel(slug, lang) {
+  const words = slug.replace(/[-_]/g, ' ');
+  if (lang === 'fr') {
+    return words.charAt(0).toUpperCase() + words.slice(1);
+  }
+  return words.replace(/\b\w/g, c => c.toUpperCase());
+}
+
 // Derives a human-readable label from URL path segments, or returns null if
 // no readable slug is found.
-function extractSlugLabel(pathname) {
-  const segments = pathname
+function extractSlugLabel(pathname, lang) {
+  const rawSegments = pathname
     .split('/')
     .map(s => s.replace(/\.[a-z]{2,5}$/i, '')) // strip file extension
-    .filter(s => s && !SKIP_SEGMENTS.has(s.toLowerCase()))
-    .filter(s => !isOpaque(s));
+    .filter(s => s && !SKIP_SEGMENTS.has(s.toLowerCase()));
 
-  if (segments.length === 0) return null;
+  // If the first remaining segment looks like an unrecognized locale code
+  // (letters only, no hyphens, ≤5 chars), skip it. This covers any language
+  // prefix other than the known EN/FR variants already in SKIP_SEGMENTS —
+  // including indigenous language codes (e.g. 'oji', 'cre', 'moh', 'iku')
+  // and other languages (e.g. 'es'). In all these cases the function falls
+  // back gracefully to "Government of Canada — domain" via Tier 3, rather
+  // than surfacing the raw language code as a label.
+  const segments = (
+    rawSegments.length > 0 && /^[a-zA-Z]{1,5}$/.test(rawSegments[0])
+  ) ? rawSegments.slice(1) : rawSegments;
 
-  const last = segments[segments.length - 1];
+  const filtered = segments.filter(s => !isOpaque(s));
+
+  if (filtered.length === 0) return null;
+
+  const last = filtered[filtered.length - 1];
 
   // Must contain at least one letter — rules out any remaining numeric-only values
   if (!/[a-zA-Z]/.test(last)) return null;
 
-  // Title-case: hyphens and underscores become word separators
-  return last
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, c => c.toUpperCase());
+  return toReadableLabel(last, lang);
 }
 
 // Builds a descriptive aria-label for a GC citation link.
@@ -60,8 +90,13 @@ function extractSlugLabel(pathname) {
 //   "Government of Canada — Employment Insurance — canada.ca (opens in new tab)"
 // Tier 2 — opaque/numeric path, domain in registry:
 //   "Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab)"
-// Tier 3 — unknown domain, opaque path (domain-only fallback):
-//   "unknown-dept.gc.ca (opens in new tab)"
+// Tier 3 — unregistered GC domain with opaque path:
+//   "Government of Canada — travel.gc.ca (opens in new tab)"
+// Tier 3 — non-GC domain (unexpected; upstream validation should prevent this):
+//   "example.com (opens in new tab)"
+//
+// C7 note: Tier 1 prepends "Government of Canada" to any domain with a readable
+// slug. This relies on upstream URL validation ensuring only GC URLs reach here.
 //
 // WCAG 2.5.3 note: the aria-label differs from the visible link text (raw URL).
 // This is intentional — 2.5.3 targets speech-input activation of named controls,
@@ -69,9 +104,13 @@ function extractSlugLabel(pathname) {
 export function buildAriaLabel(url, lang = 'en') {
   const s = STRINGS[lang];
 
+  // C1: normalise protocol-relative URLs (//canada.ca/...) so new URL() can
+  // parse them — safeHttpHref allows these through but new URL() requires a scheme.
+  const normalized = typeof url === 'string' && url.startsWith('//') ? `https:${url}` : url;
+
   let parsed;
   try {
-    parsed = new URL(url);
+    parsed = new URL(normalized);
   } catch {
     return '';
   }
@@ -79,8 +118,17 @@ export function buildAriaLabel(url, lang = 'en') {
   // Strip www. prefix so registry lookups work for both www.canada.ca and canada.ca
   const hostname = parsed.hostname.replace(/^www\./, '');
 
+  // C3: decode percent-encoded path characters (e.g. %C3%A9 → é) so slug labels
+  // are readable. Falls back to the raw encoded form if decoding fails.
+  let pathname;
+  try {
+    pathname = decodeURIComponent(parsed.pathname);
+  } catch {
+    pathname = parsed.pathname;
+  }
+
   // Tier 1: readable path slug
-  const slugLabel = extractSlugLabel(parsed.pathname);
+  const slugLabel = extractSlugLabel(pathname, lang);
   if (slugLabel) {
     return `${s.govCa} — ${slugLabel} — ${hostname} ${s.opensInNewTab}`;
   }
@@ -97,6 +145,13 @@ export function buildAriaLabel(url, lang = 'en') {
     return `${s.govCa} — ${deptName} — ${hostname} ${s.opensInNewTab}`;
   }
 
-  // Tier 3: unknown domain, opaque path — domain + "opens in new tab" only
+  // Tier 3: always prefix GC domains with "Government of Canada" so something
+  // sensible is returned for unregistered domains or any URL whose path could
+  // not produce a readable slug — including indigenous language paths and any
+  // other language prefix not covered by SKIP_SEGMENTS.
+  if (isGcDomain(hostname)) {
+    return `${s.govCa} — ${hostname} ${s.opensInNewTab}`;
+  }
+
   return `${hostname} ${s.opensInNewTab}`;
 }

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -41,9 +41,9 @@ function isGcDomain(hostname) {
 
 // Converts a slug string to a readable label using sentence case.
 // Casing has no effect on screen readers since this is only used in aria-label.
-// Note: if this were ever rendered as visible text (see Option 1 above), proper
-// program-name capitalisation would need to be solved — e.g. "Employment Insurance"
-// and "CPP" have official forms a slug transform cannot reliably reproduce.
+// If this label is ever rendered as visible text, program-name capitalisation
+// would need to be revisited — slugs cannot reliably reproduce official forms
+// like "Employment Insurance" or "CPP".
 function toReadableLabel(slug) {
   const words = slug.replace(/[-_]/g, ' ');
   return words.charAt(0).toUpperCase() + words.slice(1);
@@ -83,7 +83,7 @@ function extractSlugLabel(pathname) {
 // Builds a descriptive aria-label for a GC citation link.
 //
 // Tier 1 — readable slug in path:
-//   "Government of Canada — Employment Insurance — canada.ca (opens in new tab) https://…"
+//   "Employment insurance — canada dot ca (opens in new tab) https://…"
 // Tier 2 — opaque/numeric path, domain in registry:
 //   "Government of Canada — Indigenous Services Canada — sac-isc.gc.ca (opens in new tab) https://…"
 // Tier 3 — unregistered GC domain with opaque path:
@@ -107,13 +107,11 @@ function extractSlugLabel(pathname) {
 //   and 2.5.3 cleanly but hides the raw URL from sighted users, reducing destination
 //   transparency on a government service. Revisit if design requirements change.
 //
-// C7 note: Tier 1 prepends "Government of Canada" to any domain with a readable
-// slug. This relies on upstream URL validation ensuring only GC URLs reach here.
 export function buildAriaLabel(url, lang = 'en') {
   const s = STRINGS[lang];
 
-  // C1: normalise protocol-relative URLs (//canada.ca/...) so new URL() can
-  // parse them — safeHttpHref allows these through but new URL() requires a scheme.
+  // Normalise protocol-relative URLs (//canada.ca/...) so new URL() can parse
+  // them — safeHttpHref allows these through but new URL() requires a scheme.
   const normalized = typeof url === 'string' && url.startsWith('//') ? `https:${url}` : url;
 
   let parsed;
@@ -129,7 +127,7 @@ export function buildAriaLabel(url, lang = 'en') {
   // reader's punctuation-handling to expand the dot correctly.
   const spokenHostname = hostname.replace(/\./g, ' dot ');
 
-  // C3: decode percent-encoded path characters (e.g. %C3%A9 → é) so slug labels
+  // Decode percent-encoded path characters (e.g. %C3%A9 → é) so slug labels
   // are readable. Falls back to the raw encoded form if decoding fails.
   let pathname;
   try {

--- a/src/utils/citationAriaLabel.js
+++ b/src/utils/citationAriaLabel.js
@@ -3,9 +3,6 @@ import { DOMAIN_REGISTRY } from '../config/citationDomainRegistry.js';
 // Static bilingual strings — kept inline rather than in locale files because
 // this is a pure utility with no React context. These strings are stable; if
 // they ever need to change, update both EN and FR variants here together.
-//
-// C8 note: lang is expected to be 'en' or 'fr' only — this app's two official
-// languages. Passing any other value will produce undefined behaviour.
 const STRINGS = {
   en: {
     opensInNewTab: '(opens in new tab)',


### PR DESCRIPTION
<html><head></head><body><h1>URL-derived accessible aria-label for citation links</h1>
<h2>Summary</h2>
<p>Adds a <code>buildAriaLabel</code> utility that derives a descriptive accessible name from a citation URL and sets it as the <code>aria-label</code> on citation <code>&lt;a&gt;</code> elements. The old <code>&lt;span class="sr-only"&gt;(opens in new tab)&lt;/span&gt;</code> spans are removed — "opens in new tab" is now part of the <code>aria-label</code>.</p>
<p><strong>Example output:</strong></p>
<pre><code>"Employment insurance — canada.ca (opens in new tab) https://www.canada.ca/en/services/benefits/employment-insurance.html"
</code></pre>
<p>The label has three parts, in order:</p>
<ol>
<li>Descriptive prefix (for screen reader context)</li>
<li>"Opens in new tab" notice</li>
<li>Raw URL appended at the end (so voice control users can activate the link by speaking the URL they see)</li>
</ol>
<hr>
<h2>Accessibility coverage</h2>

Criterion | How it's addressed
-- | --
WCAG 2.4.4 Link Purpose | Descriptive prefix ("Employment insurance - canada.ca") gives screen reader users meaningful context before the full URL
WCAG 2.5.3 Label in Name | Raw URL appended after "(opens in new tab)" — voice control can match it; screen reader users hear the description first and move on if they don't want to hear the full URL


<hr>
<h2>Label derivation — 3-tier fallback</h2>
<p><strong>Tier 1 — Readable slug</strong>
Extracts the last meaningful path segment and sentence-cases it. Handles percent-encoded characters, file extensions, locale prefixes, UUIDs, and indigenous-language path codes.</p>
<p><strong>Tier 2 — Domain registry</strong>
For opaque or numeric paths on known GC domains (e.g. <code>sac-isc.gc.ca</code>), falls back to a maintained bilingual registry of department names.</p>
<p><strong>Tier 3 — GC domain fallback</strong>
Any <code>.gc.ca</code> or <code>canada.ca</code> URL that doesn't match tiers 1–2 gets "Government of Canada — hostname". For example: "Government of Canada — travel.gc.ca" </p>
<hr>
<h2>Other fixes included</h2>
<ul>
<li><strong>Protocol-relative URLs</strong> (<code>//canada.ca/...</code>) — normalized to <code>https:</code> before parsing so <code>buildAriaLabel</code> doesn't silently drop the new-tab announcement</li>
<li><strong>Percent-encoded paths</strong> — <code>decodeURIComponent</code> applied before slug extraction so French accented characters render correctly</li>
<li><strong>Dead locale key</strong> — <code>homepage.chat.input.opensInNewTab</code> removed from <code>en.json</code> and <code>fr.json</code> (no remaining usages)</li>
</ul></body></html>