### PR TITLE
feat: add program files

### DIFF
--- a/agents/prompts/scenarios/context-aafc-aac/aafc-aac-programs.md
+++ b/agents/prompts/scenarios/context-aafc-aac/aafc-aac-programs.md
@@ -1,0 +1,20 @@
+# AAFC-AAC programs
+
+Curated list of Agriculture and Agri-Food Canada programs used to keep program
+tagging consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-bac-lac/bac-lac-programs.md
+++ b/agents/prompts/scenarios/context-bac-lac/bac-lac-programs.md
@@ -1,0 +1,21 @@
+# BAC-LAC programs
+
+Curated list of Library and Archives Canada programs used to keep program
+tagging consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Census records |  |
+| Collection Search |  |
+| Genealogy |  |

--- a/agents/prompts/scenarios/context-cbsa-asfc/cbsa-asfc-programs.md
+++ b/agents/prompts/scenarios/context-cbsa-asfc/cbsa-asfc-programs.md
@@ -1,0 +1,20 @@
+# CBSA-ASFC programs
+
+Curated list of Canada Border Services Agency programs used to keep program
+tagging consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-cds-snc/cds-snc-programs.md
+++ b/agents/prompts/scenarios/context-cds-snc/cds-snc-programs.md
@@ -1,0 +1,20 @@
+# CDS-SNC programs
+
+Curated list of Canadian Digital Service programs used to keep program tagging
+consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-ceo-bec/ceo-bec-programs.md
+++ b/agents/prompts/scenarios/context-ceo-bec/ceo-bec-programs.md
@@ -1,0 +1,20 @@
+# CEO-BEC programs
+
+Curated list of this department's programs used to keep program tagging
+consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-programs.md
+++ b/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-programs.md
@@ -1,0 +1,40 @@
+# DND-MDN programs
+
+Curated list of National Defence / Canadian Armed Forces programs used to keep
+program tagging consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---------------------------------------------|---|
+| Access to Information and Privacy |  |
+| Canadian Armed Forces Retirement Dress (CAFRD) |  |
+| Canadian Cadet Organizations |  |
+| Canadian Forces Health Services |  |
+| Compensation and Benefits Instructions |  |
+| Early Retirement Incentive |  |
+| Imposed Restriction |  |
+| Military leave |  |
+| Military maternity and parental benefits |  |
+| Military medical and dental benefits |  |
+| Military medical records |  |
+| Military pay |  |
+| Military promotions |  |
+| Military relocation |  |
+| Military release process |  |
+| Military Transition Program |  |
+| Provincial health insurance plan |  |
+| Public Service Pension Plan |  |
+| Queen's Regulations and Orders |  |
+| Severance pay |  |
+| Standing offer |  |
+| Vocational Rehabilitation Program for Serving Members |  |

--- a/agents/prompts/scenarios/context-eccc/eccc-programs.md
+++ b/agents/prompts/scenarios/context-eccc/eccc-programs.md
@@ -1,0 +1,22 @@
+# ECCC programs
+
+Curated list of Environment and Climate Change Canada programs used to keep
+program tagging consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| 2030 Nature Strategy |  |
+| Convention on Biological Diversity |  |
+| Weather forecasts |  |
+| Wildlife rehabilitation |  |

--- a/agents/prompts/scenarios/context-edsc-esdc/edsc-esdc-programs.md
+++ b/agents/prompts/scenarios/context-edsc-esdc/edsc-esdc-programs.md
@@ -1,0 +1,40 @@
+# EDSC-ESDC programs
+
+Curated list of Employment and Social Development Canada / Service Canada
+programs used to keep program tagging consistent across questions. One program
+per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Canada Disability Benefit |  |
+| Canada Education Savings Grant |  |
+| Canada Pension Plan |  |
+| Canada Student Grants and Canada Student Loans |  |
+| Canadian Dental Care Plan |  |
+| CPP children's benefit |  |
+| CPP death benefit |  |
+| CPP disability benefits |  |
+| Employment insurance - Benefits for self-employed |  |
+| Employment insurance - Caregiving benefits |  |
+| Employment insurance - Fishing benefits |  |
+| Employment insurance - maternity and parental benefits |  |
+| Employment insurance - regular benefits |  |
+| Employment insurance - sickness benefits |  |
+| Job Bank |  |
+| Labour Program |  |
+| My Service Canada Account |  |
+| Old Age Security |  |
+| Public Service Health Care Plan |  |
+| Social Insurance Number |  |
+| Workplace harassment and violence prevention |  |

--- a/agents/prompts/scenarios/context-fin/fin-programs.md
+++ b/agents/prompts/scenarios/context-fin/fin-programs.md
@@ -1,0 +1,20 @@
+# FIN programs
+
+Curated list of Department of Finance Canada programs used to keep program
+tagging consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-hc-sc/hc-sc-programs.md
+++ b/agents/prompts/scenarios/context-hc-sc/hc-sc-programs.md
@@ -1,0 +1,37 @@
+# HC-SC programs
+
+Curated list of Health Canada programs used to keep program tagging consistent
+across questions. One program per row.
+
+This file also covers the **Public Health Agency of Canada (PHAC-ASPC)**, which
+shares Health Canada's scenario folder — add PHAC programs here too.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| COVID-19 public health guidance |  |
+| Canada's Food Guide |  |
+| Consumer product safety |  |
+| Display Fireworks Safety |  |
+| Fall prevention for seniors |  |
+| Food safety |  |
+| Group insurance plans |  |
+| Health complaints office |  |
+| Healthy Pregnancy Guide |  |
+| Home and garden safety |  |
+| Measles public health guidance |  |
+| Medical assistance in dying (MAID) |  |
+| Mental health support |  |
+| Pest Control Products |  |
+| Product safety certification |  |
+| Public Health Hygiene Guidelines |  |

