### PR TITLE
fix: AI eval panel hidden even when an evaluation exists

### DIFF
--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -121,7 +121,7 @@ const EvalPanel = ({ message, t, lang = 'en', answerNumber }) => {
 
   if (!message) return null;
 
-  const evalObj = data || message.interaction?.eval || message.eval || null;
+  const evalObj = data || message.interaction?.autoEval || message.autoEval || null;
   const sentenceTrace = Array.isArray(evalObj?.sentenceMatchTrace) ? evalObj.sentenceMatchTrace : [];
   const sim = evalObj?.similarityScores || {};
   const noMatch = evalObj?.hasMatches === false;


### PR DESCRIPTION
 evalObj checked interaction.eval, a field that has never existed on the
  Interaction schema (the real field is autoEval) — dead code since the
  panel was created. It stayed harmless while the panel always rendered,
  but the recent "hide eval options if no results" change started gating
  the entire panel on evalObj, so every AI eval, present or not, was
  hidden.