### PR TITLE
fix: feedback focus correction

### DIFF
--- a/src/components/chat/ExpertFeedbackComponent.js
+++ b/src/components/chat/ExpertFeedbackComponent.js
@@ -16,6 +16,7 @@ const ExpertFeedbackComponent = ({
   sentences = [],
   answerNumber,
   citationUrl,
+  titleRef,
 }) => {
   const { t } = useTranslations(lang);
   // Namespaces every id in this component so multiple instances can render on
@@ -146,7 +147,7 @@ const ExpertFeedbackComponent = ({
         aria-label={t('common.close')}
       />
       <fieldset className={`gc-chckbxrdio md${hasError ? ' has-error' : ''}`}>
-        <h4 className="feedback-followup-title">
+        <h4 className="feedback-followup-title" ref={titleRef} tabIndex={-1}>
           {t('homepage.expertRating.intro')}
           {answerNumber && (
             <span className="feedback-answer-number">{answerText}</span>

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import ExpertFeedbackComponent from "./ExpertFeedbackComponent.js";
 import PublicFeedbackComponent from "./PublicFeedbackComponent.js";
 import { useHasAnyRole } from "../RoleBasedUI.js";
 import { useTranslations } from "../../hooks/useTranslations.js";
 import { useFocusOnChange } from "../../hooks/useFocusOnChange.js";
+import { useReturnFocusOnClose } from "../../hooks/useReturnFocusOnClose.js";
 import FeedbackService from "../../services/FeedbackService.js";
 
 const FeedbackComponent = ({
@@ -30,6 +31,10 @@ const FeedbackComponent = ({
   const thankYouRef = useFocusOnChange(feedbackGiven);
   const expertRatingTitleRef = useFocusOnChange(showExpertRating);
   const publicRatingTitleRef = useFocusOnChange(showPublicRating);
+  const yesButtonRef = useRef(null);
+  const noButtonRef = useRef(null);
+  useReturnFocusOnClose(showExpertRating, noButtonRef);
+  useReturnFocusOnClose(showPublicRating, publicPositive ? yesButtonRef : noButtonRef);
 
   const handleFeedback = (isPositive) => {
     let feedbackPayload = null;
@@ -141,6 +146,7 @@ const FeedbackComponent = ({
         </span>
         <span className="feedback-buttons">
           <button
+            ref={yesButtonRef}
             className="feedback-link button-as-link link-default hover:link-hover"
             onClick={() => handleFeedback(true)}
             tabIndex="0"
@@ -150,6 +156,7 @@ const FeedbackComponent = ({
           </button>
           <span className="feedback-separator">·</span>
           <button
+            ref={noButtonRef}
             className="feedback-link button-as-link link-default hover:link-hover"
             onClick={() => handleFeedback(false)}
             tabIndex="0"
@@ -189,6 +196,7 @@ const FeedbackComponent = ({
       <span className="feedback-text">{t("homepage.feedback.or")}</span>
       <span className="feedback-separator">·</span>
       <button
+        ref={noButtonRef}
         className="feedback-link button-as-link"
         onClick={() => handleFeedback(false)}
         tabIndex="0"

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -28,6 +28,8 @@ const FeedbackComponent = ({
   const [publicPositive, setPublicPositive] = useState(true);
   const hasExpertRole = useHasAnyRole(["admin", "partner"]);
   const thankYouRef = useFocusOnChange(feedbackGiven);
+  const expertRatingTitleRef = useFocusOnChange(showExpertRating);
+  const publicRatingTitleRef = useFocusOnChange(showPublicRating);
 
   const handleFeedback = (isPositive) => {
     let feedbackPayload = null;
@@ -111,6 +113,7 @@ const FeedbackComponent = ({
         sentences={sentences}
         answerNumber={answerNumber}
         citationUrl={citationUrl}
+        titleRef={expertRatingTitleRef}
       />
     );
   }
@@ -124,6 +127,7 @@ const FeedbackComponent = ({
         userMessageId={userMessageId}
         onSubmit={handlePublicFeedback}
         onClose={() => setShowPublicRating(false)}
+        titleRef={publicRatingTitleRef}
       />
     );
   }

--- a/src/components/chat/PublicFeedbackComponent.js
+++ b/src/components/chat/PublicFeedbackComponent.js
@@ -13,6 +13,7 @@ const PublicFeedbackComponent = ({
   userMessageId,
   onSubmit = () => {},
   onClose,
+  titleRef,
 }) => {
   const { t } = useTranslations(lang);
   const [selected, setSelected] = useState('');
@@ -64,13 +65,15 @@ const PublicFeedbackComponent = ({
       >
         <i className="fa-solid fa-close"></i>
       </span>
-      <h4 className="feedback-followup-title">
+      <h4 className="feedback-followup-title" id="public-feedback-title">
         {isPositive ? t('homepage.publicFeedback.yes.title') : t('homepage.publicFeedback.no.title')}
       </h4>
       <div className="feedback-reason-card">
         <fieldset
           className={`gc-chckbxrdio feedback-reason-fieldset${hasError ? ' has-error' : ''}`}
-          aria-labelledby="public-feedback-legend public-feedback-hint"
+          aria-labelledby="public-feedback-title public-feedback-legend public-feedback-hint"
+          ref={titleRef}
+          tabIndex={-1}
         >
           <legend id="public-feedback-legend">
             {isPositive ? t('homepage.publicFeedback.yes.shortQuestion') : t('homepage.publicFeedback.no.shortQuestion')}{' '}

--- a/src/hooks/useReturnFocusOnClose.js
+++ b/src/hooks/useReturnFocusOnClose.js
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+// Focuses `targetRef` when `isOpen` transitions from true to false (the user
+// closed a disclosure/panel) — not on initial mount, when nothing was ever
+// open. Mirrors useFocusOnChange but for the closing edge, so focus returns
+// to the control that opened the panel instead of being lost to <body> when
+// the panel unmounts.
+export const useReturnFocusOnClose = (isOpen, targetRef) => {
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen && wasOpenRef.current) {
+      targetRef.current?.focus();
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, targetRef]);
+};


### PR DESCRIPTION
Focus-management fix:
  - Focus management — correct: closing the panel now returns focus to the triggering button instead of dropping to `<body>,` matching the ARIA APG disclosure-dismissal pattern.