### PR TITLE
fix: selected CEO for a CPP question

### DIFF
--- a/agents/prompts/contextSystemPrompt.js
+++ b/agents/prompts/contextSystemPrompt.js
@@ -52,7 +52,7 @@ ${departmentsString}
 
 3a. If multiple organizations could be responsible, select the one that most likely directly administers and delivers web content for the program/service.
 
-3b. If the question names no specific service/dept (e.g., CPP, EI, passport, MSCA, CRA account) and is about one of these cross-department services → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
+3b. If the question doesn't mention a specific service/dept (e.g., CPP, EI, passport, MSCA, CRA account) AND is about one of these cross-department services → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
       - Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
       - All Government of Canada contacts: https://www.canada.ca/en/contact.html or fr: https://www.canada.ca/fr/contact.html
       - All Government of Canada departments and agencies: https://www.canada.ca/en/government/dept.html or fr: https://www.canada.ca/fr/gouvernement/min.html

--- a/agents/prompts/scenarios/context-edsc-esdc/edsc-esdc-scenarios.js
+++ b/agents/prompts/scenarios/context-edsc-esdc/edsc-esdc-scenarios.js
@@ -15,14 +15,15 @@ export const EDSC_ESDC_SCENARIOS = `
 - MSCA lockout by mfauth: 1-866-279-5238: https://www.canada.ca/en/employment-social-development/services/my-account/multi-factor-authentication.html https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier/authentification-multifacteur.html
 - Canada Disability Benefit 1-833-486-3007: https://www.canada.ca/en/services/benefits/disability/canada-disability-benefit/contact.html https://www.canada.ca/fr/services/prestations/handicap/prestation-canadienne-personnes-situation-handicap/contact.html
 
-### Change direct deposit, address, phone for each program
-- ⚠️DOWNLOAD to find out if can change in MSCA (not all can!), changes frequently, good citation: https://www.canada.ca/en/employment-social-development/services/my-account/personal-information.html https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier/renseignements-personnels.html
+### Change direct deposit, address, phone for each program separately
+- Not all programs can change in MSCA at this time (CPP may have diff process than OAS), never assume can change in MSCA.
+- ALWAYS ⚠️DOWNLOAD and use as citation for how to change: https://www.canada.ca/en/employment-social-development/services/my-account/personal-information.html https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier/renseignements-personnels.html
 - If must phone, ALWAYS give phone number for program. 
 - Remind that changes aren't shared, will need to change with other programs/depts like CRA 
 
 ### Employment Insurance
 * EI eligibility/amounts Qs: complex, REDIRECT TO SELF-SERVICE PAGE to answer questions at: https://estimateurae-eiestimator.service.canada.ca/en https://estimateurae-eiestimator.service.canada.ca/fr/
-    * Qs on additional earnings while on EI (e.g. "can I get CPP and EI" or "Can I work for week while on EI") → redirect to estimator
+* Qs on additional earnings while on EI (e.g. "can I get CPP and EI" or "Can I work for week while on EI") → redirect to estimator
 * ALWAYS give eligibility URL (has estimator link) as citation for q on applying for a particular EI program that way they check eligibility first - eg. https://www.canada.ca/en/services/benefits/ei/ei-regular-benefit/eligibility.html https://www.canada.ca/fr/services/prestations/ae/assurance-emploi-reguliere/admissibilite.html or https://www.canada.ca/en/services/benefits/ei/ei-maternity-parental/eligibility.html https://www.canada.ca/fr/services/prestations/ae/assurance-emploi-maternite-parentales/admissibilite.html etc
 * NEVER advise may not qualify for EI. If any uncertainty → advise to apply immediately 
 * EI covers range of benefits. If Q reflects uncertainty on which benefit user needs→ provide Benefits finder: https://www.canada.ca/en/services/benefits/finder.html https://www.canada.ca/fr/services/prestations/chercheur.html

--- a/agents/prompts/scenarios/scenarios-all.js
+++ b/agents/prompts/scenarios/scenarios-all.js
@@ -29,6 +29,7 @@ If user asks for specific detail that couldn't be verified, or calculation:
 * Only offer mail-in form for bank changes/sign up if asked or person can't use self-service.
 * General direct deposit for individuals - REDIRECT TO SELF-SERVICE PAGE to get customized instructions: https://www.canada.ca/en/public-services-procurement/services/payments-to-from-government/direct-deposit/individuals-canada.html https://www.canada.ca/fr/services-publics-approvisionnement/services/paiements-vers-depuis-gouvernement/depot-direct/particuliers-canada.html
 * For general address/phone updates where no program provided in Q, REDIRECT TO SELF-SERVICE page for all programs: https://www.canada.ca/en/government/change-address.html https://www.canada.ca/fr/gouvernement/changement-adresse.html so can use links to change for all programs since changes aren't shared. 
+* Never assume can change online unless verified in downloaded content - if can't verify, advise to use general self-service page for all programs
 * Distinguish phone number changes for two-factor auth vs changing numbers for program profiles - usually different processes. 
 
 ### Date-Sensitive Info


### PR DESCRIPTION
fine tune to prevent assigning to CEO-BEC if not a general question

# Summary | Résumé

> assigned CEO-BEC as dept for question "Change address for CPP" and then **answered incorrectly that could change in MSCA.** Just trying to prevent assigning to CEO and added to scenarios-all to never assume can change online.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
