### PR TITLE
Fix/download logs andor logic

### DIFF
--- a/docs/coding-agent-docs/dashboards.md
+++ b/docs/coding-agent-docs/dashboards.md
@@ -30,6 +30,8 @@ When changing `FilterPanel.js` or the backend filter logic in `getChatFilterCond
 - **ChatViewer / Chat Logs list** (`api/db/db-chat-logs.js`)
 - **Export/Download** (`api/chat/chat-export-logs.js`) — has a `$lookup` that overwrites `user`; user-type filter must be applied early in `dateFilter` before the overwrite
 
+**Any new/changed `FilterPanel` field must also be forwarded by `ChatLogsDashboard.js`, or the download silently ignores it.** `ChatDashboardPage.js` forwards filters generically (`DashboardService.getChatDashboard` appends every key in the filters object as a query param), but `ChatLogsDashboard.js`'s `handleApplyFilters` (the "Download chat logs" page) hand-picks specific fields into `URLSearchParams` before calling `chat-export-logs.js`. When adding or renaming a field in `FilterPanel.js`, check `ChatLogsDashboard.js`'s param-building list explicitly — it won't fail loudly, it just drops the field.
+
 **`partnerEval`/`aiEval`/`answerType` allow-lists are hand-duplicated, not shared — check both when adding a category.** `api/db/db-chat-logs.js` and `api/chat/chat-export-logs.js` each keep their own `validCategories`/`validAnswerTypes` arrays that gate requests with a 400 *before* the pipeline runs, separate from the pseudo-category handling (`noEval`, `hasContentIssue`) inside `getChatFilterConditions` in `chat-filters.js`. Adding a new pseudo-category to `chat-filters.js` + `FilterPanel.js` is not enough — you must also add it to the `validCategories` (or `validPartnerEvalCategories`) array in *both* `db-chat-logs.js` and `chat-export-logs.js`, or requests using it get rejected with "Invalid partnerEval values" even though the filter logic itself supports it.
 
 ## Cross-dashboard gotchas

--- a/src/components/admin/ChatLogsDashboard.js
+++ b/src/components/admin/ChatLogsDashboard.js
@@ -58,6 +58,7 @@ const ChatLogsDashboard = ({ lang = 'en' }) => {
         if (filters.aiEval && filters.aiEval !== 'all') {
           params.append('aiEval', filters.aiEval);
         }
+        if (filters.evalLogic) params.append('evalLogic', filters.evalLogic);
       }
 
       params.append('view', selectedView);


### PR DESCRIPTION
ChatLogsDashboard.js (the download page) builds its export request by manually listing filter fields and forgot to include evalLogic, so the "Partner eval and AI eval match: Either (or)" selection was silently dropped and the export always ran with AND logic instead.

Fix: added the missing evalLogic param in src/components/admin/ChatLogsDashboard.js:60. The backend (api/chat/chat-export-logs.js / api/util/chat-filters.js) already supported it