### PR TITLE
fix: account pages accessibility (heading, error announcements)

### DIFF
--- a/src/components/auth/PasswordInput.js
+++ b/src/components/auth/PasswordInput.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 
-const PasswordInput = ({ id, name, label, value, onChange, onInvalid, title, required, disabled, autoComplete, ariaDescribedBy, ariaInvalid, lang = 'en' }) => {
+const PasswordInput = ({ id, name, label, value, onChange, title, required, disabled, autoComplete, ariaDescribedBy, ariaInvalid, lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -17,7 +17,6 @@ const PasswordInput = ({ id, name, label, value, onChange, onInvalid, title, req
           value={value}
           title={title}
           onChange={onChange}
-          onInvalid={onInvalid}
           required={required}
           disabled={disabled}
           autoComplete={autoComplete}

--- a/src/hooks/auth/useAuthFormValidation.js
+++ b/src/hooks/auth/useAuthFormValidation.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useAnnouncedError } from './useAnnouncedError.js';
+import { validateRequiredEmailFields } from '../../utils/auth/validateAuthFields.js';
+
+// Wraps useAnnouncedError with per-field invalid tracking, so setting one
+// error message doesn't mark every field on the form aria-invalid — only the
+// field(s) that error actually concerns (e.g. a missing password shouldn't
+// flag an already-valid email as invalid too).
+//
+// validate() runs the shared required/email-format check (see
+// validateAuthFields.js) and announces + flags on failure. setError() covers
+// page-specific errors that check isn't aware of (password mismatch, invalid
+// credentials, server errors) — pass the field name(s) it concerns as the
+// second argument, or omit it when no specific field is at fault.
+export const useAuthFormValidation = () => {
+  const { error, errorCount, errorRef, setError: setAnnouncedError, clearError: clearAnnouncedError } = useAnnouncedError();
+  const [invalidFields, setInvalidFields] = useState([]);
+
+  const setError = (message, fields = []) => {
+    setInvalidFields(fields);
+    setAnnouncedError(message);
+  };
+
+  const clearError = () => {
+    setInvalidFields([]);
+    clearAnnouncedError();
+  };
+
+  const validate = (fields, t) => {
+    const result = validateRequiredEmailFields(fields);
+    if (result) {
+      setError(t(result.errorKey), result.invalidFields);
+      return false;
+    }
+    return true;
+  };
+
+  const isFieldInvalid = (name) => invalidFields.includes(name);
+
+  return { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid };
+};

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -7,6 +7,7 @@ import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
 import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
+import { isValidEmail } from '../utils/auth/validateEmail.js';
 import { GcdsNotice, GcdsText } from '@gcds-core/components-react';
 
 const LoginPage = ({ lang = 'en' }) => {
@@ -27,13 +28,20 @@ const LoginPage = ({ lang = 'en' }) => {
     if (sessionExpired) {
       navigate(location.pathname, { replace: true });
     }
-    setIsLoading(true);
     clearError();
     // If 2FA flow already started, ignore normal submit
     if (showTwoStep) {
-      setIsLoading(false);
       return;
     }
+    if (!email || !password) {
+      setError(t('validation.required'));
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setError(t('validation.emailInvalid'));
+      return;
+    }
+    setIsLoading(true);
     try {
       const data = await login(email, password);
       // If backend requires two-step verification, backend already sent the email; prompt for code
@@ -102,6 +110,7 @@ const LoginPage = ({ lang = 'en' }) => {
 
   return (
     <div className="auth-login-container">
+      <h1>{showTwoStep ? t('login.2fa.title') : t('login.title')}</h1>
       {sessionExpired && (
         <GcdsNotice
           noticeRole="warning"
@@ -116,7 +125,6 @@ const LoginPage = ({ lang = 'en' }) => {
       {/* When in 2FA flow show only the 2FA UI */}
       {showTwoStep ? (
         <div>
-          <h2>{t('login.2fa.title')}</h2>
           <p>{t('login.2fa.sentToEmail')}</p>
           {twoStepError && (
             <AnnouncedError
@@ -142,11 +150,10 @@ const LoginPage = ({ lang = 'en' }) => {
       ) : (
         // Default login form with signup link when not in 2FA flow
         <>
-          <h1>{t('login.title')}</h1>
           {error && (
             <AnnouncedError id="login-error" message={error} errorCount={errorCount} inputRef={errorRef} />
           )}
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} noValidate>
             <div className="auth-form-group">
               <label htmlFor="email">{t('login.email')}</label>
               <input
@@ -154,8 +161,8 @@ const LoginPage = ({ lang = 'en' }) => {
                 id="email"
                 value={email}
                 title={t('login.email')}
-                onChange={(e) => { e.target.setCustomValidity(''); setEmail(e.target.value); }}
-                onInvalid={(e) => e.target.setCustomValidity(e.target.validity.typeMismatch ? t('validation.emailInvalid') : t('validation.required'))}
+                autoComplete="email"
+                onChange={(e) => setEmail(e.target.value)}
                 required
                 disabled={isLoading}
                 aria-describedby={error ? 'login-error' : undefined}
@@ -167,8 +174,7 @@ const LoginPage = ({ lang = 'en' }) => {
               label={t('login.password')}
               value={password}
               title={t('login.password')}
-              onChange={(e) => { e.target.setCustomValidity(''); setPassword(e.target.value); }}
-              onInvalid={(e) => e.target.setCustomValidity(t('validation.required'))}
+              onChange={(e) => setPassword(e.target.value)}
               required
               disabled={isLoading}
               autoComplete="current-password"

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -7,7 +7,8 @@ import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
 import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
-import { isValidEmail } from '../utils/auth/validateEmail.js';
+import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { normalizeEmail } from '../utils/auth/validateEmail.js';
 import { GcdsNotice, GcdsText } from '@gcds-core/components-react';
 
 const LoginPage = ({ lang = 'en' }) => {
@@ -17,33 +18,30 @@ const LoginPage = ({ lang = 'en' }) => {
   const { login, refreshUser, getDefaultRouteForRole } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
+  const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
   const sessionExpired = new URLSearchParams(location.search).get('reason') === 'session-expired';
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    // The expiry marker is informational only. Once the user starts a fresh
-    // login attempt, remove it so it cannot persist into a new session.
-    if (sessionExpired) {
-      navigate(location.pathname, { replace: true });
-    }
     clearError();
     // If 2FA flow already started, ignore normal submit
     if (showTwoStep) {
       return;
     }
-    if (!email || !password) {
-      setError(t('validation.required'));
+    const trimmedEmail = normalizeEmail(email);
+    if (!validate({ email: trimmedEmail, password }, t)) {
       return;
     }
-    if (!isValidEmail(email)) {
-      setError(t('validation.emailInvalid'));
-      return;
+    // The expiry marker is informational only. Once the user starts a fresh
+    // login attempt that passes validation, remove it so it cannot persist
+    // into a new session.
+    if (sessionExpired) {
+      navigate(location.pathname, { replace: true });
     }
     setIsLoading(true);
     try {
-      const data = await login(email, password);
+      const data = await login(trimmedEmail, password);
       // If backend requires two-step verification, backend already sent the email; prompt for code
       if (data && data.twoFA) {
         setShowTwoStep(true);
@@ -52,7 +50,7 @@ const LoginPage = ({ lang = 'en' }) => {
       const defaultRoute = data?.defaultRoute || '/';
       navigate(defaultRoute);
     } catch (err) {
-      setError(t('login.invalidCredentials'));
+      setError(t('login.invalidCredentials'), ['email', 'password']);
     } finally {
       setIsLoading(false);
     }
@@ -166,7 +164,7 @@ const LoginPage = ({ lang = 'en' }) => {
                 required
                 disabled={isLoading}
                 aria-describedby={error ? 'login-error' : undefined}
-                aria-invalid={!!error}
+                aria-invalid={isFieldInvalid('email')}
               />
             </div>
             <PasswordInput
@@ -179,7 +177,7 @@ const LoginPage = ({ lang = 'en' }) => {
               disabled={isLoading}
               autoComplete="current-password"
               ariaDescribedBy={error ? 'login-error' : undefined}
-              ariaInvalid={!!error}
+              ariaInvalid={isFieldInvalid('password')}
               lang={lang}
             />
             <button type="submit" disabled={isLoading} className="btn-primary-sm auth-submit-button">

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -6,6 +6,7 @@ import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
 import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
+import { isValidEmail } from '../utils/auth/validateEmail.js';
 
 const RegisterPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -19,6 +20,16 @@ const RegisterPage = ({ lang = 'en' }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     clearError();
+
+    if (!email || !password || !confirmPassword) {
+      setError(t('validation.required'));
+      return;
+    }
+
+    if (!isValidEmail(email)) {
+      setError(t('validation.emailInvalid'));
+      return;
+    }
 
     if (password !== confirmPassword) {
       setError(t('signup.passwordMismatch'));
@@ -47,7 +58,7 @@ const RegisterPage = ({ lang = 'en' }) => {
       {error && (
         <AnnouncedError id="signup-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} noValidate>
         <div className="auth-form-group">
           <label htmlFor="email">{t('signup.email')}</label>
           <input
@@ -55,8 +66,8 @@ const RegisterPage = ({ lang = 'en' }) => {
             id="email"
             value={email}
             title={t('signup.email')}
-            onChange={(e) => { e.target.setCustomValidity(''); setEmail(e.target.value); }}
-            onInvalid={(e) => e.target.setCustomValidity(e.target.validity.typeMismatch ? t('validation.emailInvalid') : t('validation.required'))}
+            autoComplete="email"
+            onChange={(e) => setEmail(e.target.value)}
             required
             disabled={isLoading}
           />
@@ -67,8 +78,7 @@ const RegisterPage = ({ lang = 'en' }) => {
           label={t('signup.password')}
           value={password}
           title={t('signup.password')}
-          onChange={(e) => { e.target.setCustomValidity(''); setPassword(e.target.value); }}
-          onInvalid={(e) => e.target.setCustomValidity(t('validation.required'))}
+          onChange={(e) => setPassword(e.target.value)}
           required
           disabled={isLoading}
           autoComplete="new-password"
@@ -82,8 +92,7 @@ const RegisterPage = ({ lang = 'en' }) => {
           label={t('signup.confirmPassword')}
           value={confirmPassword}
           title={t('signup.confirmPassword')}
-          onChange={(e) => { e.target.setCustomValidity(''); setConfirmPassword(e.target.value); }}
-          onInvalid={(e) => e.target.setCustomValidity(t('validation.required'))}
+          onChange={(e) => setConfirmPassword(e.target.value)}
           required
           disabled={isLoading}
           autoComplete="new-password"

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -5,8 +5,8 @@ import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
-import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
-import { isValidEmail } from '../utils/auth/validateEmail.js';
+import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { normalizeEmail } from '../utils/auth/validateEmail.js';
 
 const RegisterPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -14,36 +14,31 @@ const RegisterPage = ({ lang = 'en' }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
+  const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     clearError();
 
-    if (!email || !password || !confirmPassword) {
-      setError(t('validation.required'));
-      return;
-    }
-
-    if (!isValidEmail(email)) {
-      setError(t('validation.emailInvalid'));
+    const trimmedEmail = normalizeEmail(email);
+    if (!validate({ email: trimmedEmail, password, confirmPassword }, t)) {
       return;
     }
 
     if (password !== confirmPassword) {
-      setError(t('signup.passwordMismatch'));
+      setError(t('signup.passwordMismatch'), ['password', 'confirmPassword']);
       return;
     }
 
     if (password.length < 8) {
-      setError(t('signup.passwordTooShort'));
+      setError(t('signup.passwordTooShort'), ['password']);
       return;
     }
 
     setIsLoading(true);
     try {
-      await AuthService.signup(email, password);
+      await AuthService.signup(trimmedEmail, password);
       navigate(getPath('admin', lang));
     } catch (err) {
       setError(err.message || t('signup.errorOccurred'));
@@ -70,6 +65,8 @@ const RegisterPage = ({ lang = 'en' }) => {
             onChange={(e) => setEmail(e.target.value)}
             required
             disabled={isLoading}
+            aria-describedby={error ? 'signup-error' : undefined}
+            aria-invalid={isFieldInvalid('email')}
           />
         </div>
         <PasswordInput
@@ -83,7 +80,7 @@ const RegisterPage = ({ lang = 'en' }) => {
           disabled={isLoading}
           autoComplete="new-password"
           ariaDescribedBy={error ? 'signup-error' : undefined}
-          ariaInvalid={!!error}
+          ariaInvalid={isFieldInvalid('password')}
           lang={lang}
         />
         <PasswordInput
@@ -97,7 +94,7 @@ const RegisterPage = ({ lang = 'en' }) => {
           disabled={isLoading}
           autoComplete="new-password"
           ariaDescribedBy={error ? 'signup-error' : undefined}
-          ariaInvalid={!!error}
+          ariaInvalid={isFieldInvalid('confirmPassword')}
           lang={lang}
         />
         <button type="submit" disabled={isLoading} className="btn-primary-sm auth-submit-button">

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -4,14 +4,14 @@ import AuthService from '../services/AuthService.js';
 import { Link, useNavigate } from 'react-router-dom';
 import { getPath } from '../utils/routes.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
-import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
-import { isValidEmail } from '../utils/auth/validateEmail.js';
+import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { normalizeEmail } from '../utils/auth/validateEmail.js';
 
 const ResetRequestPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const [email, setEmail] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
-  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
+  const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
@@ -19,17 +19,13 @@ const ResetRequestPage = ({ lang = 'en' }) => {
     e && e.preventDefault();
     setSuccessMessage('');
     clearError();
-    if (!email) {
-      setError(t('validation.required'));
-      return;
-    }
-    if (!isValidEmail(email)) {
-      setError(t('validation.emailInvalid'));
+    const trimmedEmail = normalizeEmail(email);
+    if (!validate({ email: trimmedEmail }, t)) {
       return;
     }
     setIsLoading(true);
     try {
-      await AuthService.sendReset(email, lang);
+      await AuthService.sendReset(trimmedEmail, lang);
       setSuccessMessage(t('reset.request.sent'));
       // Optionally redirect to signin after a short delay
       setTimeout(() => navigate(getPath('signin', lang)), 3000);
@@ -64,6 +60,8 @@ const ResetRequestPage = ({ lang = 'en' }) => {
             onChange={(e) => setEmail(e.target.value)}
             required
             disabled={isLoading}
+            aria-describedby={error ? 'reset-request-error' : undefined}
+            aria-invalid={isFieldInvalid('email')}
           />
         </div>
         <button type="submit" className="btn-primary-sm auth-submit-button" disabled={isLoading}>{isLoading ? t('reset.request.sending') : t('reset.request.send')}</button>

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { getPath } from '../utils/routes.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
 import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
+import { isValidEmail } from '../utils/auth/validateEmail.js';
 
 const ResetRequestPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -16,9 +17,17 @@ const ResetRequestPage = ({ lang = 'en' }) => {
 
   const submit = async (e) => {
     e && e.preventDefault();
-    setIsLoading(true);
     setSuccessMessage('');
     clearError();
+    if (!email) {
+      setError(t('validation.required'));
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setError(t('validation.emailInvalid'));
+      return;
+    }
+    setIsLoading(true);
     try {
       await AuthService.sendReset(email, lang);
       setSuccessMessage(t('reset.request.sent'));
@@ -43,7 +52,7 @@ const ResetRequestPage = ({ lang = 'en' }) => {
       {error && (
         <AnnouncedError id="reset-request-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={submit}>
+      <form onSubmit={submit} noValidate>
         <div className="auth-form-group">
           <label htmlFor="email">{t('login.email')}</label>
           <input
@@ -51,8 +60,8 @@ const ResetRequestPage = ({ lang = 'en' }) => {
             type="email"
             value={email}
             title={t('login.email')}
-            onChange={(e) => { e.target.setCustomValidity(''); setEmail(e.target.value); }}
-            onInvalid={(e) => e.target.setCustomValidity(e.target.validity.typeMismatch ? t('validation.emailInvalid') : t('validation.required'))}
+            autoComplete="email"
+            onChange={(e) => setEmail(e.target.value)}
             required
             disabled={isLoading}
           />

--- a/src/utils/auth/validateAuthFields.js
+++ b/src/utils/auth/validateAuthFields.js
@@ -1,0 +1,21 @@
+import { isValidEmail } from './validateEmail.js';
+
+// Shared required-field + email-format check used by LoginPage, RegisterPage,
+// and ResetRequestPage, so the rule (and any future change to it) lives in
+// one place instead of being copied per page. `fields` is a flat map of
+// field name -> current value (email should already be normalized via
+// normalizeEmail before being passed in); every key is treated as required,
+// and a key named "email" is additionally checked for shape.
+//
+// Returns null when the fields pass, or { errorKey, invalidFields } naming
+// the translation key to show and which field(s) to mark aria-invalid.
+export const validateRequiredEmailFields = (fields) => {
+  const missing = Object.keys(fields).filter((name) => !fields[name]);
+  if (missing.length > 0) {
+    return { errorKey: 'validation.required', invalidFields: missing };
+  }
+  if ('email' in fields && !isValidEmail(fields.email)) {
+    return { errorKey: 'validation.emailInvalid', invalidFields: ['email'] };
+  }
+  return null;
+};

--- a/src/utils/auth/validateEmail.js
+++ b/src/utils/auth/validateEmail.js
@@ -5,4 +5,9 @@
 // check accessibly instead of a native validation bubble.
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// Strips incidental leading/trailing whitespace (e.g. pasted from a
+// clipboard) before an email is validated or sent anywhere — callers should
+// normalize through this rather than validating/sending the raw input value.
+export const normalizeEmail = (value) => (value || '').trim();
+
 export const isValidEmail = (value) => EMAIL_PATTERN.test(value);

--- a/src/utils/auth/validateEmail.js
+++ b/src/utils/auth/validateEmail.js
@@ -1,0 +1,8 @@
+// Minimal email shape check used by the account pages (Login, Register,
+// ResetRequest) once they stopped relying on the browser's native
+// type="email" constraint validation for error messaging — see
+// AnnouncedError / useAnnouncedError, which those pages use to surface this
+// check accessibly instead of a native validation bubble.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const isValidEmail = (value) => EMAIL_PATTERN.test(value);


### PR DESCRIPTION
  - Give LoginPage's 2FA screen an h1 (was missing entirely) and fix
    heading order so the session-expired notice always renders after
    the h1, not before it (need to review globally to position correctly as a statusmessage - for another PR)
  - Replace native browser validation on Login/Register/ResetRequest
    forms with the existing AnnouncedError pattern (noValidate + manual
    required/format checks), so errors are announced accessibly instead
    of via the native validation bubble
  - Add autocomplete="email" to the email inputs on all three pages
  - Add src/utils/auth/validateEmail.js, a small shared email-format
    check used by the three pages above
- per-field aria-invalid instead of shared error flag
- add missing aria-invalid/describedby on register/reset email
- trim email before validate/send
- don't clear session-expired notice on failed client validation
- centralize required/email validation (was copy-pasted x3)
- drop dead onInvalid prop on PasswordInput
