### PR TITLE
feat: language attr detection for answers

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -12,6 +12,7 @@ import { AVAILABLE_MODELS } from '../../config/workflows.js';
 import { safeHttpHref } from '../../utils/safeUrl.js';
 import { buildAriaLabel } from '../../utils/citationAriaLabel.js';
 import { getCitationUrl } from '../../utils/getCitationUrl.js';
+import { getAnswerLanguage, toLangAttr } from '../../utils/answerLanguage.js';
 // Utility functions go here, before the component
 const decodeHTMLEntities = (text) => {
   const entities = {
@@ -712,8 +713,9 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     const displayUrl = getCitationUrl(message.interaction);
     // interactionId is the message id (client-side userMessageId)
     const interactionId = messageId || message.interaction?.interactionId || message.interaction?.userMessageId || '';
+    const answerLang = toLangAttr(getAnswerLanguage(message.interaction));
     return (
-      <div className="ai-message-content">
+      <div className="ai-message-content" lang={answerLang}>
         {contentArr.map((content, index) => {
           // If using paragraphs, split into sentences; if using sentences, just display
           const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useTranslations, translate } from '../../hooks/useTranslations.js';
+import { useTranslations } from '../../hooks/useTranslations.js';
 import { usePageContext, DEPARTMENT_MAPPINGS } from '../../hooks/usePageParam.js';
 import ChatInterface from './ChatInterface.js';
 import { ChatWorkflowService, RedactionError, ShortQueryValidation } from '../../services/ChatWorkflowService.js';
@@ -12,7 +12,7 @@ import { AVAILABLE_MODELS } from '../../config/workflows.js';
 import { safeHttpHref } from '../../utils/safeUrl.js';
 import { buildAriaLabel } from '../../utils/citationAriaLabel.js';
 import { getCitationUrl } from '../../utils/getCitationUrl.js';
-import { getAnswerLanguage, toLangAttr, resolveChromeLang } from '../../utils/answerLanguage.js';
+import { getAnswerLanguage, toLangAttr } from '../../utils/answerLanguage.js';
 // Utility functions go here, before the component
 const decodeHTMLEntities = (text) => {
   const entities = {
@@ -714,8 +714,6 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     // interactionId is the message id (client-side userMessageId)
     const interactionId = messageId || message.interaction?.interactionId || message.interaction?.userMessageId || '';
     const answerLang = toLangAttr(getAnswerLanguage(message.interaction));
-    // Chrome (citation heading, disclaimer) only ever exists in en/fr - see resolveChromeLang.
-    const chromeLang = resolveChromeLang(answerLang, lang);
     return (
       <div className="ai-message-content">
         {contentArr.map((content, index) => {
@@ -738,8 +736,8 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
         {displayUrl && (
           <>
             <hr className="citation-divider" aria-hidden="true" />
-            <div className="citation-container" lang={chromeLang}>
-              <p key={`${messageId}-head`} className="citation-head font-size-text-small">{translate('homepage.chat.citation.heading', chromeLang)}</p>
+            <div className="citation-container">
+              <p key={`${messageId}-head`} className="citation-head font-size-text-small">{safeT('homepage.chat.citation.heading')}</p>
               <ul key={`${messageId}-link`} className="citation-link list-disc">
                   <li>
                     <a
@@ -913,14 +911,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
             </div>
           </>
         )}
-        <div className="disclaimer" lang={chromeLang}>
+        <div className="disclaimer">
           <p className="font-size-text-xsm-nr">
-            {translate('homepage.chat.input.disclaimer', chromeLang)}
+            {safeT('homepage.chat.input.disclaimer')}
           </p>
         </div>
       </div>
     );
-  }, [chatId, isMobile, lang]);
+  }, [safeT, chatId, isMobile]);
 
   // Add handler for department changes
 

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -718,19 +718,17 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     const chromeLang = resolveChromeLang(answerLang, lang);
     return (
       <div className="ai-message-content">
-        <div lang={answerLang}>
-          {contentArr.map((content, index) => {
-            // If using paragraphs, split into sentences; if using sentences, just display
-            const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
-              ? extractSentences(content)
-              : [content];
-            return sentences.map((sentence, sentenceIndex) => (
-              <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence">
-                {decodeHTMLEntities(sentence)}
-              </p>
-            ));
-          })}
-        </div>
+        {contentArr.map((content, index) => {
+          // If using paragraphs, split into sentences; if using sentences, just display
+          const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
+            ? extractSentences(content)
+            : [content];
+          return sentences.map((sentence, sentenceIndex) => (
+            <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence" lang={answerLang}>
+              {decodeHTMLEntities(sentence)}
+            </p>
+          ));
+        })}
         {displayUrl && (
           <>
             <hr className="citation-divider" aria-hidden="true" />

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -720,9 +720,15 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
       <div className="ai-message-content">
         {contentArr.map((content, index) => {
           // If using paragraphs, split into sentences; if using sentences, just display
-          const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
+          const rawSentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
             ? extractSentences(content)
             : [content];
+          // Drop blanks: an empty <s-N></s-N> tag (translation collapsed a sentence) or a
+          // paragraph left empty after the <translated-question> strip above would otherwise
+          // render as an empty <p>.
+          const sentences = rawSentences.filter(
+            (sentence) => typeof sentence === 'string' && sentence.trim()
+          );
           return sentences.map((sentence, sentenceIndex) => (
             <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence" lang={answerLang}>
               {decodeHTMLEntities(sentence)}

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useTranslations } from '../../hooks/useTranslations.js';
+import { useTranslations, translate } from '../../hooks/useTranslations.js';
 import { usePageContext, DEPARTMENT_MAPPINGS } from '../../hooks/usePageParam.js';
 import ChatInterface from './ChatInterface.js';
 import { ChatWorkflowService, RedactionError, ShortQueryValidation } from '../../services/ChatWorkflowService.js';
@@ -12,7 +12,7 @@ import { AVAILABLE_MODELS } from '../../config/workflows.js';
 import { safeHttpHref } from '../../utils/safeUrl.js';
 import { buildAriaLabel } from '../../utils/citationAriaLabel.js';
 import { getCitationUrl } from '../../utils/getCitationUrl.js';
-import { getAnswerLanguage, toLangAttr } from '../../utils/answerLanguage.js';
+import { getAnswerLanguage, toLangAttr, resolveChromeLang } from '../../utils/answerLanguage.js';
 // Utility functions go here, before the component
 const decodeHTMLEntities = (text) => {
   const entities = {
@@ -714,24 +714,28 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     // interactionId is the message id (client-side userMessageId)
     const interactionId = messageId || message.interaction?.interactionId || message.interaction?.userMessageId || '';
     const answerLang = toLangAttr(getAnswerLanguage(message.interaction));
+    // Chrome (citation heading, disclaimer) only ever exists in en/fr - see resolveChromeLang.
+    const chromeLang = resolveChromeLang(answerLang, lang);
     return (
-      <div className="ai-message-content" lang={answerLang}>
-        {contentArr.map((content, index) => {
-          // If using paragraphs, split into sentences; if using sentences, just display
-          const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
-            ? extractSentences(content)
-            : [content];
-          return sentences.map((sentence, sentenceIndex) => (
-            <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence">
-              {decodeHTMLEntities(sentence)}
-            </p>
-          ));
-        })}
+      <div className="ai-message-content">
+        <div lang={answerLang}>
+          {contentArr.map((content, index) => {
+            // If using paragraphs, split into sentences; if using sentences, just display
+            const sentences = (answer.paragraphs && Array.isArray(answer.paragraphs))
+              ? extractSentences(content)
+              : [content];
+            return sentences.map((sentence, sentenceIndex) => (
+              <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence">
+                {decodeHTMLEntities(sentence)}
+              </p>
+            ));
+          })}
+        </div>
         {displayUrl && (
           <>
             <hr className="citation-divider" aria-hidden="true" />
-            <div className="citation-container">
-              <p key={`${messageId}-head`} className="citation-head font-size-text-small">{safeT('homepage.chat.citation.heading')}</p>
+            <div className="citation-container" lang={chromeLang}>
+              <p key={`${messageId}-head`} className="citation-head font-size-text-small">{translate('homepage.chat.citation.heading', chromeLang)}</p>
               <ul key={`${messageId}-link`} className="citation-link list-disc">
                   <li>
                     <a
@@ -905,14 +909,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
             </div>
           </>
         )}
-        <div className="disclaimer">
+        <div className="disclaimer" lang={chromeLang}>
           <p className="font-size-text-xsm-nr">
-            {safeT('homepage.chat.input.disclaimer')}
+            {translate('homepage.chat.input.disclaimer', chromeLang)}
           </p>
         </div>
       </div>
     );
-  }, [safeT, chatId, isMobile]);
+  }, [chatId, isMobile, lang]);
 
   // Add handler for department changes
 

--- a/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
@@ -13,7 +13,6 @@ vi.mock('../../../hooks/usePageParam', () => ({
 
 vi.mock('../../../hooks/useTranslations', () => ({
     useTranslations: vi.fn(() => ({ t: (k) => k })),
-    translate: (k) => k,
 }));
 
 // Mock services

--- a/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import ChatAppContainer from '../ChatAppContainer';
+import { usePageContext } from '../../../hooks/usePageParam';
+
+// Mock hooks before importing components that use them
+vi.mock('../../../hooks/usePageParam', () => ({
+    usePageContext: vi.fn(() => ({ url: '', department: '' })),
+    DEPARTMENT_MAPPINGS: {}
+}));
+
+vi.mock('../../../hooks/useTranslations', () => ({
+    useTranslations: vi.fn(() => ({ t: (k) => k })),
+    translate: (k) => k,
+}));
+
+// Mock services
+vi.mock('../../../services/DataStoreService', () => ({ default: { getPublicSetting: vi.fn(() => Promise.resolve('azure')) } }));
+vi.mock('../../../services/SessionService', () => ({ default: { getChatId: vi.fn(() => Promise.resolve('abc')) } }));
+vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)) } }));
+vi.mock('../../../services/ChatWorkflowService', () => ({ ChatWorkflowService: { processResponse: vi.fn() }, RedactionError: class { }, ShortQueryValidation: class { } }));
+
+// Capture formatAIResponse and invoke it directly with a crafted message, in place of
+// rendering the full ChatInterface (which is exercised elsewhere).
+let capturedFormatAIResponse;
+vi.mock('../ChatInterface', () => ({
+    default: ({ formatAIResponse }) => {
+        capturedFormatAIResponse = formatAIResponse;
+        return <div data-testid="chat-interface" />;
+    }
+}));
+
+describe('ChatAppContainer - formatAIResponse blank-sentence filtering', () => {
+    afterEach(() => {
+        cleanup();
+        capturedFormatAIResponse = undefined;
+    });
+
+    it('does not render an empty <p> for a blank <s-N></s-N> tag or an empty paragraph', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        expect(capturedFormatAIResponse).toBeInstanceOf(Function);
+
+        const message = {
+            id: 'm1',
+            interaction: {
+                answer: {
+                    // Second sentence tag is empty (translation collapsed it); second paragraph is
+                    // entirely a <translated-question> tag, which strips to an empty string.
+                    paragraphs: [
+                        '<s-1>Real sentence.</s-1><s-2></s-2>',
+                        '<translated-question>hidden</translated-question>',
+                    ],
+                    questionLanguage: 'eng',
+                },
+            },
+        };
+
+        const { container } = render(<div>{capturedFormatAIResponse('openai', message)}</div>);
+
+        const paragraphs = container.querySelectorAll('p.ai-sentence');
+        expect(paragraphs).toHaveLength(1);
+        expect(paragraphs[0].textContent).toBe('Real sentence.');
+    });
+});

--- a/src/hooks/useTranslations.js
+++ b/src/hooks/useTranslations.js
@@ -3,28 +3,28 @@ import { useCallback } from 'react';
 import enTranslations from '../locales/en.json';
 import frTranslations from '../locales/fr.json';
 
-// Looks up a key against an explicit language, independent of any component's ambient `lang`.
-// Used where a single string needs to render in a language other than the page's own (see
-// resolveChromeLang in src/utils/answerLanguage.js).
-export const translate = (key, lang) => {
-  const translations = lang === 'fr' ? frTranslations : enTranslations;
-  const keys = key.split('.');
-  let value = translations;
-
-  for (const k of keys) {
-    if (value && typeof value === 'object') {
-      value = value[k];
-    } else {
-      console.warn(`Translation missing for key: ${key}`);
-      return key;
-    }
-  }
-
-  return value || key;
-};
-
 export const useTranslations = (lang) => {
-  const t = useCallback((key) => translate(key, lang), [lang]);
+  const translations = lang === 'fr' ? frTranslations : enTranslations;
+
+  const t = useCallback(
+    (key) => {
+      // Split the key by dots to access nested objects
+      const keys = key.split('.');
+      let value = translations;
+
+      for (const k of keys) {
+        if (value && typeof value === 'object') {
+          value = value[k];
+        } else {
+          console.warn(`Translation missing for key: ${key}`);
+          return key;
+        }
+      }
+
+      return value || key;
+    },
+    [translations]
+  );
 
   return { t };
 };

--- a/src/hooks/useTranslations.js
+++ b/src/hooks/useTranslations.js
@@ -3,28 +3,28 @@ import { useCallback } from 'react';
 import enTranslations from '../locales/en.json';
 import frTranslations from '../locales/fr.json';
 
-export const useTranslations = (lang) => {
+// Looks up a key against an explicit language, independent of any component's ambient `lang`.
+// Used where a single string needs to render in a language other than the page's own (see
+// resolveChromeLang in src/utils/answerLanguage.js).
+export const translate = (key, lang) => {
   const translations = lang === 'fr' ? frTranslations : enTranslations;
+  const keys = key.split('.');
+  let value = translations;
 
-  const t = useCallback(
-    (key) => {
-      // Split the key by dots to access nested objects
-      const keys = key.split('.');
-      let value = translations;
+  for (const k of keys) {
+    if (value && typeof value === 'object') {
+      value = value[k];
+    } else {
+      console.warn(`Translation missing for key: ${key}`);
+      return key;
+    }
+  }
 
-      for (const k of keys) {
-        if (value && typeof value === 'object') {
-          value = value[k];
-        } else {
-          console.warn(`Translation missing for key: ${key}`);
-          return key;
-        }
-      }
+  return value || key;
+};
 
-      return value || key;
-    },
-    [translations]
-  );
+export const useTranslations = (lang) => {
+  const t = useCallback((key) => translate(key, lang), [lang]);
 
   return { t };
 };

--- a/src/utils/__tests__/answerLanguage.test.js
+++ b/src/utils/__tests__/answerLanguage.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getAnswerLanguage, toLangAttr } from '../answerLanguage.js';
+import { getAnswerLanguage, toLangAttr, resolveChromeLang } from '../answerLanguage.js';
 
 describe('getAnswerLanguage', () => {
   it('prefers the live-session shape (answer.questionLanguage) over the persisted shape', () => {
@@ -68,5 +68,28 @@ describe('toLangAttr', () => {
     expect(toLangAttr('arb')).toBe('ar');
     expect(toLangAttr('zho')).toBe('zh');
     expect(toLangAttr('cmn')).toBe('zh');
+  });
+});
+
+describe('resolveChromeLang', () => {
+  it('switches chrome to the answer language when the answer is in the other official language', () => {
+    expect(resolveChromeLang('fr', 'en')).toBe('fr');
+    expect(resolveChromeLang('en', 'fr')).toBe('en');
+  });
+
+  it('keeps chrome in the answer language when it already matches the page language', () => {
+    expect(resolveChromeLang('en', 'en')).toBe('en');
+    expect(resolveChromeLang('fr', 'fr')).toBe('fr');
+  });
+
+  it('falls back to the page language when the answer is in a non-official language', () => {
+    expect(resolveChromeLang('es', 'en')).toBe('en');
+    expect(resolveChromeLang('ar', 'fr')).toBe('fr');
+    expect(resolveChromeLang('crk', 'en')).toBe('en');
+  });
+
+  it('falls back to the page language when the answer language is undefined (und/zxx/undetected)', () => {
+    expect(resolveChromeLang(undefined, 'en')).toBe('en');
+    expect(resolveChromeLang(undefined, 'fr')).toBe('fr');
   });
 });

--- a/src/utils/__tests__/answerLanguage.test.js
+++ b/src/utils/__tests__/answerLanguage.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getAnswerLanguage, toLangAttr } from '../answerLanguage.js';
+
+describe('getAnswerLanguage', () => {
+  it('prefers the live-session shape (answer.questionLanguage) over the persisted shape', () => {
+    expect(
+      getAnswerLanguage({
+        answer: { questionLanguage: 'fra' },
+        question: { language: 'eng' },
+      })
+    ).toBe('fra');
+  });
+
+  it('falls back to the persisted shape (question.language) when answer.questionLanguage is absent', () => {
+    expect(
+      getAnswerLanguage({
+        answer: {},
+        question: { language: 'spa' },
+      })
+    ).toBe('spa');
+  });
+
+  it('returns empty string when neither shape has a language', () => {
+    expect(getAnswerLanguage({ answer: {}, question: {} })).toBe('');
+  });
+
+  it('returns empty string when interaction is undefined', () => {
+    expect(getAnswerLanguage(undefined)).toBe('');
+  });
+});
+
+describe('toLangAttr', () => {
+  it('maps an ISO-639-3 code to its BCP-47 equivalent', () => {
+    expect(toLangAttr('eng')).toBe('en');
+    expect(toLangAttr('fra')).toBe('fr');
+    expect(toLangAttr('spa')).toBe('es');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(toLangAttr(' FRA ')).toBe('fr');
+  });
+
+  it('passes through a code with no ISO-639-1 equivalent unchanged', () => {
+    expect(toLangAttr('crk')).toBe('crk');
+  });
+
+  it('passes through an already-BCP-47 code unchanged', () => {
+    expect(toLangAttr('en')).toBe('en');
+    expect(toLangAttr('fr')).toBe('fr');
+  });
+
+  it('returns undefined for the "undetermined" sentinel (und)', () => {
+    expect(toLangAttr('und')).toBeUndefined();
+  });
+
+  it('returns undefined for the "no linguistic content" sentinel (zxx)', () => {
+    expect(toLangAttr('zxx')).toBeUndefined();
+  });
+
+  it('returns undefined for falsy input', () => {
+    expect(toLangAttr('')).toBeUndefined();
+    expect(toLangAttr(null)).toBeUndefined();
+    expect(toLangAttr(undefined)).toBeUndefined();
+  });
+
+  it('maps known aliases for the same language to the same BCP-47 code', () => {
+    expect(toLangAttr('ara')).toBe('ar');
+    expect(toLangAttr('arb')).toBe('ar');
+    expect(toLangAttr('zho')).toBe('zh');
+    expect(toLangAttr('cmn')).toBe('zh');
+  });
+});

--- a/src/utils/__tests__/answerLanguage.test.js
+++ b/src/utils/__tests__/answerLanguage.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getAnswerLanguage, toLangAttr, resolveChromeLang } from '../answerLanguage.js';
+import { getAnswerLanguage, toLangAttr } from '../answerLanguage.js';
 
 describe('getAnswerLanguage', () => {
   it('prefers the live-session shape (answer.questionLanguage) over the persisted shape', () => {
@@ -68,28 +68,5 @@ describe('toLangAttr', () => {
     expect(toLangAttr('arb')).toBe('ar');
     expect(toLangAttr('zho')).toBe('zh');
     expect(toLangAttr('cmn')).toBe('zh');
-  });
-});
-
-describe('resolveChromeLang', () => {
-  it('switches chrome to the answer language when the answer is in the other official language', () => {
-    expect(resolveChromeLang('fr', 'en')).toBe('fr');
-    expect(resolveChromeLang('en', 'fr')).toBe('en');
-  });
-
-  it('keeps chrome in the answer language when it already matches the page language', () => {
-    expect(resolveChromeLang('en', 'en')).toBe('en');
-    expect(resolveChromeLang('fr', 'fr')).toBe('fr');
-  });
-
-  it('falls back to the page language when the answer is in a non-official language', () => {
-    expect(resolveChromeLang('es', 'en')).toBe('en');
-    expect(resolveChromeLang('ar', 'fr')).toBe('fr');
-    expect(resolveChromeLang('crk', 'en')).toBe('en');
-  });
-
-  it('falls back to the page language when the answer language is undefined (und/zxx/undetected)', () => {
-    expect(resolveChromeLang(undefined, 'en')).toBe('en');
-    expect(resolveChromeLang(undefined, 'fr')).toBe('fr');
   });
 });

--- a/src/utils/answerLanguage.js
+++ b/src/utils/answerLanguage.js
@@ -105,3 +105,15 @@ export function toLangAttr(rawLanguage) {
   if (code === 'und' || code === 'zxx') return undefined;
   return ISO3_TO_BCP47[code] || code;
 }
+
+// UI chrome around the answer (citation heading, disclaimer - see formatAIResponse in
+// ChatAppContainer.js) only ever exists in English and French (src/locales/en.json / fr.json) -
+// there's no translation of it for the ~60 other languages an answer can be detected in. So:
+// - if the answer's detected language IS English or French (even if it's not the page's own
+//   language - e.g. a French answer on an English page), use that language for this message's
+//   chrome too, so the whole message reads consistently instead of mixing languages.
+// - for any other detected language, chrome has nothing to switch to, so it stays in the page's
+//   own language.
+export function resolveChromeLang(answerLangBCP47, pageLang) {
+  return answerLangBCP47 === 'en' || answerLangBCP47 === 'fr' ? answerLangBCP47 : pageLang;
+}

--- a/src/utils/answerLanguage.js
+++ b/src/utils/answerLanguage.js
@@ -1,0 +1,107 @@
+// Resolves the language an answer's content is actually in, across the two real shapes:
+// - live, same-session message (before persistence): `interaction.answer.questionLanguage`,
+//   set by the graph's answer node (agents/graphs/workflows/GraphWorkflowHelper.js) and
+//   streamed straight to the client.
+// - reloaded/review-mode message (after persistence): `interaction.question.language`,
+//   the same value persisted onto the Question model (services/InteractionPersistenceService.js).
+// Returns the raw ISO-639-3-ish code (e.g. "eng", "fra", or a Canadian Indigenous code), or ''.
+//
+// Called per-message (see formatAIResponse in ChatAppContainer.js) against that message's own
+// `interaction`, not shared/conversation-level state - messages are appended immutably
+// (`setMessages(prev => [...prev, newMessage])`), so each turn's answer keeps its own detected
+// language. If a user switches language mid-conversation (French, then English, then Spanish),
+// each answer bubble is tagged independently based on what was actually detected for that turn.
+export function getAnswerLanguage(interaction) {
+  return interaction?.answer?.questionLanguage
+    || interaction?.question?.language
+    || '';
+}
+
+// Maps a raw language code to the tag used for the answer bubble's `lang` attribute, so
+// screen readers/browser TTS pronounce the answer in its actual language instead of
+// inheriting the page's lang="en"/"fr" (document.documentElement.lang, set in App.js).
+// The answer is genuinely generated in the question's detected language, not just en/fr -
+// agents/prompts/agenticBase.js translates the English draft answer into whatever language
+// the <output-lang> tag carries (agents/graphs/workflows/GraphWorkflowHelper.js), for any
+// language the translation step can identify - so this table needs real per-language entries,
+// not just en/fr.
+//
+// BCP-47 requires the ISO-639-1 two-letter code when one exists for the language, so ISO-639-3
+// codes (what the translator returns, per agents/prompts/translationPrompt.js) need mapping to
+// their 639-1 form. Covers the languages most commonly seen among Canadian newcomers/immigrants
+// plus other major world languages.
+//
+// Canadian Indigenous languages (UNSUPPORTED_INDIGENOUS_ISO3 in
+// agents/graphs/guardrails/translationGuardrail.js) are deliberately NOT in this table and don't
+// need to be: by default the guardrail.indigenousLanguageBlocking admin setting (default true)
+// hard-blocks these questions before an answer is ever generated, so there's normally nothing to
+// tag. If an admin disables that setting and the LLM answers in one of these languages anyway,
+// the code (e.g. "crk", "ike") has no ISO-639-1 equivalent and is already a valid BCP-47 primary
+// language subtag on its own, so the fallback below passes it through unchanged and it still
+// gets tagged correctly - this table does not need a special case for that to work.
+const ISO3_TO_BCP47 = {
+  eng: 'en',
+  fra: 'fr',
+  spa: 'es',
+  por: 'pt',
+  ita: 'it',
+  deu: 'de',
+  nld: 'nl',
+  ell: 'el',
+  ron: 'ro',
+  pol: 'pl',
+  ces: 'cs',
+  slk: 'sk',
+  hun: 'hu',
+  bul: 'bg',
+  ukr: 'uk',
+  rus: 'ru',
+  srp: 'sr',
+  hrv: 'hr',
+  swe: 'sv',
+  dan: 'da',
+  nor: 'no',
+  fin: 'fi',
+  tur: 'tr',
+  heb: 'he',
+  ara: 'ar',
+  arb: 'ar',
+  fas: 'fa',
+  pes: 'fa',
+  urd: 'ur',
+  pus: 'ps',
+  kur: 'ku',
+  hin: 'hi',
+  ben: 'bn',
+  pan: 'pa',
+  guj: 'gu',
+  mar: 'mr',
+  tam: 'ta',
+  tel: 'te',
+  mal: 'ml',
+  sin: 'si',
+  nep: 'ne',
+  zho: 'zh',
+  cmn: 'zh',
+  jpn: 'ja',
+  kor: 'ko',
+  vie: 'vi',
+  tha: 'th',
+  khm: 'km',
+  lao: 'lo',
+  msa: 'ms',
+  zsm: 'ms',
+  ind: 'id',
+  tgl: 'tl',
+  fil: 'tl',
+  swa: 'sw',
+  som: 'so',
+  amh: 'am',
+};
+
+export function toLangAttr(rawLanguage) {
+  if (!rawLanguage) return undefined;
+  const code = String(rawLanguage).trim().toLowerCase();
+  if (code === 'und' || code === 'zxx') return undefined;
+  return ISO3_TO_BCP47[code] || code;
+}

--- a/src/utils/answerLanguage.js
+++ b/src/utils/answerLanguage.js
@@ -105,15 +105,3 @@ export function toLangAttr(rawLanguage) {
   if (code === 'und' || code === 'zxx') return undefined;
   return ISO3_TO_BCP47[code] || code;
 }
-
-// UI chrome around the answer (citation heading, disclaimer - see formatAIResponse in
-// ChatAppContainer.js) only ever exists in English and French (src/locales/en.json / fr.json) -
-// there's no translation of it for the ~60 other languages an answer can be detected in. So:
-// - if the answer's detected language IS English or French (even if it's not the page's own
-//   language - e.g. a French answer on an English page), use that language for this message's
-//   chrome too, so the whole message reads consistently instead of mixing languages.
-// - for any other detected language, chrome has nothing to switch to, so it stays in the page's
-//   own language.
-export function resolveChromeLang(answerLangBCP47, pageLang) {
-  return answerLangBCP47 === 'en' || answerLangBCP47 === 'fr' ? answerLangBCP47 : pageLang;
-}


### PR DESCRIPTION
Accessibility review correction:

  #330 - Page section missing lang attribute

  Sets each AI answer sentence's lang attribute based on the detected language of that specific answer, so screen readers/TTS pronounce it correctly instead of inheriting the page's lang="en"/"fr" — this matters most when a screen reader user asks a question in a different language than the page they're on.

  - src/utils/answerLanguage.js: resolves the detected language from either the live-session or persisted interaction shape (getAnswerLanguage), and maps ISO-639-3 → BCP-47 for the lang attribute (toLangAttr), covering ~60 detected languages (more can be added later).
 
  - src/components/chat/ChatAppContainer.js: each answer sentence (`<p className="ai-sentence">`) gets `lang={answerLang}` individually, so only the actual AI-generated text is tagged with the detected language. The citation heading and disclaimer are left untouched — they stay in the page's own language, matching the same Official Languages rule that governs citation URLs (agents/prompts/citationInstructions.js), which must always match the page's language. 
  -  This same change also drops blank paragraphs/sentences (e.g. an empty translation-collapsed sentence tag) that would otherwise render as empty <p> elements, and read out "blank" and confusing to screen reader users and creates unnecessary spacing for sighted users.
 
 - Full test coverage added for both language-resolution functions (getAnswerLanguage, toLangAttr) and the blank-sentence filtering behaviour.