--- a/agents/prompts/scenarios/context-ircc/ircc-programs.md
+++ b/agents/prompts/scenarios/context-ircc/ircc-programs.md
@@ -1,0 +1,31 @@
+# IRCC programs
+
+Curated list of Immigration, Refugees and Citizenship Canada programs used to
+keep program tagging consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Adult passport |  |
+| Child passport |  |
+| Citizenship |  |
+| Electronic travel authorization (eTA) |  |
+| IRCC account |  |
+| Immigrate - general |  |
+| Immigration - express entry |  |
+| Immigration - provincial nominee |  |
+| Permanent Residency |  |
+| Refugee protection |  |
+| Study permit |  |
+| Visitor visa |  |
+| Work permit |  |

--- a/agents/prompts/scenarios/context-ised-isde/ised-isde-programs.md
+++ b/agents/prompts/scenarios/context-ised-isde/ised-isde-programs.md
@@ -1,0 +1,26 @@
+# ISED-ISDE programs
+
+Curated list of Innovation, Science and Economic Development Canada programs used
+to keep program tagging consistent across questions. One program per row.
+
+This file also covers the **regional development agencies** (ACOA, CED-QR,
+CanNor, FedDev Ontario, FedNor, PacifiCan, PrairiesCan), which share ISED's
+scenario folder — add their programs here too.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Amateur radio call signs |  |
+| Canada Digital Identity Grant Program |  |
+| Women Entrepreneurship Loan Fund |  |
+| Women's Enterprise Initiative |  |

--- a/agents/prompts/scenarios/context-jus/jus-programs.md
+++ b/agents/prompts/scenarios/context-jus/jus-programs.md
@@ -1,0 +1,20 @@
+# JUS programs
+
+Curated list of Justice Canada programs used to keep program tagging consistent
+across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-nrcan-rncan/nrcan-rncan-programs.md
+++ b/agents/prompts/scenarios/context-nrcan-rncan/nrcan-rncan-programs.md
@@ -1,0 +1,20 @@
+# NRCAN-RNCAN programs
+
+Curated list of Natural Resources Canada programs used to keep program tagging
+consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/prompts/scenarios/context-sac-isc/sac-isc-programs.md
+++ b/agents/prompts/scenarios/context-sac-isc/sac-isc-programs.md
@@ -1,0 +1,28 @@
+# SAC-ISC programs
+
+Curated list of Indigenous Services Canada programs used to keep program tagging
+consistent across questions. One program per row.
+
+This file also covers **Crown-Indigenous Relations and Northern Affairs
+(RCAANC-CIRNAC)**, which shares this scenario folder — add its programs here too.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Aboriginal Entrepreneurship Program |  |
+| Contributions to support service transfer and transformation |  |
+| Indian status |  |
+| Indian status registration |  |
+| Non-Insured Health Benefits (NIHB) |  |
+| Secure Certificate of Indian Status (SCIS) |  |
+| Treaty Annuities |  |

--- a/agents/prompts/scenarios/context-statcan/statcan-programs.md
+++ b/agents/prompts/scenarios/context-statcan/statcan-programs.md
@@ -1,0 +1,24 @@
+# STATCAN programs
+
+Curated list of Statistics Canada programs used to keep program tagging
+consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Annual Survey of Manufactures and Logging |  |
+| Census jobs |  |
+| Census of Population |  |
+| Consumer Price Index (CPI) |  |
+| Labour Force Survey |  |
+| Population estimates |  |

--- a/agents/prompts/scenarios/context-tbs-sct/tbs-sct-programs.md
+++ b/agents/prompts/scenarios/context-tbs-sct/tbs-sct-programs.md
@@ -1,0 +1,38 @@
+# TBS-SCT programs
+
+Curated list of Treasury Board of Canada Secretariat programs used to keep
+program tagging consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Access to Information |  |
+| Commerce and Purchasing collective agreement |  |
+| Conflict of interest disclosure |  |
+| Early Retirement Incentive |  |
+| Economic Development Collective Agreement |  |
+| Government of Canada AI Strategy |  |
+| Pay equity |  |
+| Pensioners' Dental Services Plan |  |
+| Performance management program |  |
+| Policy on Service and Digital |  |
+| Public Service Dental Care Plan |  |
+| Public Service Disability Insurance Plan |  |
+| Public Service Employment |  |
+| Public Service Health Care Plan |  |
+| Public Service Labour Relations |  |
+| Public Service Pension Plan |  |
+| Public Service Supplementary Death Benefit |  |
+| Treasury Board Secretariat risk taxonomy |  |
+| Values and Ethics in the Public Sector |  |
+| Workforce Adjustment Policy |  |

--- a/agents/prompts/scenarios/context-tc/tc-programs.md
+++ b/agents/prompts/scenarios/context-tc/tc-programs.md
@@ -1,0 +1,26 @@
+# TC programs
+
+Curated list of Transport Canada programs used to keep program tagging
+consistent across questions. One program per row.
+
+**How to edit (for partners):**
+- Add a row for a missing program; remove one that doesn't apply.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here. The Français column is a
+draft placeholder — fill in the official French program names.
+
+| English | Français |
+|---|---|
+| Aircraft registration |  |
+| Aviation Document Booklet |  |
+| Aviation licensing |  |
+| Boating safety |  |
+| Civil Aviation Medical Certificate |  |
+| Marine Medical Certificate |  |
+| Pleasure Craft Licence (PCL) |  |
+| Pleasure Craft Operator Card (PCOC) |  |

--- a/agents/prompts/scenarios/context-vac-acc/vac-acc-programs.md
+++ b/agents/prompts/scenarios/context-vac-acc/vac-acc-programs.md
@@ -1,0 +1,20 @@
+# VAC-ACC programs
+
+Curated list of Veterans Affairs Canada programs used to keep program tagging
+consistent across questions. One program per row.
+
+**This is a starter file** — no programs have been curated yet. Add your
+department's programs to the table below.
+
+**How to edit (for partners):**
+- Add a row for each program your department is asked about.
+- Keep the two columns: **English** name, then the official **Français** name.
+- Use the official Government of Canada program name (as it appears on canada.ca),
+  not a web-page or section title.
+- Keep the header row and the `|---|---|` separator line intact.
+
+The English names anchor the classifier; the French names are used for display to
+French users. Both are stored exactly as written here.
+
+| English | Français |
+|---|---|

