### PR TITLE
fix: harmful included in count

### DIFF
--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -310,6 +310,7 @@ const ExecDashboard = ({ lang = 'en' }) => {
               data={blockedBarData}
               height={Math.max(240, blockedBarData.length * 60)}
               lang={lang}
+              yAxisWidth={220}
               tooltipContent={BlockedBarTooltip}
               noDataLabel={t('blockedQueries.noData')}
             />

--- a/src/components/admin/ExecDashboard.js
+++ b/src/components/admin/ExecDashboard.js
@@ -65,10 +65,12 @@ const ExecDashboard = ({ lang = 'en' }) => {
   const expertTotal = metrics.expertScored?.total?.total || 0;
   const evaluatedPct = expertTotal > 0 && totalQuestions > 0 ? Math.round((expertTotal / totalQuestions) * 100) : 0;
 
-  // Accuracy donut (expert + AI evals combined; only hasError counts against accuracy)
+  // Accuracy donut (expert + AI evals combined; hasError AND harmful count against accuracy —
+  // they are mutually exclusive categories, so harmful must be added separately)
   const aiTotal = metrics.aiScored?.total?.total || 0;
   const evalTotal = expertTotal + aiTotal;
-  const hasError = (metrics.expertScored?.hasError?.total || 0) + (metrics.aiScored?.hasError?.total || 0);
+  const hasError = (metrics.expertScored?.hasError?.total || 0) + (metrics.aiScored?.hasError?.total || 0)
+    + (metrics.expertScored?.harmful?.total || 0) + (metrics.aiScored?.harmful?.total || 0);
   const accuracyPct = evalTotal > 0 ? 100 - Math.round((hasError / evalTotal) * 100) : null;
   const accuracyDonutData = evalTotal > 0 ? [
     { name: t('execDashboard.charts.accurate'), value: evalTotal - hasError },

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -58,13 +58,14 @@ const PartnerDashboard = ({ lang = 'en' }) => {
     );
   };
 
-  // Accuracy rate (MetricsDashboard definition): only "has answer error" counts
-  // against accuracy — citation issues / needs-improvement scores do not.
-  // Total accuracy combines expert + AI evals; the breakdown is by language.
+  // Accuracy rate: "has answer error" AND "harmful" count against accuracy —
+  // they are mutually exclusive categories, so harmful must be added separately.
+  // Citation issues / needs-improvement do not affect accuracy. Total accuracy
+  // combines expert + AI evals; the breakdown is by language.
   const accuracyOf = (total, hasError) => (total > 0 ? 100 - Math.round((hasError / total) * 100) : null);
-  const expertHasError = metrics.expertScored?.hasError?.total || 0;
+  const expertHasError = (metrics.expertScored?.hasError?.total || 0) + (metrics.expertScored?.harmful?.total || 0);
   const aiTotal = metrics.aiScored?.total?.total || 0;
-  const aiHasError = metrics.aiScored?.hasError?.total || 0;
+  const aiHasError = (metrics.aiScored?.hasError?.total || 0) + (metrics.aiScored?.harmful?.total || 0);
   const totalAccuracy = accuracyOf(expertTotal + aiTotal, expertHasError + aiHasError);
 
   // EN/FR accuracy breakdown (expert + AI per language), shown only when each
@@ -72,8 +73,12 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   // misleading, so below the threshold both are left blank.
   const enEvalTotal = (metrics.expertScored?.total?.en || 0) + (metrics.aiScored?.total?.en || 0);
   const frEvalTotal = (metrics.expertScored?.total?.fr || 0) + (metrics.aiScored?.total?.fr || 0);
-  const enAccuracy = accuracyOf(enEvalTotal, (metrics.expertScored?.hasError?.en || 0) + (metrics.aiScored?.hasError?.en || 0));
-  const frAccuracy = accuracyOf(frEvalTotal, (metrics.expertScored?.hasError?.fr || 0) + (metrics.aiScored?.hasError?.fr || 0));
+  const enAccuracy = accuracyOf(enEvalTotal,
+    (metrics.expertScored?.hasError?.en || 0) + (metrics.aiScored?.hasError?.en || 0)
+    + (metrics.expertScored?.harmful?.en || 0) + (metrics.aiScored?.harmful?.en || 0));
+  const frAccuracy = accuracyOf(frEvalTotal,
+    (metrics.expertScored?.hasError?.fr || 0) + (metrics.aiScored?.hasError?.fr || 0)
+    + (metrics.expertScored?.harmful?.fr || 0) + (metrics.aiScored?.harmful?.fr || 0));
   const showAccuracyByLang = enEvalTotal > 10 && frEvalTotal > 10;
 
   // Harmful + content issues (expert evaluations only). Always shown, even at 0.

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -413,6 +413,7 @@ const PartnerDashboard = ({ lang = 'en' }) => {
               data={blockedBarData}
               height={Math.max(240, blockedBarData.length * 60)}
               lang={lang}
+              yAxisWidth={220}
               tooltipContent={BlockedBarTooltip}
               noDataLabel={t('blockedQueries.noData')}
             />

--- a/src/components/admin/dashboard/HBarCard.js
+++ b/src/components/admin/dashboard/HBarCard.js
@@ -14,9 +14,9 @@ import { formatNumber, formatPercent } from '../../../utils/numberFormat.js';
 const HBarCard = ({ title, subtitle, data, height, colour = COLOURS.brand, percent = false, noDataLabel = '', lang = 'en', tooltipContent = null, yAxisWidth = 160, yAxisTextAlign = 'left', marginLeft = 8 }) => {
   const fmtVal = (v) => (percent ? formatPercent(v, lang) : formatNumber(v, lang));
   const lineH = 18;
-  const CHAR_PX = 7.0;
+  const CHAR_PX = 8.0;
   const YAXIS_W = yAxisWidth;
-  const charsPerLine = Math.floor((YAXIS_W - 8) / CHAR_PX); // ~20 chars
+  const charsPerLine = Math.floor((YAXIS_W - 8) / CHAR_PX);
   const wrapLines = (text) => {
     const words = (text || '').split(' ');
     const lines = [];
@@ -33,7 +33,7 @@ const HBarCard = ({ title, subtitle, data, height, colour = COLOURS.brand, perce
   const maxLines = allWrapped.length > 0 ? Math.max(...allWrapped.map(ls => ls.length)) : 1;
   const maxLineLen = allWrapped.length > 0 ? Math.max(...allWrapped.flatMap(ls => ls.map(l => l.length))) : 10;
   const barPx = Math.max(40, maxLines * lineH + 16);
-  const xOffset = Math.min(maxLineLen * CHAR_PX + 8, YAXIS_W - 4);
+  const xOffset = Math.min(maxLineLen * CHAR_PX + 8, YAXIS_W - 6);
   // When right-aligned, only allocate as much axis space as the text needs.
   const effectiveYAxisWidth = yAxisTextAlign === 'right'
     ? Math.min(YAXIS_W, maxLineLen * CHAR_PX + 16)

--- a/src/utils/dashboard/feedbackBreakdown.js
+++ b/src/utils/dashboard/feedbackBreakdown.js
@@ -61,21 +61,25 @@ export const buildQualityBarData = (expertScored, aiScored, t) => {
   const pct = (n) => Math.round((n / total) * 100);
   // Fixed order = top→bottom in the horizontal bar (recharts renders the first
   // row at the top). "Has answer error" is intentionally last so it always
-  // sits at the bottom of the chart. Harmful is excluded here — it's a subset
-  // of "has answer error" and lives on its own harmful/content-issues card.
+  // sits at the bottom of the chart. Harmful is a separate, mutually exclusive
+  // category (higher priority than hasError), so it must be added to the
+  // hasError bar explicitly — it does not fall through to hasError on its own.
   return [
     { key: 'correct',          colour: COLOURS.correct },
     { key: 'needsImprovement', colour: COLOURS.needsImprovement, stroke: COLOURS.qualityBorder },
     { key: 'hasCitationError', colour: COLOURS.hasCitationError, stroke: COLOURS.qualityBorder },
     { key: 'hasError',         colour: COLOURS.hasError },
   ]
-    .map(({ key, colour, stroke }) => ({
-      name: t(`metrics.dashboard.qualityBar.${key}`),
-      value: pct(sum(key)),
-      colour,
-      ...(stroke && { stroke, strokeWidth: 1 }),
-      count: sum(key),
-    }))
+    .map(({ key, colour, stroke }) => {
+      const count = sum(key) + (key === 'hasError' ? sum('harmful') : 0);
+      return {
+        name: t(`metrics.dashboard.qualityBar.${key}`),
+        value: pct(count),
+        colour,
+        ...(stroke && { stroke, strokeWidth: 1 }),
+        count,
+      };
+    })
     .filter(d => d.count > 0);
 };
 

--- a/src/utils/dashboard/feedbackBreakdown.js
+++ b/src/utils/dashboard/feedbackBreakdown.js
@@ -60,22 +60,25 @@ export const buildQualityBarData = (expertScored, aiScored, t) => {
   if (total <= 0) return [];
   const pct = (n) => Math.round((n / total) * 100);
   // Fixed order = top→bottom in the horizontal bar (recharts renders the first
-  // row at the top). "Has answer error" is intentionally last so it always
-  // sits at the bottom of the chart. Harmful is excluded here — it is a
-  // separate mutually exclusive category that lives on its own safety card.
+  // row at the top). Harmful is a mutually exclusive category (higher priority
+  // than hasError), so it is folded into the hasError bar explicitly — it does
+  // not fall through to hasError on its own.
   return [
     { key: 'correct',          colour: COLOURS.correct },
     { key: 'needsImprovement', colour: COLOURS.needsImprovement, stroke: COLOURS.qualityBorder },
     { key: 'hasCitationError', colour: COLOURS.hasCitationError, stroke: COLOURS.qualityBorder },
     { key: 'hasError',         colour: COLOURS.hasError },
   ]
-    .map(({ key, colour, stroke }) => ({
-      name: t(`metrics.dashboard.qualityBar.${key}`),
-      value: pct(sum(key)),
-      colour,
-      ...(stroke && { stroke, strokeWidth: 1 }),
-      count: sum(key),
-    }))
+    .map(({ key, colour, stroke }) => {
+      const count = sum(key) + (key === 'hasError' ? sum('harmful') : 0);
+      return {
+        name: t(`metrics.dashboard.qualityBar.${key}`),
+        value: pct(count),
+        colour,
+        ...(stroke && { stroke, strokeWidth: 1 }),
+        count,
+      };
+    })
     .filter(d => d.count > 0);
 };
 

--- a/src/utils/dashboard/feedbackBreakdown.js
+++ b/src/utils/dashboard/feedbackBreakdown.js
@@ -61,25 +61,21 @@ export const buildQualityBarData = (expertScored, aiScored, t) => {
   const pct = (n) => Math.round((n / total) * 100);
   // Fixed order = top→bottom in the horizontal bar (recharts renders the first
   // row at the top). "Has answer error" is intentionally last so it always
-  // sits at the bottom of the chart. Harmful is a separate, mutually exclusive
-  // category (higher priority than hasError), so it must be added to the
-  // hasError bar explicitly — it does not fall through to hasError on its own.
+  // sits at the bottom of the chart. Harmful is excluded here — it is a
+  // separate mutually exclusive category that lives on its own safety card.
   return [
     { key: 'correct',          colour: COLOURS.correct },
     { key: 'needsImprovement', colour: COLOURS.needsImprovement, stroke: COLOURS.qualityBorder },
     { key: 'hasCitationError', colour: COLOURS.hasCitationError, stroke: COLOURS.qualityBorder },
     { key: 'hasError',         colour: COLOURS.hasError },
   ]
-    .map(({ key, colour, stroke }) => {
-      const count = sum(key) + (key === 'hasError' ? sum('harmful') : 0);
-      return {
-        name: t(`metrics.dashboard.qualityBar.${key}`),
-        value: pct(count),
-        colour,
-        ...(stroke && { stroke, strokeWidth: 1 }),
-        count,
-      };
-    })
+    .map(({ key, colour, stroke }) => ({
+      name: t(`metrics.dashboard.qualityBar.${key}`),
+      value: pct(sum(key)),
+      colour,
+      ...(stroke && { stroke, strokeWidth: 1 }),
+      count: sum(key),
+    }))
     .filter(d => d.count > 0);
 };
 

--- a/src/utils/dashboard/feedbackBreakdown.test.js
+++ b/src/utils/dashboard/feedbackBreakdown.test.js
@@ -43,9 +43,10 @@ describe('buildQualityBarData', () => {
     ]);
   });
 
-  it('keeps rare categories that round below 1% (count > 0) and never includes harmful', () => {
+  it('keeps rare categories that round below 1% (count > 0) and folds harmful into hasError', () => {
     // 1 citation issue out of 500 = 0.2% → rounds to 0 but stays because count > 0.
-    // harmful is excluded from this chart — it lives on its own safety card.
+    // harmful is a mutually exclusive category (higher priority than hasError) so it
+    // is folded into the hasError bar — harmful never gets its own bar.
     const expert = scored({ total: 500, correct: 499, hasCitationError: 1, harmful: 5 });
     const rows = buildQualityBarData(expert, scored({ total: 0 }), t);
     const names = rows.map((r) => r.name);
@@ -54,6 +55,9 @@ describe('buildQualityBarData', () => {
     expect(names).not.toContain('needsImprovement');
     const citation = rows.find((r) => r.name === 'hasCitationError');
     expect(citation).toMatchObject({ value: 0, count: 1, colour: COLOURS.hasCitationError });
+    // harmful (5) folds into hasError bar (0 hasError + 5 harmful = 5)
+    const errorBar = rows.find((r) => r.name === 'hasError');
+    expect(errorBar).toMatchObject({ count: 5, colour: COLOURS.hasError });
   });
 });
 

--- a/src/utils/dashboard/feedbackBreakdown.test.js
+++ b/src/utils/dashboard/feedbackBreakdown.test.js
@@ -43,10 +43,9 @@ describe('buildQualityBarData', () => {
     ]);
   });
 
-  it('keeps rare categories that round below 1% (count > 0) and folds harmful into hasError', () => {
+  it('keeps rare categories that round below 1% (count > 0) and never includes harmful', () => {
     // 1 citation issue out of 500 = 0.2% → rounds to 0 but stays because count > 0.
-    // harmful is a mutually exclusive category (higher priority than hasError) so it
-    // must be folded into the hasError bar explicitly — harmful never gets its own bar.
+    // harmful is excluded from this chart — it lives on its own safety card.
     const expert = scored({ total: 500, correct: 499, hasCitationError: 1, harmful: 5 });
     const rows = buildQualityBarData(expert, scored({ total: 0 }), t);
     const names = rows.map((r) => r.name);
@@ -55,9 +54,6 @@ describe('buildQualityBarData', () => {
     expect(names).not.toContain('needsImprovement');
     const citation = rows.find((r) => r.name === 'hasCitationError');
     expect(citation).toMatchObject({ value: 0, count: 1, colour: COLOURS.hasCitationError });
-    // harmful (5) folds into hasError bar (0 hasError + 5 harmful = 5)
-    const errorBar = rows.find((r) => r.name === 'hasError');
-    expect(errorBar).toMatchObject({ count: 5, colour: COLOURS.hasError });
   });
 });
 

--- a/src/utils/dashboard/feedbackBreakdown.test.js
+++ b/src/utils/dashboard/feedbackBreakdown.test.js
@@ -43,9 +43,10 @@ describe('buildQualityBarData', () => {
     ]);
   });
 
-  it('keeps rare categories that round below 1% (count > 0) and never includes harmful', () => {
+  it('keeps rare categories that round below 1% (count > 0) and folds harmful into hasError', () => {
     // 1 citation issue out of 500 = 0.2% → rounds to 0 but stays because count > 0.
-    // harmful is a subset of "has answer error" and must not appear as its own bar.
+    // harmful is a mutually exclusive category (higher priority than hasError) so it
+    // must be folded into the hasError bar explicitly — harmful never gets its own bar.
     const expert = scored({ total: 500, correct: 499, hasCitationError: 1, harmful: 5 });
     const rows = buildQualityBarData(expert, scored({ total: 0 }), t);
     const names = rows.map((r) => r.name);
@@ -54,6 +55,9 @@ describe('buildQualityBarData', () => {
     expect(names).not.toContain('needsImprovement');
     const citation = rows.find((r) => r.name === 'hasCitationError');
     expect(citation).toMatchObject({ value: 0, count: 1, colour: COLOURS.hasCitationError });
+    // harmful (5) folds into hasError bar (0 hasError + 5 harmful = 5)
+    const errorBar = rows.find((r) => r.name === 'hasError');
+    expect(errorBar).toMatchObject({ count: 5, colour: COLOURS.hasError });
   });
 });
 


### PR DESCRIPTION
Root cause: harmful and hasError are mutually exclusive priority categories — when an evaluation is flagged as
  harmful, it's stored as harmful and never falls through to hasError. The accuracy calculations were only
  counting hasError, so harmful answers counted as zero errors, producing a falsely high accuracy rate.

  Three places fixed:

  1. ExecDashboard.js (accuracy donut): harmful is now added to the hasError count used for both the accuracy
  percentage and the donut chart.
  2. PartnerDashboard.js (accuracy rate + EN/FR breakdown): expertHasError and aiHasError now include harmful
  totals, for both the overall accuracy rate and the per-language breakdown.
  3. feedbackBreakdown.js (Answer quality bar in Partner dashboard): harmful is folded into the hasError bar so
  the bars sum to 100%. The Safety metrics section still shows harmful as its own dedicated KPI card for
  visibility.
  
  
Additional chart fix:
- fixed text clipping in charts