### PR TITLE
fix: announce and focus form validation errors on auth pages, scoped …

### DIFF
--- a/src/components/auth/AnnouncedError.js
+++ b/src/components/auth/AnnouncedError.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { GcdsIcon } from '@gcds-core/components-react';
+
+// key={errorCount} forces a fresh DOM node on every trigger, so useAnnouncedError's
+// ref.current.focus() always targets an element that wasn't already focused —
+// see FeedbackInlineError/useInlineFormError for why that matters on repeat failures.
+// Icon matches GC DS's own gcds-error-message component (warning-triangle, same token).
+const AnnouncedError = ({ id, message, errorCount, inputRef, className = 'form-error-message font-size-text-sm-nr mrgn-bttm-20' }) => (
+  <div key={errorCount} id={id} className={className} role="alert" tabIndex={-1} ref={inputRef}>
+    <GcdsIcon name="warning-triangle" marginRight="50" />
+    {message}
+  </div>
+);
+
+export default AnnouncedError;

--- a/src/components/chat/FeedbackInlineError.js
+++ b/src/components/chat/FeedbackInlineError.js
@@ -1,17 +1,20 @@
 import React from 'react';
+import { GcdsIcon } from '@gcds-core/components-react';
 
 // key={errorCount} forces a fresh DOM node on every trigger, so useFocusOnChange's
 // ref.current.focus() always targets an element that wasn't already focused —
 // see useInlineFormError/useFocusOnChange for why that matters on repeat failures.
+// Icon matches GC DS's own gcds-error-message component (warning-triangle, same token).
 const FeedbackInlineError = ({ id, message, errorCount, inputRef }) => (
   <p
     key={errorCount}
-    className="feedback-inline-error"
+    className="form-error-message font-size-text-sm-nr"
     id={id}
     role="alert"
     ref={inputRef}
     tabIndex={-1}
   >
+    <GcdsIcon name="warning-triangle" marginRight="50" />
     {message}
   </p>
 );

--- a/src/hooks/auth/useAnnouncedError.js
+++ b/src/hooks/auth/useAnnouncedError.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { useFocusOnChange } from '../useFocusOnChange.js';
+
+// Tracks a message-bearing form error that should be announced and focused
+// every time it fires — including two consecutive failures with the identical
+// message (e.g. two invalid-login attempts in a row). errorCount (rather than
+// a message-changed check) is what makes that repeat case still re-focus/
+// re-announce — see useFocusOnChange for why a value that doesn't change
+// can't do this. Mirrors useInlineFormError's shape but carries a message
+// instead of a boolean.
+export const useAnnouncedError = () => {
+  const [message, setMessage] = useState('');
+  const [errorCount, setErrorCount] = useState(0);
+  const errorRef = useFocusOnChange(errorCount);
+
+  const setError = (msg) => {
+    if (msg) {
+      setMessage(msg);
+      setErrorCount((n) => n + 1);
+    } else {
+      setMessage('');
+    }
+  };
+
+  return { error: message, errorCount, errorRef, setError, clearError: () => setMessage('') };
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -869,7 +869,7 @@
     "email": "Email",
     "password": "Password",
     "submit": "Sign in",
-    "invalidCredentials": "Invalid email or password",
+    "invalidCredentials": "Invalid email or password.",
     "sessionExpired": {
       "title": "Session expired",
       "message": "Your session has expired. Please sign in again to continue."
@@ -887,8 +887,8 @@
       "resend": "Resend code",
       "sentToEmail": "A verification code has been sent to your email.",
       "send": "Send verification code",
-      "sendError": "Failed to send verification code",
-      "invalidCode": "Invalid verification code"
+      "sendError": "Failed to send verification code.",
+      "invalidCode": "Invalid verification code."
     },
     "showPassword": "Show password",
     "hidePassword": "Hide password"
@@ -905,7 +905,7 @@
       "send": "Send reset email",
       "sending": "Sending...",
       "sent": "If that account exists, we sent a reset email.",
-      "error": "Failed to request reset"
+      "error": "Failed to request reset."
     },
     "verify": {
       "title": "Verify reset",
@@ -917,7 +917,7 @@
       "otpSent": "A verification code has been sent to your email",
       "otpSendError": "Failed to send verification code",
       "next": "Next",
-      "invalidLink": "Invalid or missing reset link"
+      "invalidLink": "Invalid or missing reset link."
     },
     "complete": {
       "title": "Set a new password",
@@ -927,10 +927,10 @@
       "submit": "Set password",
       "submitting": "Submitting...",
       "success": "Password updated. Redirecting to sign in...",
-      "error": "Failed to reset password",
-      "invalid": "Invalid reset link",
-      "passwordTooShort": "Password must be at least 8 characters",
-      "passwordMismatch": "Passwords do not match",
+      "error": "Failed to reset password.",
+      "invalid": "Invalid reset link.",
+      "passwordTooShort": "Password must be at least 8 characters.",
+      "passwordMismatch": "Passwords do not match.",
       "lockedOut": "Too many failed attempts. Please try again later.",
       "invalidCode": "Invalid or expired code. Please try again."
     }
