### PR TITLE
fix: remove nested <main> landmark on 16 pages

### DIFF
--- a/src/pages/AdminPage.js
+++ b/src/pages/AdminPage.js
@@ -33,7 +33,7 @@ const AdminPage = ({ lang = 'en' }) => {
   const isPartner = currentUser?.role === 'partner';
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">
         {isPartner
           ? t('admin.partnerTitle', 'AI Answers Partner Dashboard')

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -125,7 +125,7 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
   ]), [formatDate, t]);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('admin.autoEvalDashboard.title', 'Auto-Evaluation dashboard')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>

--- a/src/pages/BatchPage.js
+++ b/src/pages/BatchPage.js
@@ -113,7 +113,7 @@ const BatchPage = ({ lang = 'en' }) => {
   };
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('batch.title')}</h1>
 
       <nav className="mb-400">

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -283,7 +283,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
   ]), [formatDate, truncateUrl, t]);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('admin.chatDashboard.title', 'Chat dashboard')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>

--- a/src/pages/ChatViewer.js
+++ b/src/pages/ChatViewer.js
@@ -85,7 +85,7 @@ const ChatViewer = ({ lang = 'en' }) => {
 
   return (
     <>
-      <GcdsContainer layout="page" tag="main" className="mb-600">
+      <GcdsContainer layout="page" className="mb-600">
         <h1 className="mb-400">{t('logging.title')}</h1>
         <nav className="mb-400">
           <GcdsText>

--- a/src/pages/ConnectivityPage.js
+++ b/src/pages/ConnectivityPage.js
@@ -155,7 +155,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
     }, []);
 
     return (
-        <GcdsContainer layout="page" tag="main" className="mb-600">
+        <GcdsContainer layout="page" className="mb-600">
             <h1 className="mb-400">
                 {t('connectivity.title', 'Service Connectivity Dashboard')}
             </h1>

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -149,7 +149,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
   ]), [formatDate, t]);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('admin.evalDashboard.title', 'Evaluation dashboard')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>

--- a/src/pages/ExecDashboardPage.js
+++ b/src/pages/ExecDashboardPage.js
@@ -8,7 +8,7 @@ const ExecDashboardPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-200">{t('execDashboard.title')}</h1>
 
       <GcdsText className="mb-400">{t('execDashboard.description')}</GcdsText>

--- a/src/pages/MetricsPage.js
+++ b/src/pages/MetricsPage.js
@@ -10,7 +10,7 @@ const MetricsPage = ({ lang = 'en' }) => {
   const { language } = usePageContext();
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('metrics.title')}</h1>
       
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>

--- a/src/pages/PartnerDashboardPage.js
+++ b/src/pages/PartnerDashboardPage.js
@@ -8,7 +8,7 @@ const PartnerDashboardPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('partnerDashboard.title')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>

--- a/src/pages/PublicEvalPage.js
+++ b/src/pages/PublicEvalPage.js
@@ -36,7 +36,7 @@ const PublicEvalPage = ({ lang: propLang }) => {
   };
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('admin.publicEval.title', 'Public Evaluation')}</h1>
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
         <GcdsText>

--- a/src/pages/ScenarioOverridesPage.js
+++ b/src/pages/ScenarioOverridesPage.js
@@ -81,7 +81,7 @@ class PageErrorBoundary extends React.Component {
   render() {
     if (this.state.hasError) {
       return (
-        <GcdsContainer layout="page" tag="main" className="mb-600">
+        <GcdsContainer layout="page" className="mb-600">
           <h1 className="mb-400">{this.props.t ? this.props.t('scenarioOverrides.title', 'Scenario overrides') : 'Scenario overrides'}</h1>
           <p style={{ color: '#d3080c' }}>{this.props.t ? this.props.t('scenarioOverrides.error.fallback', 'An error occurred while loading this page.') : 'An error occurred while loading this page.'}</p>
           <p>{this.state.error?.toString?.() || ''}</p>
@@ -300,7 +300,7 @@ const ScenarioOverridesPage = ({ lang = 'en' }) => {
 
   return (
     <PageErrorBoundary t={t}>
-      <GcdsContainer layout="page" tag="main" className="mb-600">
+      <GcdsContainer layout="page" className="mb-600">
         {/* no overlay styles needed in simplified UI */}
         <h1 className="mb-400">{pageTitle}</h1>
         <nav className="mb-400">

--- a/src/pages/SessionPage.js
+++ b/src/pages/SessionPage.js
@@ -54,7 +54,7 @@ const SessionPage = ({ lang: propLang }) => {
   }, [fetchSessions]);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('admin.session.title', 'Sessions')}</h1>
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
         <GcdsText>

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -574,7 +574,7 @@ const SettingsPage = ({ lang = 'en' }) => {
   };
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('settings.title')}</h1>
       <nav className="mb-400">
         <a href={`/${lang}/admin`}>{t('common.backToAdmin')}</a>

--- a/src/pages/TechnicalMetricsPage.js
+++ b/src/pages/TechnicalMetricsPage.js
@@ -8,7 +8,7 @@ const TechnicalMetricsPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
 
   return (
-    <GcdsContainer layout="page" tag="main" className="mb-600">
+    <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('technicalMetrics.title')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>

--- a/src/pages/UsersPage.js
+++ b/src/pages/UsersPage.js
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import DataTable from 'datatables.net-react';
 import 'datatables.net-dt/css/dataTables.dataTables.css';
 import DT from 'datatables.net-dt';
-import { GcdsButton, GcdsLink, GcdsText } from '@gcds-core/components-react';
+import { GcdsButton, GcdsContainer, GcdsLink, GcdsText } from '@gcds-core/components-react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { dataTableLanguage } from '../utils/dataTableLanguage.js';
 import UserService from '../services/UserService.js';
@@ -242,8 +242,8 @@ const UsersPage = ({ lang }) => {
     },
   ];
   return (
-    <div className="container mt-4">
-      <h1>{t('users.title')}</h1>
+    <GcdsContainer layout="page" className="mb-600">
+      <h1 className="mb-400">{t('users.title')}</h1>
 
       <nav className="mb-400">
         <GcdsText>
@@ -297,7 +297,7 @@ const UsersPage = ({ lang }) => {
           },
         }}
       />
-    </div>
+    </GcdsContainer>
   );
 };
 

--- a/src/pages/experimental/ExperimentalAnalysisPage.js
+++ b/src/pages/experimental/ExperimentalAnalysisPage.js
@@ -377,7 +377,7 @@ export default function ExperimentalAnalysisPage({ lang = 'en' }) {
     const selectedAnalyzer = analyzers.find(a => a.id === selectedAnalyzerId);
 
     return (
-        <GcdsContainer layout="page" tag="main" className="mb-600">
+        <GcdsContainer layout="page" className="mb-600">
             <header className="mb-400">
                 <GcdsHeading tag="h1">
                     {selectedDataset?.name || t('experimental.analysis.title')}

--- a/src/pages/experimental/ExperimentalDatasetsPage.js
+++ b/src/pages/experimental/ExperimentalDatasetsPage.js
@@ -114,7 +114,7 @@ export default function ExperimentalDatasetsPage({ lang = 'en' }) {
         };
 
     return (
-        <GcdsContainer layout="page" tag="main" className="mb-600">
+        <GcdsContainer layout="page" className="mb-600">
             <GcdsHeading tag="h1">{t('experimental.datasets.title')}</GcdsHeading>
             <div className="mb-400">
                 <GcdsLink href={`/${lang}/admin`}>


### PR DESCRIPTION
App.js already wraps every routed page in <main id="main-content">.