### PR TITLE
feat: italics - style guide alignment

### DIFF
--- a/docs/coding-agent-docs/design-system.md
+++ b/docs/coding-agent-docs/design-system.md
@@ -49,6 +49,14 @@ Do not use inline `style={{...}}` attributes on elements. Add a CSS class instea
 
 Inline styles are only acceptable when the value is genuinely dynamic and cannot be expressed as a class (e.g. a runtime-computed width or colour).
 
+## Italics
+
+No italics (Canada.ca Content Style Guide rule). Exceptions are narrow: French/foreign words, legal references, math/scientific material, titles of works, Latin terms/abbreviations. UI labels, placeholders, status text, and quoted content don't qualify.
+
+- No `font-style: italic` (CSS or inline `style`).
+- No `<em>` for styling — it means stress emphasis, not "make it italic." Use `<strong>` or nothing.
+- No `<i>` outside the exceptions above. (Font-icon glyphs like `<i className="fa-solid fa-close">` aren't text italics — not a concern.)
+
 ## Styling hierarchy
 
 When adding any style, follow this order — stop at the first option that works:

--- a/src/components/admin/dashboard/EvalAnalysisReport.js
+++ b/src/components/admin/dashboard/EvalAnalysisReport.js
@@ -199,7 +199,7 @@ const EvalAnalysisReport = ({ analysis, lang = 'en' }) => {
               {Array.isArray(theme.examples) && theme.examples.length > 0 && (
                 <ul className="font-size-text-xsm-nr" style={{ marginTop: 0 }}>
                   {theme.examples.map((ex, j) => (
-                    <li key={j}><em>{ex}</em></li>
+                    <li key={j}><strong>{ex}</strong></li>
                   ))}
                 </ul>
               )}

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -821,7 +821,7 @@ const ChatInterface = ({
                           {referringUrl}
                         </a>
                       ) : (
-                        <span style={{ fontStyle: "italic", color: "#666" }}>none</span>
+                        <span style={{ color: "#666" }}>none</span>
                       )}
                     </div>
                   )}

--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -200,7 +200,7 @@ const EvalPanel = ({ message, t, lang = 'en', answerNumber }) => {
             <br />
             {noMatchReason && (
               <>
-                <em>{t('eval.reason', 'Reason')}:</em> {noMatchReason}
+                <strong>{t('eval.reason', 'Reason')}:</strong> {noMatchReason}
               </>
             )}
           </p>

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -250,7 +250,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       title: t('admin.chatDashboard.columns.referringUrl', 'Referring URL'),
       data: 'referringUrl',
       render: (value) => {
-        if (!value) return '<span style="font-style: italic; color: #666;">none</span>';
+        if (!value) return '<span style="color: #666;">none</span>';
         return escapeHtmlAttribute(truncateUrl(value));
       }
     },

--- a/src/pages/DatabasePage.js
+++ b/src/pages/DatabasePage.js
@@ -846,7 +846,7 @@ const DatabasePage = ({ lang }) => {
                         </span>
                       )}
                       {col.status === 'incomplete' && col.missingIndexes?.length > 0 && (
-                        <span className="font-size-text-xxs-nr" style={{ marginLeft: 8, fontStyle: 'italic' }}>
+                        <span className="font-size-text-xxs-nr" style={{ marginLeft: 8 }}>
                           {t('admin.database.missingLabel')} {col.missingIndexes.join('; ')}
                         </span>
                       )}

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -144,7 +144,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
     { title: t('admin.evalDashboard.columns.department', 'Department'), data: 'department', searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.program', 'Program'), data: 'program', render: (v, type, row) => { const d = (lang === 'fr' && row && row.programFr) ? row.programFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: true, orderable: true },
     { title: t('admin.evalDashboard.columns.action', 'Action'), data: 'action', render: (v, type, row) => { const d = (lang === 'fr' && row && row.actionFr) ? row.actionFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: true, orderable: true },
-    { title: t('admin.chatDashboard.columns.referringUrl', 'Referring URL'), data: 'referringUrl', render: v => v ? escapeHtmlAttribute(truncateUrl(v)) : '<span style="font-style: italic; color: #666;">none</span>', searchable: false, orderable: true },
+    { title: t('admin.chatDashboard.columns.referringUrl', 'Referring URL'), data: 'referringUrl', render: v => v ? escapeHtmlAttribute(truncateUrl(v)) : '<span style="color: #666;">none</span>', searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.pageLanguage', 'Page'), data: 'pageLanguage', render: v => v ? escapeHtmlAttribute(v.toUpperCase()) : '', searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.creatorEmail', 'Creator email'), data: 'creatorEmail', render: v => escapeHtmlAttribute(truncateEmail(v || '')), searchable: true, orderable: true },
     { title: t('admin.evalDashboard.columns.expertEmail', 'Expert Email'), data: 'expertEmail', render: v => escapeHtmlAttribute(truncateEmail(v || '')), searchable: true, orderable: true },

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -215,16 +215,8 @@
   display: inline-block;
 }
 
-.confidence-rating {
-  font-style: italic;
-  font-size: 85%;
-  color: #555;
-  margin-top: 0.5rem;
-  margin-bottom: 0em !important;
-}
 .follow-up-prompt {
   margin-top: 1rem;
-  font-style: italic;
   color: #555;
 }
 .input-area {
@@ -889,7 +881,6 @@ textarea:focus {
   border-left: 3px solid #ddd;
   font-size: 0.95em;
   line-height: 1.4;
-  font-style: italic;
   overflow-wrap: break-word;
   /* Was inherited from the parent <legend>'s bold font shorthand; these divs
      moved out to be legend siblings (for aria-describedby), so it no longer


### PR DESCRIPTION

  - docs/coding-agent-docs/design-system.md — new Italics section 
  - chat.css — .confidence-rating (dead, deleted whole), .follow-up-prompt, .sentence-text/.citation-text all lose font-style: italic 
  - ChatInterface.js, DatabasePage.js, EvalDashboardPage.js, ChatDashboardPage.js — inline italic removed from "none"/"missing" placeholders
  - EvalPanel.js, EvalAnalysisReport.js — <em> → <strong> 