### PR TITLE
fix: align new-tab chat links to GcdsLink/gcds-link

### DIFF
--- a/src/components/admin/SimilarChatsDashboard.js
+++ b/src/components/admin/SimilarChatsDashboard.js
@@ -5,6 +5,7 @@ import DT from 'datatables.net-dt';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
 import VectorService from '../../services/VectorService.js';
+import { buildChatReviewLinkHtml } from '../../utils/reviewLink.js';
 
 DataTable.use(DT);
 
@@ -62,17 +63,7 @@ const SimilarChatsDashboard = ({ lang = 'en' }) => {
               {
                 title: t('vector.columns.chatId'),
                 data: 'chatId',
-                // DataTables renders this as raw HTML, not JSX, so the React
-                // <GcdsLink> wrapper can't be used — but the underlying
-                // <gcds-link> custom element is just as usable in an HTML
-                // string; it auto-upgrades once inserted regardless of how
-                // it got into the DOM. Using it directly (rather than hand-
-                // rolling the icon/rel/accessible-text it already adds for
-                // target="_blank") keeps this in sync with GC DS for free.
-                render: function(data) {
-                  const url = `/${lang}?chat=${data}&review=1`;
-                  return `<gcds-link href="${url}" target="_blank" lang="${lang}">${data}</gcds-link>`;
-                }
+                render: (data) => buildChatReviewLinkHtml(data, lang)
               },
               { title: t('vector.columns.similarity'), data: 'similarity' },
               { title: t('vector.columns.aiProvider'), data: 'aiProvider' },

--- a/src/components/admin/SimilarChatsDashboard.js
+++ b/src/components/admin/SimilarChatsDashboard.js
@@ -62,9 +62,16 @@ const SimilarChatsDashboard = ({ lang = 'en' }) => {
               {
                 title: t('vector.columns.chatId'),
                 data: 'chatId',
+                // DataTables renders this as raw HTML, not JSX, so the React
+                // <GcdsLink> wrapper can't be used — but the underlying
+                // <gcds-link> custom element is just as usable in an HTML
+                // string; it auto-upgrades once inserted regardless of how
+                // it got into the DOM. Using it directly (rather than hand-
+                // rolling the icon/rel/accessible-text it already adds for
+                // target="_blank") keeps this in sync with GC DS for free.
                 render: function(data) {
                   const url = `/${lang}?chat=${data}&review=1`;
-                  return `<a href="${url}" target="_blank" rel="noopener noreferrer">${data}</a>`;
+                  return `<gcds-link href="${url}" target="_blank" lang="${lang}">${data}</gcds-link>`;
                 }
               },
               { title: t('vector.columns.similarity'), data: 'similarity' },

--- a/src/components/admin/__tests__/EvalAnalysisSection.test.js
+++ b/src/components/admin/__tests__/EvalAnalysisSection.test.js
@@ -5,6 +5,19 @@ import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// EvalAnalysisReport's example-chatId link renders via <GcdsLink> (real
+// custom element, shadow DOM) — jsdom doesn't expose its shadow-DOM anchor
+// to getByRole('link'), so stub just that export as a plain <a>, same as
+// ChatDashboardPage.test.js / UsedChatsPanel.test.js. Everything else
+// (GcdsButton, etc.) still renders for real.
+vi.mock('@gcds-core/components-react', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    GcdsLink: ({ children, href, target }) => <a href={href} target={target}>{children}</a>
+  };
+});
+
 // The section talks to the eval-analysis endpoints through the client
 // service; mock it so rendering needs no network.
 vi.mock('../../../services/EvalAnalysisService.js', () => ({

--- a/src/components/admin/dashboard/ContentIssueChatsCard.js
+++ b/src/components/admin/dashboard/ContentIssueChatsCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GcdsLink } from '@gcds-core/components-react';
 import CollapsibleCard from './CollapsibleCard.js';
+import { buildChatReviewHref } from '../../../utils/reviewLink.js';
 
 // Collapsible list of chats matching some expert-feedback flag (content
 // issue, harmful, ...), server-scoped to the dashboard's current filters.
@@ -53,8 +54,7 @@ const ContentIssueChatsCard = ({
             <tbody>
               {chats.map((c) => {
                 const chatLang = c.pageLanguage === 'fr' ? 'fr' : 'en';
-                const hash = c.interactionId ? `#interaction=${encodeURIComponent(`interactionId${c.interactionId}`)}` : '';
-                const href = `/${chatLang}?chat=${encodeURIComponent(c.chatId)}&review=1${hash}`;
+                const href = buildChatReviewHref(c.chatId, chatLang, c.interactionId);
                 return (
                   <tr key={`${c.chatId}-${c.interactionId}`}>
                     <td style={{ ...cell, wordBreak: 'break-all' }}>

--- a/src/components/admin/dashboard/EvalAnalysisReport.js
+++ b/src/components/admin/dashboard/EvalAnalysisReport.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GcdsLink } from '@gcds-core/components-react';
 import { useTranslations } from '../../../hooks/useTranslations.js';
 import { formatNumber, formatPercent, formatDecimal } from '../../../utils/numberFormat.js';
 
@@ -69,18 +70,21 @@ const EvalAnalysisReport = ({ analysis, lang = 'en' }) => {
 
   // Same review-mode deep link the eval/chat dashboards use for chatIds, in
   // the conversation's own language. Older stored reports have no example.
+  // GcdsLink's target="_blank" handles the icon, rel, and a localized
+  // "(Opens destination in a new tab.)" accessible label on its own — see
+  // ContentIssueChatsCard.js's GcdsLink for the same pattern.
   const exampleLink = (example) => {
     if (!example?.chatId) return '—';
     const chatLang = example.lang === 'fr' ? 'fr' : 'en';
     const hash = example.interactionId ? `#interaction=${encodeURIComponent(`interactionId${example.interactionId}`)}` : '';
     return (
-      <a
+      <GcdsLink
         href={`/${chatLang}?chat=${encodeURIComponent(example.chatId)}&review=1${hash}`}
         target="_blank"
-        rel="noopener noreferrer"
+        lang={chatLang}
       >
         {example.chatId}
-      </a>
+      </GcdsLink>
     );
   };
 

--- a/src/components/admin/dashboard/EvalAnalysisReport.js
+++ b/src/components/admin/dashboard/EvalAnalysisReport.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { GcdsLink } from '@gcds-core/components-react';
 import { useTranslations } from '../../../hooks/useTranslations.js';
 import { formatNumber, formatPercent, formatDecimal } from '../../../utils/numberFormat.js';
+import { buildChatReviewHref } from '../../../utils/reviewLink.js';
 
 const cell = { borderBottom: '1px solid #e0e0e0', padding: '8px 8px' };
 const head = { borderBottom: '2px solid #e0e0e0', padding: '8px 8px', textAlign: 'left' };
@@ -68,21 +69,12 @@ const EvalAnalysisReport = ({ analysis, lang = 'en' }) => {
     </div>
   );
 
-  // Same review-mode deep link the eval/chat dashboards use for chatIds, in
-  // the conversation's own language. Older stored reports have no example.
-  // GcdsLink's target="_blank" handles the icon, rel, and a localized
-  // "(Opens destination in a new tab.)" accessible label on its own — see
-  // ContentIssueChatsCard.js's GcdsLink for the same pattern.
+  // Older stored reports have no example.
   const exampleLink = (example) => {
     if (!example?.chatId) return '—';
     const chatLang = example.lang === 'fr' ? 'fr' : 'en';
-    const hash = example.interactionId ? `#interaction=${encodeURIComponent(`interactionId${example.interactionId}`)}` : '';
     return (
-      <GcdsLink
-        href={`/${chatLang}?chat=${encodeURIComponent(example.chatId)}&review=1${hash}`}
-        target="_blank"
-        lang={chatLang}
-      >
+      <GcdsLink href={buildChatReviewHref(example.chatId, chatLang, example.interactionId)} target="_blank" lang={chatLang}>
         {example.chatId}
       </GcdsLink>
     );

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -770,6 +770,10 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
               <p key={`${messageId}-head`} className="citation-head">{safeT('homepage.chat.citation.heading')}</p>
               <ul key={`${messageId}-link`} className="citation-link list-disc">
                   <li>
+                    {/* Intentionally a raw <a>, not <GcdsLink>: this needs a
+                        custom aria-label (buildAriaLabel) and an Adobe
+                        Analytics onClick tracker GcdsLink has no hook for.
+                        Not part of the "align to GcdsLink" TODOs elsewhere. */}
                     <a
                       href={safeHttpHref(displayUrl)}
                       target="_blank"

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -770,9 +770,11 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
               <p key={`${messageId}-head`} className="citation-head">{safeT('homepage.chat.citation.heading')}</p>
               <ul key={`${messageId}-link`} className="citation-link list-disc">
                   <li>
-                    {/* Intentionally a raw <a>, not <GcdsLink>: this needs a
-                        custom aria-label (buildAriaLabel) and an Adobe
-                        Analytics onClick tracker GcdsLink has no hook for.
+                    {/* Intentionally a raw <a>, not <GcdsLink>: the Adobe
+                        Analytics onClick tracker doesn't fire reliably
+                        through GcdsLink (tested), and this link needs a
+                        custom URL-based aria-label plus its own icon/URL-
+                        wrap layout — neither tried on GcdsLink.
                         Not part of the "align to GcdsLink" TODOs elsewhere. */}
                     <a
                       href={safeHttpHref(displayUrl)}

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
+import { GcdsLink } from '@gcds-core/components-react';
 import FeedbackComponent from "./FeedbackComponent.js";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ChatOptions from "./ChatOptions.js";
@@ -475,12 +476,12 @@ const ChatInterface = ({
           <span className="referring-url-label mb-300">
             <b>{safeT("homepage.chat.input.referringURL")}</b>{" "}
 
-            <a href={referringUrl}
+            <GcdsLink href={referringUrl}
               target="_blank"
-              rel="noopener noreferrer"
+              lang={lang}
             >
               {referringUrl}
-            </a>
+            </GcdsLink>
           </span>
         ) : (
           liveReferringUrlBanner
@@ -735,6 +736,7 @@ const ChatInterface = ({
                               message={message}
                               extractSentences={extractSentences}
                               t={t}
+                              lang={lang}
                               answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined}
                             />
                             <PublicFeedbackPanel
@@ -743,7 +745,7 @@ const ChatInterface = ({
                               t={t}
                               answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined}
                             />
-                            <DownloadPanel message={message} t={t} answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined} />
+                            <DownloadPanel message={message} t={t} lang={lang} answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined} />
                             <UsedChatsPanel message={message} t={t} lang={lang} answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined} />
                             <EvalPanel message={message} t={t} lang={lang} answerNumber={aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined} />
                           </div>
@@ -812,14 +814,14 @@ const ChatInterface = ({
                     >
                       <strong>{t("homepage.chat.review.referringUrl")}</strong>{" "}
                       {referringUrl ? (
-                        <a
+                        <GcdsLink
                           href={referringUrl}
                           target="_blank"
-                          rel="noopener noreferrer"
+                          lang={lang}
                           style={{ wordBreak: "break-all" }}
                         >
                           {referringUrl}
-                        </a>
+                        </GcdsLink>
                       ) : (
                         <span style={{ fontStyle: "italic", color: "#666" }}>none</span>
                       )}

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -818,7 +818,7 @@ const ChatInterface = ({
                           href={referringUrl}
                           target="_blank"
                           lang={lang}
-                          style={{ wordBreak: "break-all" }}
+                          className="url-break-all"
                         >
                           {referringUrl}
                         </GcdsLink>

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -40,7 +40,7 @@ const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
                             <span style={{ color: succeeded ? 'green' : 'red', marginRight: '0.4rem' }}>
                                 {succeeded ? '\u2714' : '\u2718'}
                             </span>
-                            <GcdsLink href={url} target="_blank" lang={lang} style={{ wordBreak: 'break-all' }}>
+                            <GcdsLink href={url} target="_blank" lang={lang} className="url-break-all">
                                 {url}
                             </GcdsLink>
                         </div>

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { GcdsLink } from '@gcds-core/components-react';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 
-const DownloadPanel = ({ message, t, answerNumber }) => {
+const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
     const { withAnswerNumber } = useAnswerNumberLabel(t, answerNumber);
 
     if (!message) return null;
@@ -39,9 +40,9 @@ const DownloadPanel = ({ message, t, answerNumber }) => {
                             <span style={{ color: succeeded ? 'green' : 'red', marginRight: '0.4rem' }}>
                                 {succeeded ? '\u2714' : '\u2718'}
                             </span>
-                            <a href={url} target="_blank" rel="noopener noreferrer" style={{ wordBreak: 'break-all' }}>
+                            <GcdsLink href={url} target="_blank" lang={lang} style={{ wordBreak: 'break-all' }}>
                                 {url}
-                            </a>
+                            </GcdsLink>
                         </div>
                     );
                 })}

--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { GcdsButton } from '@gcds-core/components-react';
+import { GcdsButton, GcdsLink } from '@gcds-core/components-react';
 import EvaluationService from '../../../services/EvaluationService.js';
 import { formatDecimal } from '../../../utils/numberFormat.js';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
@@ -22,9 +22,9 @@ const renderChatLink = (chatId) => {
   }
   const url = `/en?chat=${encodeURIComponent(strId)}&review=1`;
   return (
-    <a href={url} target="_blank" rel="noopener noreferrer">
+    <GcdsLink href={url} target="_blank" lang="en">
       {strId}
-    </a>
+    </GcdsLink>
   );
 };
 
@@ -227,7 +227,7 @@ const EvalPanel = ({ message, t, lang = 'en', answerNumber }) => {
                 {evalObj.referringUrl ? (
                   <tr>
                     <td>{tr('eval.referringUrl')}:</td>
-                    <td><a href={evalObj.referringUrl} target="_blank" rel="noopener noreferrer">{evalObj.referringUrl}</a></td>
+                    <td><GcdsLink href={evalObj.referringUrl} target="_blank" lang={lang}>{evalObj.referringUrl}</GcdsLink></td>
                   </tr>
                 ) : null}
 

--- a/src/components/chat/review/ExpertFeedbackPanel.js
+++ b/src/components/chat/review/ExpertFeedbackPanel.js
@@ -1,10 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import { GcdsButton } from '@gcds-core/components-react';
+import { GcdsButton, GcdsLink } from '@gcds-core/components-react';
 import FeedbackService from '../../../services/FeedbackService.js';
 import ClientLoggingService from '../../../services/ClientLoggingService.js';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 
-const ExpertFeedbackPanel = ({ message, extractSentences, t, answerNumber }) => {
+const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answerNumber }) => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [data, setData] = useState(null);
@@ -276,7 +276,7 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, answerNumber }) => 
                             const suggestedUrl = efSource.expertCitationUrl || efSource.citationExplanation || null;
                             const scoreCell = citationScore !== null ? citationScore : (t('reviewPanels.notAvailable') || 'N/A');
                             const explCell = suggestedUrl ? (
-                                <a href={suggestedUrl} target="_blank" rel="noopener noreferrer">{suggestedUrl}</a>
+                                <GcdsLink href={suggestedUrl} target="_blank" lang={lang}>{suggestedUrl}</GcdsLink>
                             ) : (t('reviewPanels.notAvailable') || 'N/A');
                             return (
                                 <tr key="citation-row" className="citation-row">

--- a/src/components/chat/review/UsedChatsPanel.js
+++ b/src/components/chat/review/UsedChatsPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GcdsLink } from '@gcds-core/components-react';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 import { formatNumber } from '../../../utils/numberFormat.js';
 
@@ -24,13 +25,13 @@ const UsedChatsPanel = ({ message, t, lang = 'en', answerNumber }) => {
                             <tr key={match.interactionId || `${match.chatId}-${index}`}>
                                 <td>
                                     {match.chatId ? (
-                                        <a
+                                        <GcdsLink
                                             href={`/${lang}?chat=${encodeURIComponent(match.chatId)}&review=1`}
                                             target="_blank"
-                                            rel="noopener noreferrer"
+                                            lang={lang}
                                         >
                                             {match.chatId}
-                                        </a>
+                                        </GcdsLink>
                                     ) : ''}
                                 </td>
                                 <td>{match.totalScore === null || typeof match.totalScore === 'undefined' ? '' : formatNumber(match.totalScore, lang)}</td>

--- a/src/components/chat/review/UsedChatsPanel.js
+++ b/src/components/chat/review/UsedChatsPanel.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { GcdsLink } from '@gcds-core/components-react';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 import { formatNumber } from '../../../utils/numberFormat.js';
+import { buildChatReviewHref } from '../../../utils/reviewLink.js';
 
 const UsedChatsPanel = ({ message, t, lang = 'en', answerNumber }) => {
     const { withAnswerNumber } = useAnswerNumberLabel(t, answerNumber);
@@ -25,11 +26,7 @@ const UsedChatsPanel = ({ message, t, lang = 'en', answerNumber }) => {
                             <tr key={match.interactionId || `${match.chatId}-${index}`}>
                                 <td>
                                     {match.chatId ? (
-                                        <GcdsLink
-                                            href={`/${lang}?chat=${encodeURIComponent(match.chatId)}&review=1`}
-                                            target="_blank"
-                                            lang={lang}
-                                        >
+                                        <GcdsLink href={buildChatReviewHref(match.chatId, lang)} target="_blank" lang={lang}>
                                             {match.chatId}
                                         </GcdsLink>
                                     ) : ''}

--- a/src/components/chat/review/__tests__/UsedChatsPanel.test.js
+++ b/src/components/chat/review/__tests__/UsedChatsPanel.test.js
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import UsedChatsPanel from '../UsedChatsPanel.js';
+
+// UsedChatsPanel renders its chat link via <GcdsLink> (real custom element,
+// shadow DOM) instead of a plain <a> — jsdom doesn't render its shadow-DOM
+// anchor, so tests can't query for it the normal way. Stub it as a plain
+// <a> like ChatDashboardPage.test.js does.
+vi.mock('@gcds-core/components-react', () => ({
+    GcdsLink: ({ children, href }) => <a href={href}>{children}</a>
+}));
 
 const translations = {
     'reviewPanels.usedQaChatsTitle': 'Past evals used',

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -103,7 +103,10 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
         const interactionId = row.interactionId || row._id || '';
         const prefixed = interactionId ? `interactionId${interactionId}` : '';
         const hash = prefixed ? `#interaction=${encodeURIComponent(prefixed)}` : '';
-        return `<a href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" rel="noopener noreferrer">${safeId}</a>`;
+        // <gcds-link> (the custom element, not the React wrapper — DataTables
+        // renders this as raw HTML) auto-upgrades once inserted and handles
+        // the icon/rel/accessible new-tab text itself.
+        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
       },
       searchable: true,
       orderable: true

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -7,17 +7,9 @@ import { dataTableLanguage } from '../utils/dataTableLanguage.js';
 import FilterPanel from '../components/admin/FilterPanel.js';
 import EvaluationService from '../services/EvaluationService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
 
 DataTable.use(DT);
-
-const escapeHtmlAttribute = (value) => {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-};
 
 const TABLE_STORAGE_KEY = `autoEvalDashboard_tableState_v1_`;
 
@@ -98,15 +90,8 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
       data: 'chatId',
       render: (value, type, row) => {
         if (!value) return '';
-        const safeId = escapeHtmlAttribute(value);
         const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        const interactionId = row.interactionId || row._id || '';
-        const prefixed = interactionId ? `interactionId${interactionId}` : '';
-        const hash = prefixed ? `#interaction=${encodeURIComponent(prefixed)}` : '';
-        // <gcds-link> (the custom element, not the React wrapper — DataTables
-        // renders this as raw HTML) auto-upgrades once inserted and handles
-        // the icon/rel/accessible new-tab text itself.
-        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
+        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id);
       },
       searchable: true,
       orderable: true

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -182,7 +182,11 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         if (!value) return '';
         const safeId = escapeHtmlAttribute(value);
         const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        return `<a href="/${chatLang}?chat=${safeId}&review=1" target="_blank" rel="noopener noreferrer">${safeId}</a>`;
+        // <gcds-link> (the custom element, not the React wrapper — DataTables
+        // renders this as raw HTML) auto-upgrades once inserted and handles
+        // the icon/rel/accessible new-tab text itself. See
+        // SimilarChatsDashboard.js for the same pattern.
+        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
       }
     },
     {

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -7,19 +7,9 @@ import { dataTableLanguage } from '../utils/dataTableLanguage.js';
 import FilterPanel from '../components/admin/FilterPanel.js';
 import DashboardService from '../services/DashboardService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
 
 DataTable.use(DT);
-
-const escapeHtmlAttribute = (value) => {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-};
 
 const formatDateForApi = (value) => {
   if (!value) return undefined;
@@ -180,13 +170,8 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       data: 'chatId',
       render: (value, type, row) => {
         if (!value) return '';
-        const safeId = escapeHtmlAttribute(value);
         const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        // <gcds-link> (the custom element, not the React wrapper — DataTables
-        // renders this as raw HTML) auto-upgrades once inserted and handles
-        // the icon/rel/accessible new-tab text itself. See
-        // SimilarChatsDashboard.js for the same pattern.
-        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
+        return buildChatReviewLinkHtml(value, chatLang);
       }
     },
     {

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -124,7 +124,10 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         // target DOM ids are prefixed with 'interactionId' so include that prefix in the hash
         const prefixed = interactionId ? `interactionId${interactionId}` : '';
         const hash = prefixed ? `#interaction=${encodeURIComponent(prefixed)}` : '';
-        return `<a href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" rel="noopener noreferrer">${safeId}</a>`;
+        // <gcds-link> (the custom element, not the React wrapper — DataTables
+        // renders this as raw HTML) auto-upgrades once inserted and handles
+        // the icon/rel/accessible new-tab text itself.
+        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
       },
       searchable: false,
       orderable: true

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -7,17 +7,9 @@ import { dataTableLanguage } from '../utils/dataTableLanguage.js';
 import FilterPanel from '../components/admin/FilterPanel.js';
 import EvaluationService from '../services/EvaluationService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
 
 DataTable.use(DT);
-
-const escapeHtmlAttribute = (value) => {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-};
 
 const TABLE_STORAGE_KEY = `evalDashboard_tableState_v3_`;
 
@@ -118,16 +110,8 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       data: 'chatId',
       render: (value, type, row) => {
         if (!value) return '';
-        const safeId = escapeHtmlAttribute(value);
         const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        const interactionId = row.interactionId || row._id || '';
-        // target DOM ids are prefixed with 'interactionId' so include that prefix in the hash
-        const prefixed = interactionId ? `interactionId${interactionId}` : '';
-        const hash = prefixed ? `#interaction=${encodeURIComponent(prefixed)}` : '';
-        // <gcds-link> (the custom element, not the React wrapper — DataTables
-        // renders this as raw HTML) auto-upgrades once inserted and handles
-        // the icon/rel/accessible new-tab text itself.
-        return `<gcds-link href="/${chatLang}?chat=${safeId}&review=1${hash}" target="_blank" lang="${chatLang}">${safeId}</gcds-link>`;
+        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id);
       },
       searchable: false,
       orderable: true

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -620,7 +620,7 @@ const SettingsPage = ({ lang = 'en' }) => {
   return (
     <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('settings.title')}</h1>
-      <nav className="mb-400">
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <a href={`/${lang}/admin`}>{t('common.backToAdmin')}</a>
       </nav>
       <StatusMessage message={statusMessage?.text} isError={statusMessage?.isError} />

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -171,6 +171,13 @@
 .citation-link a:focus {
     color: var(--gcds-link-focus-text) !important;
 }
+
+/* Reusable: force long unbroken URLs (no natural wrap points) to break
+   mid-word instead of overflowing their container. */
+.url-break-all {
+  word-break: break-all;
+}
+
 .citation-url-text {
   display: inline;
 }

--- a/src/utils/reviewLink.js
+++ b/src/utils/reviewLink.js
@@ -1,0 +1,37 @@
+// Shared "open this chat in review mode" link builders
+// (`/{lang}?chat={chatId}&review=1[#interaction=...]`), used by dashboards
+// (ChatDashboardPage, EvalDashboardPage, AutoEvalDashboardPage,
+// SimilarChatsDashboard) and review panels (ContentIssueChatsCard,
+// EvalAnalysisReport, UsedChatsPanel).
+//
+// Two flavours: a plain href for React <GcdsLink>, and a full <gcds-link>
+// HTML string for DataTables render functions, which render raw HTML
+// rather than JSX.
+
+const buildInteractionHash = (interactionId) => {
+  if (!interactionId) return '';
+  return `#interaction=${encodeURIComponent(`interactionId${interactionId}`)}`;
+};
+
+// Escapes a value for safe interpolation into an HTML attribute/text
+// context. Also used by DataTables columns unrelated to this link.
+export const escapeHtmlAttribute = (value) => {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+};
+
+// For React <GcdsLink href={...}>.
+export const buildChatReviewHref = (chatId, lang, interactionId) =>
+  `/${lang}?chat=${encodeURIComponent(chatId)}&review=1${buildInteractionHash(interactionId)}`;
+
+// For DataTables render funcs: a full <gcds-link> HTML string. The custom
+// element auto-upgrades once inserted and handles the icon/rel/accessible
+// new-tab text itself.
+export const buildChatReviewLinkHtml = (chatId, lang, interactionId) => {
+  const safeId = escapeHtmlAttribute(chatId);
+  return `<gcds-link href="/${lang}?chat=${safeId}&review=1${buildInteractionHash(interactionId)}" target="_blank" lang="${lang}">${safeId}</gcds-link>`;
+};


### PR DESCRIPTION
 Replace links with <GcdsLink>/<gcds-link> everywhere a chat/citation/
  referring-URL link opens in a new tab, so they all get GcdsLink's icon,
  rel, and localized "(Opens destination in a new tab.)" accessible text
  for free instead of each site re-implementing (or omitting) it. Admin
  dashboard/review links don't need Adobe Analytics click tracking, so
  GcdsLink is a clean fit there; the public chat citation link does need
  AA tracking, so it's the one exception (see below).

  JSX call sites -> <GcdsLink>: ChatInterface (referring URL, x2),
  DownloadPanel, EvalPanel (chat-link helper + referring URL),
  ExpertFeedbackPanel (suggested citation URL), UsedChatsPanel,
  EvalAnalysisReport (example chatId), ContentIssueChatsCard

  DataTables raw-HTML render columns -> the <gcds-link> custom element
  directly (auto-upgrades regardless of how it's inserted into the DOM):
  SimilarChatsDashboard, ChatDashboardPage, EvalDashboardPage,
  AutoEvalDashboardPage

  Threaded a lang prop through to DownloadPanel/ExpertFeedbackPanel,
  which didn't previously receive one, so GcdsLink's icon/text localize
  correctly

  Left ChatAppContainer's citation link as a raw <a>, with a comment
  explaining why: the Adobe Analytics onClick tracker doesn't fire
  reliably through GcdsLink (tested), and the link needs a custom
  URL-based aria-label plus its own icon/URL-wrap layout — neither
  tried on GcdsLink

  Extracted the review-link URL/HTML building duplicated across all
  seven chat-review-link call sites into src/utils/reviewLink.js
  (escapeHtmlAttribute, buildChatReviewHref, buildChatReviewLinkHtml) —
  also fixes SimilarChatsDashboard's chatId missing HTML-escaping as a
  side effect of sharing the builder

  Replaced inline style={{ wordBreak: 'break-all' }} on GcdsLink with a
  shared .url-break-all class in chat.css (DownloadPanel, ChatInterface
  referring-URL display)

  Updated UsedChatsPanel.test.js and EvalAnalysisSection.test.js to mock
  GcdsLink as a plain <a> — jsdom doesn't expose the real component's
  shadow-DOM anchor to getByRole('link')/closest('a')