@@ -941,9 +941,9 @@
     "password": "Password",
     "confirmPassword": "Confirm password",
     "submit": "Create account",
-    "passwordMismatch": "Passwords do not match",
-    "passwordTooShort": "Password must be at least 8 characters",
-    "errorOccurred": "An error occurred creating your account",
+    "passwordMismatch": "Passwords do not match.",
+    "passwordTooShort": "Password must be at least 8 characters.",
+    "errorOccurred": "An error occurred creating your account.",
     "submitting": "Creating account...wait for approval"
   },
   "users": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -870,9 +870,9 @@
     "password": "Mot de passe",
     "confirmPassword": "Confirmer le mot de passe",
     "submit": "Créer un compte",
-    "passwordMismatch": "Les mots de passe ne correspondent pas",
-    "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères",
-    "errorOccurred": "Une erreur est survenue lors de l'inscription",
+    "passwordMismatch": "Les mots de passe ne correspondent pas.",
+    "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
+    "errorOccurred": "Une erreur est survenue lors de l'inscription.",
     "submitting": "Création du compte...en attente d'approbation"
   },
   "login": {
@@ -880,7 +880,7 @@
     "email": "Courriel",
     "password": "Mot de passe",
     "submit": "Se connecter",
-    "invalidCredentials": "Courriel ou mot de passe invalide",
+    "invalidCredentials": "Courriel ou mot de passe invalide.",
     "sessionExpired": {
       "title": "Session expirée",
       "message": "Votre session a expiré. Veuillez vous reconnecter pour continuer."
@@ -898,8 +898,8 @@
       "resend": "Renvoyer le code",
       "sentToEmail": "Un code de vérification a été envoyé à votre adresse courriel.",
       "send": "Envoyer le code de vérification",
-      "sendError": "Impossible d'envoyer le code de vérification",
-      "invalidCode": "Code de vérification invalide"
+      "sendError": "Impossible d'envoyer le code de vérification.",
+      "invalidCode": "Code de vérification invalide."
     },
     "showPassword": "Afficher le mot de passe",
     "hidePassword": "Masquer le mot de passe"
@@ -916,7 +916,7 @@
       "send": "Envoyer le courriel de réinitialisation",
       "sending": "Envoi...",
       "sent": "Si ce compte existe, nous avons envoyé un courriel de réinitialisation.",
-      "error": "Échec de la demande de réinitialisation"
+      "error": "Échec de la demande de réinitialisation."
     },
     "verify": {
       "title": "Vérifier la réinitialisation",
@@ -928,7 +928,7 @@
       "otpSent": "Un code de vérification a été envoyé à votre adresse courriel",
       "otpSendError": "Échec de l'envoi du code de vérification",
       "next": "Suivant",
-      "invalidLink": "Lien de réinitialisation invalide ou manquant"
+      "invalidLink": "Lien de réinitialisation invalide ou manquant."
     },
     "complete": {
       "title": "Définir un nouveau mot de passe",
@@ -938,10 +938,10 @@
       "submit": "Définir le mot de passe",
       "submitting": "Envoi...",
       "success": "Mot de passe mis à jour. Redirection vers la page de connexion...",
-      "error": "Échec de la réinitialisation du mot de passe",
-      "invalid": "Lien de réinitialisation invalide",
-      "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères",
-      "passwordMismatch": "Les mots de passe ne correspondent pas",
+      "error": "Échec de la réinitialisation du mot de passe.",
+      "invalid": "Lien de réinitialisation invalide.",
+      "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
+      "passwordMismatch": "Les mots de passe ne correspondent pas.",
       "lockedOut": "Trop de tentatives échouées. Veuillez réessayer plus tard.",
       "invalidCode": "Code invalide ou expiré. Veuillez réessayer."
     }

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -5,6 +5,8 @@ import AuthService from '../services/AuthService.js';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
+import AnnouncedError from '../components/auth/AnnouncedError.js';
+import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 import { GcdsNotice, GcdsText } from '@gcds-core/components-react';
 
 const LoginPage = ({ lang = 'en' }) => {
@@ -14,14 +16,14 @@ const LoginPage = ({ lang = 'en' }) => {
   const { login, refreshUser, getDefaultRouteForRole } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
   const [isLoading, setIsLoading] = useState(false);
   const sessionExpired = new URLSearchParams(location.search).get('reason') === 'session-expired';
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
-    setError('');
+    clearError();
     // If 2FA flow already started, ignore normal submit
     if (showTwoStep) {
       setIsLoading(false);
@@ -46,11 +48,17 @@ const LoginPage = ({ lang = 'en' }) => {
   // Two-step verification state
   const [showTwoStep, setShowTwoStep] = useState(false);
   const [code, setCode] = useState('');
-  const [twoStepError, setTwoStepError] = useState('');
+  const {
+    error: twoStepError,
+    errorCount: twoStepErrorCount,
+    errorRef: twoStepErrorRef,
+    setError: setTwoStepError,
+    clearError: clearTwoStepError,
+  } = useAnnouncedError();
 
   const verifyTwoStep = async () => {
     setIsLoading(true);
-    setTwoStepError('');
+    clearTwoStepError();
     try {
       // backend method remains verify2FA
       const data = await AuthService.verify2FA(email, code);
@@ -75,7 +83,7 @@ const LoginPage = ({ lang = 'en' }) => {
   const requestTwoStep = async () => {
     if (!email) return;
     setIsLoading(true);
-    setError('');
+    clearError();
     try {
       // backend method remains send2FA
       await AuthService.send2FA(email);
@@ -105,7 +113,14 @@ const LoginPage = ({ lang = 'en' }) => {
         <div>
           <h2>{t('login.2fa.title')}</h2>
           <p>{t('login.2fa.sentToEmail')}</p>
-          {twoStepError && <div className="auth-error-message">{twoStepError}</div>}
+          {twoStepError && (
+            <AnnouncedError
+              id="login-2fa-error"
+              message={twoStepError}
+              errorCount={twoStepErrorCount}
+              inputRef={twoStepErrorRef}
+            />
+          )}
           <div className="auth-form-group">
             <label htmlFor="code">{t('login.2fa.code')}</label>
             <input id="code" value={code} onChange={(e) => setCode(e.target.value)} disabled={isLoading} />
@@ -123,7 +138,9 @@ const LoginPage = ({ lang = 'en' }) => {
         // Default login form with signup link when not in 2FA flow
         <>
           <h1>{t('login.title')}</h1>
-          {error && <div className="auth-error-message">{error}</div>}
+          {error && (
+            <AnnouncedError id="login-error" message={error} errorCount={errorCount} inputRef={errorRef} />
+          )}
           <form onSubmit={handleSubmit}>
             <div className="auth-form-group">
               <label htmlFor="email">{t('login.email')}</label>

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -4,6 +4,8 @@ import AuthService from '../services/AuthService.js';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
+import AnnouncedError from '../components/auth/AnnouncedError.js';
+import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 
 const RegisterPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -11,12 +13,12 @@ const RegisterPage = ({ lang = 'en' }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState('');
+  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError('');
+    clearError();
 
     if (password !== confirmPassword) {
       setError(t('signup.passwordMismatch'));
@@ -42,7 +44,9 @@ const RegisterPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-signup-container">
       <h1>{t('signup.title')}</h1>
-      {error && <div className="auth-error-message">{error}</div>}
+      {error && (
+        <AnnouncedError id="signup-error" message={error} errorCount={errorCount} inputRef={errorRef} />
+      )}
       <form onSubmit={handleSubmit}>
         <div className="auth-form-group">
           <label htmlFor="email">{t('signup.email')}</label>

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -4,6 +4,8 @@ import { useTranslations } from '../hooks/useTranslations.js';
 import AuthService from '../services/AuthService.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
+import AnnouncedError from '../components/auth/AnnouncedError.js';
+import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 
 const ResetCompletePage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -12,32 +14,34 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   const email = searchParams.get('email');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
-  const [message, setMessage] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!code || !email) {
-      setMessage(t('reset.complete.invalid'));
+      setError(t('reset.complete.invalid'));
     }
   }, [code, email, t]);
 
   const submit = async (e) => {
     e && e.preventDefault();
-    setMessage('');
+    setSuccessMessage('');
+    clearError();
     if (!password || password.length < 8) {
-      setMessage(t('reset.complete.passwordTooShort'));
+      setError(t('reset.complete.passwordTooShort'));
       return;
     }
     if (password !== confirm) {
-      setMessage(t('reset.complete.passwordMismatch'));
+      setError(t('reset.complete.passwordMismatch'));
       return;
     }
     setIsLoading(true);
     try {
       // TOTP-based password reset
       await AuthService.resetPassword({ email, code, password });
-      setMessage(t('reset.complete.success'));
+      setSuccessMessage(t('reset.complete.success'));
       setTimeout(() => navigate(getPath('signin', lang)), 2500);
     } catch (err) {
       const errorKeys = {
@@ -45,7 +49,7 @@ const ResetCompletePage = ({ lang = 'en' }) => {
         RESET_INVALID_CODE: 'reset.complete.invalidCode',
       };
       const key = err.code && errorKeys[err.code];
-      setMessage(key ? t(key) : t('reset.complete.error'));
+      setError(key ? t(key) : t('reset.complete.error'));
     } finally {
       setIsLoading(false);
     }
@@ -54,7 +58,10 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.complete.title')}</h1>
-      {message && <div>{message}</div>}
+      {successMessage && <div>{successMessage}</div>}
+      {error && (
+        <AnnouncedError id="reset-complete-error" message={error} errorCount={errorCount} inputRef={errorRef} />
+      )}
       <form onSubmit={submit}>
         {/* No code/OTP field — link verification is sufficient to set a new password */}
         <PasswordInput

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -58,7 +58,12 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.complete.title')}</h1>
-      {successMessage && <div>{successMessage}</div>}
+      {successMessage && (
+        <p className="thank-you" role="status" aria-live="polite">
+          <span className="gcds-icon fa fa-solid fa-check-circle" aria-hidden="true"></span>
+          {successMessage}
+        </p>
+      )}
       {error && (
         <AnnouncedError id="reset-complete-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -3,25 +3,29 @@ import { useTranslations } from '../hooks/useTranslations.js';
 import AuthService from '../services/AuthService.js';
 import { Link, useNavigate } from 'react-router-dom';
 import { getPath } from '../utils/routes.js';
+import AnnouncedError from '../components/auth/AnnouncedError.js';
+import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 
 const ResetRequestPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const [email, setEmail] = useState('');
-  const [message, setMessage] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   const submit = async (e) => {
     e && e.preventDefault();
     setIsLoading(true);
-    setMessage('');
+    setSuccessMessage('');
+    clearError();
     try {
       await AuthService.sendReset(email, lang);
-      setMessage(t('reset.request.sent'));
+      setSuccessMessage(t('reset.request.sent'));
       // Optionally redirect to signin after a short delay
       setTimeout(() => navigate(getPath('signin', lang)), 3000);
     } catch (err) {
-      setMessage(t('reset.request.error'));
+      setError(t('reset.request.error'));
     } finally {
       setIsLoading(false);
     }
@@ -30,7 +34,10 @@ const ResetRequestPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.request.title')}</h1>
-      {message && <div>{message}</div>}
+      {successMessage && <div>{successMessage}</div>}
+      {error && (
+        <AnnouncedError id="reset-request-error" message={error} errorCount={errorCount} inputRef={errorRef} />
+      )}
       <form onSubmit={submit}>
         <div className="auth-form-group">
           <label htmlFor="email">{t('login.email')}</label>

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -34,7 +34,12 @@ const ResetRequestPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.request.title')}</h1>
-      {successMessage && <div>{successMessage}</div>}
+      {successMessage && (
+        <p className="thank-you" role="status" aria-live="polite">
+          <span className="gcds-icon fa fa-solid fa-check-circle" aria-hidden="true"></span>
+          {successMessage}
+        </p>
+      )}
       {error && (
         <AnnouncedError id="reset-request-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}

--- a/src/pages/ResetVerifyPage.js
+++ b/src/pages/ResetVerifyPage.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
+import AnnouncedError from '../components/auth/AnnouncedError.js';
+import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 
 
 const ResetVerifyPage = ({ lang = 'en' }) => {
@@ -10,14 +12,14 @@ const ResetVerifyPage = ({ lang = 'en' }) => {
   const code = searchParams.get('code');
   const email = searchParams.get('email');
   const [mode, setMode] = useState('unknown');
-  const [message, setMessage] = useState('');
+  const { error, errorCount, errorRef, setError } = useAnnouncedError();
   const [isLoading] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
     // Redirect directly to reset-complete with code and email
     if (!code || !email) {
-      setMessage(t('reset.verify.invalidLink'));
+      setError(t('reset.verify.invalidLink'));
       setMode('invalid');
       return;
     }
@@ -31,8 +33,9 @@ const ResetVerifyPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.verify.title')}</h1>
-      {message && <div>{message}</div>}
-      {mode === 'invalid' && <div>{t('reset.verify.invalidLink')}</div>}
+      {mode === 'invalid' && (
+        <AnnouncedError id="reset-verify-error" message={error} errorCount={errorCount} inputRef={errorRef} />
+      )}
       {mode === 'ready' && (
         <>
           <p>{t('reset.verify.instructionsNoOtp')}</p>

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1273,16 +1273,6 @@
   cursor: not-allowed;
 }
 
-.auth-error-message {
-  padding: 12px;
-  margin-bottom: 20px;
-  background-color: #FEE;
-  border: 1px solid #FCC;
-  border-radius: 4px;
-  color: #C00;
-  font-size: 0.9rem;
-}
-
 .auth-links {
   margin-top: 20px;
   text-align: center;

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -555,12 +555,6 @@
   margin: 1em 1em 1em 1em;
 }
 
-.feedback-inline-error {
-  color: var(--gcds-error-message-text-color);
-  font-weight: var(--gcds-font-weights-bold);
-  font-size: 18px;
-}
-
 /* Add spacing between sections */
 .sentence-rating-group,
 .citation-rating-group,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,10 @@
 }
 
 /* Custom non-responsive font sizes */
+.font-size-text-sm-nr {
+  font-size: var(--gcds-font-sizes-text-small); /* 18px — GC DS token, stays this size on mobile rather than shrinking to --gcds-font-sizes-text-small-mobile (16px) */
+}
+
 .font-size-text-xsm-nr {
   font-size: 1rem !important; /* 16px */
   line-height: 1.5em;
@@ -168,6 +172,11 @@ gcds-details {
 
 .mrgn-bttm-20 {
   margin-bottom: 20px;
+}
+
+.form-error-message {
+  color: var(--gcds-error-message-text-color);
+  font-weight: var(--gcds-font-weights-bold);
 }
 
 .mrgn-bttm-10 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,22 @@
 /* Add Font Awesome CSS import at the top */
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css");
 
-/* Suppress focus ring on programmatically focused elements (tabindex="-1").
-   These are never reachable via keyboard tab so removing the outline is safe. */
+/* Suppress focus ring on programmatically focused elements (tabindex="-1")
+   that exist only to move the screen-reader cursor for a status/loading
+   announcement (e.g. FeedbackComponent's "thank you" message, ChatInterface's
+   loading indicator) — sighted keyboard users have nothing to act on there,
+   so a visible ring would be confusing rather than helpful. */
 [tabindex="-1"]:focus {
   outline: none;
+}
+
+/* Error alerts opt back into a visible ring: focus moving to a role="alert"
+   error (AnnouncedError.js, FeedbackInlineError.js) is meaningful to sighted
+   keyboard users too, not just screen readers, so they need to see where
+   focus landed. */
+[role="alert"][tabindex="-1"]:focus {
+  outline: var(--gcds-border-width-lg) solid var(--gcds-focus-background);
+  outline-offset: 2px;
 }
 
 /* Custom non-responsive font sizes */


### PR DESCRIPTION
…css cleanup

Summary:
  - Login, Register, Reset Request, Reset Verify, and Reset Complete previously pushed error text into a plain, unannounced `<div> `with no focus move — a screen-reader user who failed login or mismatched a password heard nothing. This mirrors the fix already applied to radio-group feedback errors in #1534.
  - Adds useAnnouncedError (src/hooks/auth/) + AnnouncedError (src/components/auth/) — the message-bearing sibling to useInlineFormError/FeedbackInlineError, reusing the existing useFocusOnChange hook. Each error now gets role="alert" + focus on every trigger, including repeat failures with identical text.
  - Fixed a pre-existing bug found along the way: ResetVerifyPage rendered its invalid-link message twice.
  - Unified styling: merged .feedback-inline-error (chat.css) and .auth-error-message (admin.css) into one shared .form-error-message class in global.css, since both are now the same validation-error treatment. Added .font-size-text-sm-nr (GC DS --gcds-font-sizes-text-small token, non-responsive) so it stays 18px on mobile.
  - Added the warning-triangle GcdsIcon to both error components, matching GC DS's own gcds-error-message component (decorative/aria-hidden, same as the official component).
 - Added trailing periods to the 12 auth error strings in en.json/fr.json for consistency; verified 0 locale parity gaps.