--- a/agents/strategies/evalAnalysisClassifyStrategy.js
+++ b/agents/strategies/evalAnalysisClassifyStrategy.js
@@ -1,50 +1,13 @@
-// Strategies for the partner eval-analysis program classification (Tier 2).
+// Strategy for the partner eval-analysis program classification (Tier 2).
 //
 // NOTE FOR PROMPT MAINTAINERS: the prompt text below is new and has not been
 // through the prompt-tuning process. It lives here (not in agents/prompts/)
 // because it is analysis tooling, not part of the answer pipeline — but the
 // wording should still be reviewed by Lisa Fast or Ryan Hyma before shipping.
-// The program-naming / URL / account rules are shared with the per-question
-// classifier via programClassificationGuidance.js.
+// The URL / account rules are shared with the per-question classifier via
+// programClassificationGuidance.js.
 
-import { PROGRAM_NAMING_RULE, URL_EVIDENCE_RULE, ACCOUNT_RULE, extractJson } from './programClassificationGuidance.js';
-
-const PROGRAM_PROPOSAL_PROMPT = `You are analyzing questions asked to a Government of Canada AI assistant so a team of expert evaluators can spot patterns by program.
-
-Propose a set of program groups that partitions the sample questions by the government program (or subject) users were asking about. Name the program, not the activity: a separate pass tags what the user was trying to do (apply, sign in, change contact information…), so "Canada child benefit" is right and "Updating address with CRA" is wrong — the action half would be redundant. Aim for groups specific enough that score differences between them are actionable (a named program or subject — not "general inquiries"), but broad enough that most groups will collect several questions. 5-15 groups is the useful range. The seed vocabulary shows the granularity wanted; when a seed name fits the sample, use it verbatim, but derive groups from the questions themselves — do not include seed entries nothing was asked about. ${PROGRAM_NAMING_RULE} ${URL_EVIDENCE_RULE} ${ACCOUNT_RULE}
-
-Respond with ONLY a JSON object: {"programs": ["...", "..."]}. Program group names in English, max 6 words each.`;
-
-// request: { department, seedPrograms: string[], sampleRows: [{ q, cite, ref }] }
-export const evalAnalysisProgramsStrategy = {
-  buildMessages: (request = {}) => {
-    const { department = '', seedPrograms = [], sampleRows = [] } = request;
-    return [
-      { role: 'system', content: PROGRAM_PROPOSAL_PROMPT },
-      {
-        role: 'user',
-        content: JSON.stringify({
-          department,
-          seed_vocabulary: seedPrograms,
-          sample_questions: sampleRows.map((r) => ({ question: r.q, citation_url: r.cite, referring_url: r.ref }))
-        })
-      }
-    ];
-  },
-  parse: (normalized) => {
-    const { parsed, raw } = extractJson(normalized?.content, '{', '}');
-    const programs = Array.isArray(parsed?.programs)
-      ? parsed.programs.filter((t) => typeof t === 'string' && t.trim()).map((t) => t.trim())
-      : null;
-    return {
-      programs,
-      raw,
-      model: normalized.model,
-      inputTokens: normalized.inputTokens,
-      outputTokens: normalized.outputTokens
-    };
-  }
-};
+import { URL_EVIDENCE_RULE, ACCOUNT_RULE, extractJson } from './programClassificationGuidance.js';
 
 const CLASSIFY_PROMPT = `You are tagging questions asked to a Government of Canada AI assistant so evaluators can cross-tabulate expert scores by program and by what the user was trying to do.
 

--- a/api/chat/chat-export-logs.js
+++ b/api/chat/chat-export-logs.js
@@ -115,6 +115,8 @@ const DEFAULT_HEADER_ORDER = [
     'redactedQuestion',
     'aiService',
     'context.department',
+    'context.program',
+    'context.action',
     'citationUrl',
     'englishAnswer',
     'answer',
@@ -408,6 +410,11 @@ function flattenInteraction(chat, interaction, view) {
             'expertFeedback.updatedAt': get(interaction, 'expertFeedback.updatedAt') ? new Date(get(interaction, 'expertFeedback.updatedAt')).toISOString() : '',
 
             'context.department': get(interaction, 'context.department'),
+            // Per-question program/action classification (see
+            // docs/plans/program-action-classification.md). Set explicitly so
+            // the columns export even when the value is the default ''.
+            'context.program': get(interaction, 'context.program'),
+            'context.action': get(interaction, 'context.action'),
             'context.searchQuery': get(interaction, 'context.searchQuery'),
             // Context search results might be array/object, flatten or stringify? Default behavior is usually stringify for cells if object.
             'context.searchResults': JSON.stringify(get(interaction, 'context.searchResults', '')),

--- a/api/data/__tests__/programSeedsLoader.test.js
+++ b/api/data/__tests__/programSeedsLoader.test.js
@@ -51,18 +51,34 @@ describe('getSeedPrograms / getProgramNameMap — CRA from the .md file', () => 
   });
 });
 
-describe('getSeedPrograms — fallback for departments without a .md file', () => {
-  it('falls back to the legacy hardcoded seeds (EDSC-ESDC)', () => {
+describe('getSeedPrograms / getProgramNameMap — EDSC-ESDC now curated from .md', () => {
+  it('loads EDSC-ESDC programs from its curated .md file', () => {
     const programs = getSeedPrograms('EDSC-ESDC');
     expect(programs).toContain('Canada Pension Plan');
+    expect(programs).toContain('Old Age Security');
   });
 
+  it('has an empty French map while the EDSC-ESDC .md Français column is unfilled', () => {
+    // Draft .md files ship with a blank Français column; only real EN→FR pairs
+    // populate the map, so it stays empty until French names are added.
+    expect(getProgramNameMap('EDSC-ESDC').size).toBe(0);
+  });
+});
+
+describe('getSeedPrograms — aliased departments resolve to the primary .md', () => {
+  it('resolves PHAC-ASPC to the shared HC-SC program list', () => {
+    const programs = getSeedPrograms('PHAC-ASPC');
+    expect(programs).toContain('COVID-19 public health guidance');
+  });
+});
+
+describe('getSeedPrograms — empty cases', () => {
   it('returns an empty list for an unknown department', () => {
     expect(getSeedPrograms('NOT-A-DEPT')).toEqual([]);
   });
 
-  it('has no French map when falling back to legacy seeds', () => {
-    expect(getProgramNameMap('EDSC-ESDC').size).toBe(0);
+  it('returns an empty list for a stub department whose .md has no program rows', () => {
+    expect(getSeedPrograms('FIN')).toEqual([]);
   });
 });
 

--- a/api/data/programActionSeeds.js
+++ b/api/data/programActionSeeds.js
@@ -10,52 +10,15 @@
 // abbrKey (see agents/prompts/scenarios/departments_EN.js — never invent new
 // abbrKeys); the action list is global across departments.
 //
-// MIGRATING TO PER-DEPARTMENT MARKDOWN: departments are moving to a curated,
-// partner-editable EN/FR list at
+// PER-DEPARTMENT MARKDOWN IS NOW THE SOURCE OF TRUTH: each department's programs
+// live in a curated, partner-editable EN/FR list at
 //   agents/prompts/scenarios/context-<dept-dashed>/<dept-dashed>-programs.md
-// loaded via programSeedsLoader.js (getSeedPrograms), which falls back to the
-// arrays below for any department without a file yet. CRA-ARC has migrated and
-// is intentionally no longer listed here — its .md is the source of truth.
+// loaded via programSeedsLoader.js (getSeedPrograms). Every department that had
+// harvested programs has migrated to its .md, so this map is now empty; it is
+// kept only as the loader's fallback for any department that has neither a .md
+// file nor yet-harvested programs (the loader returns [] in that case).
 
-export const PROGRAM_SEEDS_BY_DEPARTMENT = {
-    'EDSC-ESDC': [
-        'Canada Disability Benefit',
-        'Canadian Dental Care Plan',
-        'Canada Education Savings Grant',
-        'Canada Pension Plan',
-        "CPP children's benefit",
-        'CPP disability benefits',
-        'CPP death benefit',
-        'Canada Student Grants and Canada Student Loans',
-        'Social Insurance Number',
-        'Employment insurance - regular benefits',
-        'Employment insurance - sickness benefits',
-        'Employment insurance - maternity and parental benefits',
-        'Employment insurance - Caregiving benefits',
-        'Employment insurance - Fishing benefits',
-        'Employment insurance - Benefits for self-employed',
-        'My Service Canada Account',
-        'Old Age Security'
-    ],
-    'TBS-SCT': [
-        'Early Retirement Incentive'
-    ],
-    IRCC: [
-        'Adult passport',
-        'Child passport',
-        'Electronic travel authorization (eTA)',
-        'Visitor visa',
-        'Study permit',
-        'Work permit',
-        'Immigrate - general',
-        'Immigration - express entry',
-        'Immigration - provincial nominee',
-        'Refugee protection',
-        'Permanent Residency',
-        'Citizenship',
-        'IRCC account'
-    ]
-};
+export const PROGRAM_SEEDS_BY_DEPARTMENT = {};
 
 // Global action vocabulary: what the user is trying to DO with a program.
 // `synonyms` help the classifier recognize phrasing variants.

--- a/api/data/programSeedsLoader.js
+++ b/api/data/programSeedsLoader.js
@@ -60,7 +60,10 @@ function load(abbrKey) {
 
   let entry;
   if (programs && programs.length > 0) {
-    entry = { programs, enToFr: new Map(programs.map((p) => [p.en, p.fr])) };
+    // Only real EN→FR pairs go in the map — draft files ship with a blank
+    // Français column, and an en→'' entry would clobber the English fallback
+    // for any consumer that localizes a program name.
+    entry = { programs, enToFr: new Map(programs.filter((p) => p.fr).map((p) => [p.en, p.fr])) };
   } else {
     const fallback = (PROGRAM_SEEDS_BY_DEPARTMENT[resolveScenarioKey(abbrKey)] || PROGRAM_SEEDS_BY_DEPARTMENT[abbrKey] || [])
       .map((en) => ({ en, fr: '' }));

--- a/docs/plans/partner-eval-analysis.md
+++ b/docs/plans/partner-eval-analysis.md
@@ -85,6 +85,18 @@ New stats this feature computes (input to the report + the insight pass):
 
 ### Tier 2 — LLM program classification (chunked)
 
+> **Updated (July 2026) — now prefers stored values.** This tier was written
+> before the per-question program/action classifier existed. It now **reuses the
+> stored `context.program`/`context.action`** for every row that has them, and
+> only falls back to the LLM for rows still lacking a program **whose answer type
+> is normal** (non-normal turns — not-gc / pt-muni / clarifying-question — carry
+> no GC program and stay unclassified). The fallback classifies against the
+> department's **curated seed list** (`getSeedPrograms`) plus program names
+> already present in the run — the emergent program-proposal call was removed. No
+> write-back to `context`. See
+> [program-action-classification.md → Phase 2 §5](./program-action-classification.md#5-rationalize-with-the-eval-analysis-tier-2-decided-july-2026).
+> The description below is the original design, kept for context.
+
 Tag each evaluated Q&A with an **emergent program group** and an **action**
 (Apply, Check status, Pay, Sign in, …). Inputs per row: question, answer (first
 sentence or two), **citationUrl and referringUrl** (strong program clues).

--- a/docs/plans/program-action-classification.md
+++ b/docs/plans/program-action-classification.md
@@ -214,6 +214,10 @@ FR map coalesce obvious variants immediately, no data migration), plus a
 **D-style review list** feeding the curated `.md` for the rest, with **C**
 reserved only if semantic drift dominates once we can measure it.
 
+> **See also Phase 2 below** — rolling curated `.md` lists to all partners is the
+> **source-side** version of this mitigation (fix the seed vocabulary so the
+> classifier snaps to canonical names), complementary to read-time coalescing.
+
 ### Where it runs / write-back
 
 - Read-time coalescing (A/B) lives next to `getAllProgramNameMap` /
@@ -241,3 +245,140 @@ handful of aliases (→ A) or a long tail (→ B + D), and whether C is worth it
   for GC program names that differ by a single word? Needs the audit data.
 - Who curates the review list (D) — CDS only, or partners for their own
   department, mirroring the `.md` edit model?
+
+## Phase 2 — curated program lists for all partners + eval-analysis rationalization
+
+**Status:** planned (July 2026). **Owner:** Lisa Fast.
+
+Phase 1 migrated only CRA-ARC to a curated `.md`. Phase 2 rolls a curated program
+list to **every partner that has a scenario folder**, seeded from a cleaned
+version of the auto-harvested draft (`.../CDS/AI/programs-by-dept-draft.csv` — a
+dump of the `context.program` values the classifier has emitted over the last few
+weeks), and rationalizes the two places programs/actions get produced (this
+classifier vs. the eval-analysis Tier-2). Curating the seed vocabulary at the
+source is the drift mitigation from the section above, applied before the fact.
+
+### 1. Rollout target
+
+One `context-<dept>/<dept>-programs.md` per partner folder, same format as
+`cra-arc-programs.md` (English | Français, curated header, one program per row).
+The draft covers 13 departments: BAC-LAC, CEO-BEC, DND-MDN, ECCC, EDSC-ESDC,
+HC-SC, IRCC, ISED-ISDE, PHAC-ASPC, SAC-ISC, STATCAN, TBS-SCT, TC.
+
+- **Aliased departments share the primary's file.** `PHAC-ASPC` has no scenario
+  folder — it resolves to `HC-SC` via `resolveScenarioKey`, and the loader keys
+  the file off the *resolved* abbrKey. So PHAC-ASPC programs are **merged into
+  `hc-sc-programs.md`**, not given their own file. Same rule for every other
+  aliased abbrKey (Defence portfolio → DND-MDN, RCAANC → SAC-ISC, RDAs →
+  ISED-ISDE): curate at the primary folder. Net: 13 draft departments → **12
+  files** (PHAC folds into HC-SC).
+- Scenario folders with no draft data yet (AAFC-AAC, CBSA-ASFC, CDS-SNC, FIN,
+  JUS, NRCAN-RNCAN, VAC-ACC) keep falling back to model knowledge until they
+  accrue data — no empty files.
+
+### 2. CSV cleanup rules (draft → curated)
+
+The harvest is raw classifier output and has three recurring defects. Apply
+before writing each `.md`:
+
+- **Department-name-as-program → drop it.** The classifier sometimes emitted the
+  department's own name as the "program"; that carries no granularity — remove
+  the row (the question then buckets as `unknown`/empty, which is correct).
+  Examples to drop: "Environment and Climate Change Canada", "Health Canada",
+  "Public Health Agency of Canada", "Statistics Canada" / "Statistics Canada
+  surveys", "Indigenous Services Canada", "Treasury Board of Canada Secretariat",
+  plus placeholder rows like "AI Answers" / "Canada.ca guidance" (CEO-BEC).
+- **Strip the `Canadian Armed Forces` / `CAF` prefix (DND).** The harvest
+  prepended the organization onto dozens of DND rows ("Canadian Armed Forces
+  release process", "CAF Transition Services"), which is duplicative and makes
+  names hard to parse. Strip the prefix and merge the sprawling
+  release/transition/pay/benefits variants down to a small set of canonical
+  programs. Stripping is safe here — the DND partners review their own file, and
+  program names don't have to be unique across departments.
+- **Dedupe variants/typos → one canonical name.** The whole point of the seed
+  file is one name per program. Collapse case / punctuation / abbreviation /
+  singular-plural / typo variants. Examples: "Consumer Price Index" +
+  "Consumer Price Index (CPI)"; "Census" + "Census of Population" + "Statistics
+  Canada Census" + "2021 Census of Population"; "Pleasure Craft Licence" +
+  "(PCL)" + "Pleasure Craft Licensing"; "Pleasure Craft Operator Card" +
+  "(PCOC)"; "Pensioners Dental Services Plan" + "Pensioners' Dental Services
+  Plan"; "Public Service Pension" + "Public Service Pension Plan"; typos
+  "Geneology" → "Genealogy", "Canada Dentall Care Plan" → "Canada Dental Care
+  Plan".
+
+**Programs need not be unique across departments.** Each partner curates its
+**own** file, so a genuinely shared program (e.g. Public Service Health Care Plan
+/ Pension Plan / Dental Care Plan) may legitimately appear in several department
+files, and there is no requirement to coordinate identical wording across them.
+Cleanup is only ever *within* a file: strip the department's own name and dedupe
+that file's variants.
+
+### 3. French names
+
+Draft `.md` files land with the **English column populated** from the cleaned
+harvest and the **Français column blank**. The loader tolerates an empty FR cell
+(`getSeedPrograms` uses `.en`; `getAllProgramNameMap` skips en-only rows) — so an
+EN-only draft is strictly better than today's English-only fallback arrays, with
+no FR regression. Official French program names are filled in afterward by Lisa /
+partners, same edit model as CRA-ARC. Do **not** machine-generate official GC
+program names (consistent with the EN-first MVP).
+
+### 4. Retire the legacy seed arrays
+
+`programActionSeeds.js` still hardcodes program arrays for **EDSC-ESDC**,
+**IRCC**, and **TBS-SCT** (one entry). Once each has a curated `.md`, remove its
+array from `PROGRAM_SEEDS_BY_DEPARTMENT` (mirroring how CRA-ARC was removed) so
+the `.md` is the single source of truth and the two can't diverge. The draft
+`.md` for those three should **merge** the existing array entries with the
+cleaned harvest — the arrays hold curated names the harvest may miss (EI
+sub-benefit breakdowns, IRCC `Study permit` / `Citizenship`, etc.). `ACTION_SEEDS`
+and `OTHER_LABEL` stay in `programActionSeeds.js` — actions remain a global,
+non-department list.
+
+### 5. Rationalize with the eval-analysis Tier-2 (decided July 2026)
+
+`partner-eval-analysis.md` predates this classifier, so its Tier-2 runs its own
+two-pass emergent program/action grouping — which now double-classifies every
+recent normal question (those already carry `context.program`/`context.action`).
+
+Decision: **read stored, keep Tier-2 as a fallback.**
+
+- Eval-analysis uses the stored `context.program` / `context.action` when
+  present — so recent rows bucket **identically to the partner volume card** (one
+  curated taxonomy). No re-classification of already-tagged rows.
+- For rows still at `''` (historical, or a failed classify call), Tier-2 runs as
+  before to fill the gap **for that report only** — it does **not** write back to
+  `context.program` (see below). When it falls back it should classify against the
+  **curated seed lists** (`programSeedsLoader.getSeedPrograms` for the row's
+  department) rather than proposing a fresh emergent set, so a historical CPP row
+  and a recent CPP row land in the same bucket.
+- **Gate the fallback on answer type — only classify `normal`-type rows.**
+  Non-normal answers (`not-gc`, `pt-muni`, `clarifying-question`) carry no GC
+  program and must be skipped, exactly as the per-question classifier does via
+  `NON_CLASSIFIABLE_ANSWER_TYPES` (`api/util/answerTypes.js`). **This is a bug in
+  the current eval-analysis:** `EvalAnalysisService` already projects
+  `interactions.answerType` (row fetch) but never filters on it, so today it
+  classifies clarifying-question / not-gc / pt-muni rows too. Reuse the shared
+  `NON_CLASSIFIABLE_ANSWER_TYPES` set so both paths gate identically — don't
+  reimplement the type list.
+- **No backfill** (decided): historical interactions are not re-run through the
+  classifier. Dashboards read stored values only, so pre-feature rows stay in the
+  existing `unknown`/empty bucket and coverage improves organically as new
+  questions arrive. Revisit only if the historical gap proves to matter.
+
+Net effect: one canonical program/action vocabulary (curated `.md` +
+`ACTION_SEEDS`), produced once by the classifier for new questions and reused
+everywhere; the eval-analysis Tier-2 shrinks to a gap-filler for old data. The
+`partner-eval-analysis.md` Tier-2 section should get a pointer back here noting it
+now prefers stored values.
+
+### Open items for the walkthrough
+
+- The initial draft I generate is a **first cut** for partners to curate; I'll
+  pick a reasonable canonical name per merged cluster (esp. the DND
+  release/transition/pay family and the STATCAN census/CPI/survey clusters), and
+  partners refine their own file afterward.
+- Whether to seed FR for the highest-volume programs in the same PR or defer all
+  FR to a follow-up.
+- Confirm which of the seven data-less scenario folders (if any) you want stubbed
+  now vs. left on model-knowledge fallback.

--- a/public/content/about-en.md
+++ b/public/content/about-en.md
@@ -52,9 +52,7 @@ For detailed information about how AI Answers works, our safety measures, evalua
 - [Current status](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#current-status)
 - [System purpose and scope](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#system-purpose-and-scope)
 - [Technical architecture](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#technical-architecture)
-- [Risk assessment and safety measures](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#risk-assessment-and-safety-measures)
 - [Performance and evaluation](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#performance-and-evaluation)
-- [Limitations and constraints](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#limitations-and-constraints)
 - [Responsible AI principles and governance](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD.md#responsible-ai-principles-and-governance)
 
 ## Contact us

--- a/public/content/about-fr.md
+++ b/public/content/about-fr.md
@@ -52,9 +52,7 @@ Pour des informations détaillées sur le fonctionnement de Réponses IA, nos me
 - [État actuel](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#état-actuel)
 - [Objectif et portée du système](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#objectif-et-portée-du-système)
 - [Architecture technique](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#architecture-technique)
-- [Évaluation des risques et mesures de sécurité](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#évaluation-des-risques-et-mesures-de-sécurité)
 - [Performance et évaluation](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#performance-et-évaluation)
-- [Limitations et contraintes](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#limitations-et-contraintes)
 - [Principes d'IA responsable et gouvernance](https://github.com/cds-snc/ai-answers/blob/main/SYSTEM_CARD_FR.md#principes-dia-responsable-et-gouvernance)
 
 ## Contactez-nous

--- a/services/EvalAnalysisService.js
+++ b/services/EvalAnalysisService.js
@@ -6,13 +6,10 @@ import {
     getPartnerEvalAggregationExpression,
     getAiEvalAggregationExpression
 } from '../api/util/chat-filters.js';
-import { toCompactRow, computeStats, buildCrossTab } from './evalAnalysisStats.js';
+import { toCompactRow, computeStats, buildCrossTab, rowNeedsClassification } from './evalAnalysisStats.js';
 import AgentOrchestratorService from '../agents/AgentOrchestratorService.js';
 import { createEvalAnalysisAgent } from '../agents/AgentFactory.js';
-import {
-    evalAnalysisProgramsStrategy,
-    evalAnalysisClassifyStrategy
-} from '../agents/strategies/evalAnalysisClassifyStrategy.js';
+import { evalAnalysisClassifyStrategy } from '../agents/strategies/evalAnalysisClassifyStrategy.js';
 import { evalAnalysisInsightsStrategy } from '../agents/strategies/evalAnalysisInsightsStrategy.js';
 import { ACTION_SEEDS, OTHER_LABEL } from '../api/data/programActionSeeds.js';
 import { getSeedPrograms } from '../api/data/programSeedsLoader.js';
@@ -25,7 +22,6 @@ export const MIN_EVALS = 20;
 export const MAX_EVALS = 200;
 
 const CLASSIFY_CHUNK_SIZE = 20;
-const PROGRAM_SAMPLE_SIZE = 80;
 
 const parseDateRange = (filters = {}) => {
     const start = filters.startDate ? new Date(filters.startDate) : null;
@@ -58,7 +54,16 @@ function buildPipeline(filters = {}, { countOnly = false } = {}) {
     pipeline.push({ $match: { expertFeedbackDoc: { $ne: null } } });
 
     pipeline.push({ $lookup: { from: 'contexts', localField: 'interactions.context', foreignField: '_id', as: 'contextDocs' } });
-    pipeline.push({ $addFields: { 'interactions.department': { $ifNull: [{ $arrayElemAt: ['$contextDocs.department', 0] }, ''] } } });
+    // department drives filtering; program/action are the per-question
+    // classifier's stored tags, reused so the analysis doesn't re-classify what
+    // the pipeline already tagged (see rowNeedsClassification).
+    pipeline.push({
+        $addFields: {
+            'interactions.department': { $ifNull: [{ $arrayElemAt: ['$contextDocs.department', 0] }, ''] },
+            'interactions.program': { $ifNull: [{ $arrayElemAt: ['$contextDocs.program', 0] }, ''] },
+            'interactions.action': { $ifNull: [{ $arrayElemAt: ['$contextDocs.action', 0] }, ''] }
+        }
+    });
 
     pipeline.push({ $lookup: { from: 'answers', localField: 'interactions.answer', foreignField: '_id', as: 'answerDocs' } });
     pipeline.push({
@@ -99,6 +104,9 @@ function buildPipeline(filters = {}, { countOnly = false } = {}) {
             createdAt: '$interactions.createdAt',
             referringUrl: '$interactions.referringUrl',
             department: '$interactions.department',
+            program: '$interactions.program',
+            action: '$interactions.action',
+            answerType: '$interactions.answerType',
             question: { $ifNull: [{ $arrayElemAt: ['$questionDocs.redactedQuestion', 0] }, ''] },
             citationUrl: {
                 $ifNull: [
@@ -123,14 +131,6 @@ const invoke = (strategy, request, chatId) =>
         createAgentFn: (agentType, cid) => createEvalAnalysisAgent(agentType, cid),
         strategy
     });
-
-// Evenly spread sample so the program proposal sees the full date range, not
-// just the earliest questions.
-const sampleRows = (rows, size) => {
-    if (rows.length <= size) return rows;
-    const step = rows.length / size;
-    return Array.from({ length: size }, (_, i) => rows[Math.floor(i * step)]);
-};
 
 const slimRowForInsights = (r) => ({
     q: r.q,
@@ -269,23 +269,17 @@ class EvalAnalysisServiceClass {
         }
         const stats = computeStats(rows);
 
-        const chatId = `eval-analysis-${doc._id}`;
-        const proposal = await invoke(
-            evalAnalysisProgramsStrategy,
-            {
-                department: doc.department,
-                seedPrograms: getSeedPrograms(doc.department),
-                sampleRows: sampleRows(rows, PROGRAM_SAMPLE_SIZE)
-            },
-            chatId
-        );
-        if (!proposal?.programs?.length) {
-            throw new Error('Program proposal did not return a usable program list');
-        }
+        // Classification vocabulary for the fallback step is the department's
+        // curated seed list (the same names the per-question classifier and the
+        // partner dashboard use), plus any program names already stored on rows
+        // in this run — so a fallback row snaps to the same bucket as a
+        // pre-classified one instead of a fresh emergent set. No LLM proposal.
+        const storedPrograms = rows.map((r) => r.program).filter(Boolean);
+        const programs = Array.from(new Set([...getSeedPrograms(doc.department), ...storedPrograms]));
 
         const scalars = {
             stats,
-            programs: proposal.programs,
+            programs,
             evalCount: rows.length,
             excludedCount: stats.excludedCount,
             progress: { classified: 0, total: rows.length },
@@ -310,12 +304,19 @@ class EvalAnalysisServiceClass {
             chunk = chunkDoc?.rows || [];
         }
 
+        // Only rows the pipeline did not already tag AND whose answer type is a
+        // real GC answer attempt reach the LLM (see rowNeedsClassification):
+        // pre-classified rows keep their stored program/action, and non-normal
+        // turns (not-gc / pt-muni / clarifying-question) stay unclassified
+        // rather than being force-fit into a program group.
+        //
         // Row tag updates as targeted dotted-path $set deltas (rows.<i>.program)
-        // so only the ~20 changed rows are written, not the whole Mixed array.
+        // so only the changed rows are written, not the whole Mixed array.
         const rowSets = {};
-        if (chunk.length > 0) {
+        const toClassify = chunk.filter(rowNeedsClassification);
+        if (toClassify.length > 0) {
             const chatId = `eval-analysis-${doc._id}`;
-            const request = { programs: doc.programs, actions: ACTION_SEEDS, rows: chunk };
+            const request = { programs: doc.programs, actions: ACTION_SEEDS, rows: toClassify };
             let assignments = null;
             try {
                 assignments = (await invoke(evalAnalysisClassifyStrategy, request, chatId))?.assignments;
@@ -333,10 +334,11 @@ class EvalAnalysisServiceClass {
                 }
             }
             if (assignments) {
-                const validPrograms = new Set([...doc.programs, OTHER_LABEL]);
+                const validPrograms = new Set([...(doc.programs || []), OTHER_LABEL]);
                 const validActions = new Set([...ACTION_SEEDS.map((a) => a.action), OTHER_LABEL]);
                 const byId = new Map(assignments.map((a) => [a.id, a]));
                 chunk.forEach((row, i) => {
+                    if (!rowNeedsClassification(row)) return;
                     const a = byId.get(row.id);
                     if (!a) return;
                     rowSets[`rows.${offset + i}.program`] = validPrograms.has(a.program) ? a.program : OTHER_LABEL;

--- a/services/__tests__/evalAnalysisStats.test.js
+++ b/services/__tests__/evalAnalysisStats.test.js
@@ -4,6 +4,7 @@ import {
     computeStats,
     buildCrossTab,
     combinedLabel,
+    rowNeedsClassification,
     MIN_EVALS_FOR_FLAG
 } from '../evalAnalysisStats.js';
 import { deriveExpertFeedbackCategory as deriveCategory } from '../../api/util/chat-filters.js';
@@ -112,6 +113,48 @@ describe('toCompactRow', () => {
         const compact = toCompactRow({ _id: 'x', expertFeedback: { expertEmail: 'e@x.ca' } });
         expect(compact.score).toBeNull();
         expect(compact.category).toBeNull();
+    });
+
+    it('reuses a real stored program/action from the per-question classifier', () => {
+        const compact = toCompactRow({
+            _id: 'x',
+            program: 'Canada Pension Plan',
+            action: 'Apply',
+            answerType: 'normal',
+            expertFeedback: {}
+        });
+        expect(compact.program).toBe('Canada Pension Plan');
+        expect(compact.action).toBe('Apply');
+        expect(compact.answerType).toBe('normal');
+    });
+
+    it("normalizes '' and 'unknown' stored program/action to null (unclassified)", () => {
+        expect(toCompactRow({ _id: 'x', program: '', action: '', expertFeedback: {} }).program).toBeNull();
+        expect(toCompactRow({ _id: 'x', program: 'unknown', action: 'unknown', expertFeedback: {} }).program).toBeNull();
+        expect(toCompactRow({ _id: 'x', program: 'unknown', expertFeedback: {} }).action).toBeNull();
+    });
+
+    it('carries the answer type through for the classification gate', () => {
+        expect(toCompactRow({ _id: 'x', answerType: 'clarifying-question', expertFeedback: {} }).answerType)
+            .toBe('clarifying-question');
+        expect(toCompactRow({ _id: 'x', expertFeedback: {} }).answerType).toBe('');
+    });
+});
+
+describe('rowNeedsClassification', () => {
+    it('classifies only normal-type rows that lack a reusable program', () => {
+        expect(rowNeedsClassification({ program: null, answerType: 'normal' })).toBe(true);
+        expect(rowNeedsClassification({ program: null, answerType: '' })).toBe(true); // empty = normal
+    });
+
+    it('skips rows already tagged by the per-question classifier', () => {
+        expect(rowNeedsClassification({ program: 'Canada Pension Plan', answerType: 'normal' })).toBe(false);
+    });
+
+    it('skips non-normal answer types (no GC program to classify)', () => {
+        expect(rowNeedsClassification({ program: null, answerType: 'not-gc' })).toBe(false);
+        expect(rowNeedsClassification({ program: null, answerType: 'pt-muni' })).toBe(false);
+        expect(rowNeedsClassification({ program: null, answerType: 'clarifying-question' })).toBe(false);
     });
 });
 

--- a/services/evalAnalysisStats.js
+++ b/services/evalAnalysisStats.js
@@ -7,8 +7,24 @@
 
 import { deriveExpertFeedbackCategory } from '../api/util/chat-filters.js';
 import { OTHER_LABEL } from '../api/data/programActionSeeds.js';
+import { NON_CLASSIFIABLE_ANSWER_TYPES } from '../api/util/answerTypes.js';
 
 const SENTENCE_NUMBERS = [1, 2, 3, 4];
+
+// A stored program/action value is reusable only when it is a real program
+// name — '' (never classified) and 'unknown' (classifier ran, not confident)
+// both mean "no usable program" and are normalized to null.
+const reusableValue = (value) => {
+    const str = typeof value === 'string' ? value.trim() : '';
+    return str && str.toLowerCase() !== 'unknown' ? str : null;
+};
+
+// A row reaches the fallback classifier only when it has no reusable program
+// from the per-question classifier AND its answer type is a real GC answer
+// attempt. Non-normal turns (not-gc / pt-muni / clarifying-question) carry no
+// program, so they stay unclassified instead of being force-fit into a group.
+export const rowNeedsClassification = (row = {}) =>
+    !row.program && !NON_CLASSIFIABLE_ANSWER_TYPES.has(row.answerType || '');
 
 // An evaluator's perfect-rate must differ from the rest of the group by more
 // than this many percentage points (with at least MIN_EVALS_FOR_FLAG evals)
@@ -58,8 +74,13 @@ export function toCompactRow(aggRow) {
         improve: truncate(ef.answerImprovement, 400),
         evaluator: ef.expertEmail || '',
         createdAt: aggRow.createdAt ? new Date(aggRow.createdAt).toISOString() : null,
-        program: null,
-        action: null
+        // Answer type drives the classification gate (rowNeedsClassification).
+        answerType: typeof aggRow.answerType === 'string' ? aggRow.answerType : '',
+        // Reuse the per-question classifier's stored program/action so the
+        // report groups the same way the partner dashboard does; the fallback
+        // classifier fills only the rows still left null here.
+        program: reusableValue(aggRow.program),
+        action: reusableValue(aggRow.action)
     };
 }
 


### PR DESCRIPTION
# Summary | Résumé

> next step of program-action classifier. Had only created CRA program file to test on prod - now add all other files. Some are stubs. 
> rationalize this classifier with eval-analysis feature (it was designed and built first so now needs to use the questions that are already tagged with a program and action)

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
