### PR TITLE
fix: bug in Options on eval chat view

### DIFF
--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -155,6 +155,13 @@ async function handler(req, res) {
 
   // Server-side Workflow Resolution
   let graphName;
+  // TODO(follow-up, PR #1684 review): the `|| DEFAULT_WORKFLOW` fallback is
+  // dead code on the normal path — 'workflow.default' is now seeded into
+  // SETTING_DEFAULTS, so SettingsService.get() should never return a falsy
+  // value here. It silently masks the narrow window where the in-memory
+  // settings cache hasn't been refreshed yet (rather than failing fast), which
+  // AGENTS.md's "prefer fail-fast contracts" guidance would push back on —
+  // worth an explicit cache-not-ready check/log instead of a silent fallback.
   const defaultWorkflow = SettingsService.get('workflow.default') || DEFAULT_WORKFLOW;
 
   if (req.user) {

--- a/api/chat/chat-graph-run.js
+++ b/api/chat/chat-graph-run.js
@@ -4,7 +4,7 @@ import ConversationIntegrityService from '../../services/ConversationIntegritySe
 import { withOptionalUser } from '../../middleware/auth.js';
 import { getGraphApp } from '../../agents/graphs/registry.js';
 import { graphRequestContext } from '../../agents/graphs/requestContext.js';
-import { MODEL_VALUES } from '../../src/config/workflows.js';
+import { MODEL_VALUES, DEFAULT_WORKFLOW } from '../../src/config/workflows.js';
 import BlockedQueryService from '../../services/BlockedQueryService.js';
 import ChatSessionService from '../../services/ChatSessionService.js';
 
@@ -155,7 +155,7 @@ async function handler(req, res) {
 
   // Server-side Workflow Resolution
   let graphName;
-  const defaultWorkflow = SettingsService.get('workflow.default') || 'GenericGraph';
+  const defaultWorkflow = SettingsService.get('workflow.default') || DEFAULT_WORKFLOW;
 
   if (req.user) {
     // Authenticated users can choose their workflow, fallback to default if not provided

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -1,10 +1,17 @@
 import dbConnect from '../api/db/db-connect.js';
 import { Setting } from '../models/setting.js';
 import { requireLiteralString, requireString } from '../api/util/db-query.js';
+import { DEFAULT_WORKFLOW } from '../src/config/workflows.js';
 
 // Default values for settings that must always exist.
 // Seeded on startup if missing from the database.
 const SETTING_DEFAULTS = {
+  // Seeded alongside model.default so an environment that has never had a
+  // workflow saved reports the value it actually runs, instead of returning
+  // null and leaving each caller to substitute its own fallback — which made
+  // "nothing is stored" look identical to "GenericGraph is stored" on the
+  // Settings page and in the chat Options dropdown.
+  'workflow.default': DEFAULT_WORKFLOW,
   'model.default': 'openai-gpt51',
   'chat.transport': 'sse',
   'guardrail.indigenousLanguageBlocking': 'true',

--- a/src/components/batch/BatchList.js
+++ b/src/components/batch/BatchList.js
@@ -170,7 +170,6 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
             // Totals column is after status - find it as the cell before the actions cell
             const actionsCell = row.querySelector('td:last-child');
             const totalsCell = actionsCell ? actionsCell.previousElementSibling : cells[cells.length - 2];
-            actionsCell.innerHTML = '';
             // Populate totals: prefer stats from service, fallback to 0/0
             try {
               const stats = data.stats || {};

--- a/src/components/batch/BatchList.js
+++ b/src/components/batch/BatchList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
-import { createRoot } from 'react-dom/client'; // Import createRoot
+import { getCellRoot } from '../../utils/dataTableCellRoot.js';
 import DataTable from 'datatables.net-react';
 import 'datatables.net-dt/css/dataTables.dataTables.css';
 import DT from 'datatables.net-dt';
@@ -184,17 +184,9 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
             } catch (e) {
               // ignore totals rendering errors
             }
-            // Unmount any previous root mounted on this cell to avoid memory leaks
-            try {
-              if (actionsCell._batchRoot) {
-                actionsCell._batchRoot.unmount();
-              }
-            } catch (e) {
-              // ignore unmount errors
-            }
-            const root = createRoot(actionsCell);
-            // Store the root so we can unmount later when the row is re-rendered/removed
-            actionsCell._batchRoot = root;
+            // Unmounts any previous root mounted on this cell before creating
+            // the new one, so redraws don't leak roots.
+            const root = getCellRoot(actionsCell);
 
             // If processed >= total show download/delete actions
             const stats = data.stats || {};

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -94,6 +94,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     }
   };
 
+  // TODO(follow-up, PR #1684 review): modelIsOverride/workflowIsOverride (below)
+  // are separate state from selectedAI/workflow rather than derived from them.
+  // The invariant "isOverride === (value came from localStorage, not the
+  // fetched default)" is only maintained by convention across every call site
+  // that touches these — handleAIToggle/handleWorkflowChange, the persist
+  // effects, the fetch-default effects. Fine today since all of it is in this
+  // one file, but fragile for the next edit; consider deriving isOverride from
+  // whether the stored key exists rather than tracking it as parallel state.
   const [selectedAI, setSelectedAI] = useState(() => readStoredOverride('selectedAI', MODEL_VALUES));
   const [modelIsOverride, setModelIsOverride] = useState(
     () => readStoredOverride('selectedAI', MODEL_VALUES) !== null
@@ -417,6 +425,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
   // select falls back to rendering its first option, which misreports the
   // workflow whenever workflow.default is set to anything else. Does not mark
   // the value as user-set, so it isn't persisted to localStorage.
+  //
+  // TODO(follow-up, PR #1684 review): fetched once per mount and cached for the
+  // tab's lifetime — an admin changing workflow.default in Settings won't reach
+  // an already-open tab until reload. This mirrors model.default's existing,
+  // pre-PR fetch-once behavior below, so it's consistent rather than a new
+  // regression, but the underlying "no live update" tradeoff for both is worth
+  // a deliberate decision (e.g. re-fetch on window focus, or a settings-changed
+  // event) rather than being carried forward implicitly.
   useEffect(() => {
     let mounted = true;
     const loadDefaultWorkflow = async () => {

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -7,7 +7,7 @@ import { ChatWorkflowService, RedactionError, ShortQueryValidation, ChatRunInPro
 
 import DataStoreService from '../../services/DataStoreService.js';
 import AuthService from '../../services/AuthService.js';
-import { AVAILABLE_MODELS } from '../../config/workflows.js';
+import { AVAILABLE_MODELS, MODEL_VALUES, WORKFLOW_VALUES, DEFAULT_WORKFLOW } from '../../config/workflows.js';
 import { safeHttpHref } from '../../utils/safeUrl.js';
 import { buildAriaLabel } from '../../utils/citationAriaLabel.js';
 import { getCitationUrl } from '../../utils/getCitationUrl.js';
@@ -73,9 +73,18 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
   const [showFeedback, setShowFeedback] = useState(false);
   // Persisted options (except referringUrl) saved in localStorage so they survive refresh/new chats
   const storageKey = (k) => `aiAnswers.${k}`;
-  // selectedAI: always start null so we fetch the current model.default from Settings.
-  // Only persist to localStorage when the admin explicitly picks a model in the UI.
-  const [selectedAI, setSelectedAI] = useState(null);
+  // selectedAI: prefer a user-set value in localStorage; if none exists — or the
+  // stored value is no longer an available model — leave null so we fetch the
+  // current model.default from Settings. Mirrors the workflow handling below.
+  const [selectedAI, setSelectedAI] = useState(() => {
+    try {
+      const val = localStorage.getItem(storageKey('selectedAI'));
+      return MODEL_VALUES.includes(val) ? val : null;
+    } catch (e) {
+      return null;
+    }
+  });
+  const initialModelFromLocalStorage = useRef(false);
   const userSetModel = useRef(false);
   const [selectedSearch, setSelectedSearch] = useState(() => {
     try {
@@ -84,13 +93,14 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
       return 'google';
     }
   });
-  // workflow: prefer a user-set value in localStorage; if none exists, leave null
-  // so we can fetch the public default setting and avoid persisting it unless
-  // the user explicitly chooses a workflow in the UI.
+  // workflow: prefer a user-set value in localStorage; if none exists — or the
+  // stored value is no longer a valid workflow — leave null so we can fetch the
+  // public default setting and avoid persisting it unless the user explicitly
+  // chooses a workflow in the UI.
   const [workflow, setWorkflow] = useState(() => {
     try {
       const val = localStorage.getItem(storageKey('workflow'));
-      return val !== null ? val : null;
+      return WORKFLOW_VALUES.includes(val) ? val : null;
     } catch (e) {
       return null;
     }
@@ -353,11 +363,24 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     console.log('Search toggled to:', e.target.value);
   };
 
+  // Record whether a model value existed in localStorage at mount, so a stored
+  // override keeps being persisted on later changes.
+  useEffect(() => {
+    try {
+      const val = localStorage.getItem(storageKey('selectedAI'));
+      if (MODEL_VALUES.includes(val)) initialModelFromLocalStorage.current = true;
+    } catch (e) {
+      // ignore
+    }
+  }, []);
+
   // Persist selection changes to localStorage
   useEffect(() => {
     try {
-      // Only persist when the admin explicitly changed the model in the UI
-      if (userSetModel.current && selectedAI !== null && selectedAI !== undefined) {
+      // Only persist the admin's own choice — never the fetched model.default,
+      // which must keep following the Settings value.
+      if (selectedAI !== null && selectedAI !== undefined
+        && (initialModelFromLocalStorage.current || userSetModel.current)) {
         localStorage.setItem(storageKey('selectedAI'), selectedAI);
       }
     } catch (e) {
@@ -375,7 +398,7 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
         try {
           const model = await DataStoreService.getPublicSetting('model.default', null);
           if (mounted) {
-            setSelectedAI(model || AVAILABLE_MODELS[0].value);
+            setSelectedAI(MODEL_VALUES.includes(model) ? model : AVAILABLE_MODELS[0].value);
           }
         } catch (err) {
           if (mounted) setSelectedAI(AVAILABLE_MODELS[0].value);
@@ -399,13 +422,34 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
   useEffect(() => {
     try {
       const val = localStorage.getItem(storageKey('workflow'));
-      if (val !== null) initialWorkflowFromLocalStorage.current = true;
+      if (WORKFLOW_VALUES.includes(val)) initialWorkflowFromLocalStorage.current = true;
     } catch (e) {
       // ignore
     }
   }, []);
 
-
+  // With no local override, load the configured default workflow so the Options
+  // dropdown shows the workflow the server will actually run. Without this the
+  // select falls back to rendering its first option, which misreports the
+  // workflow whenever workflow.default is set to anything else. Does not mark
+  // the value as user-set, so it isn't persisted to localStorage.
+  useEffect(() => {
+    let mounted = true;
+    const loadDefaultWorkflow = async () => {
+      if (workflow === null) {
+        try {
+          const defaultWorkflow = await DataStoreService.getPublicSetting('workflow.default', null);
+          if (mounted) {
+            setWorkflow(WORKFLOW_VALUES.includes(defaultWorkflow) ? defaultWorkflow : DEFAULT_WORKFLOW);
+          }
+        } catch (err) {
+          if (mounted) setWorkflow(DEFAULT_WORKFLOW);
+        }
+      }
+    };
+    loadDefaultWorkflow();
+    return () => { mounted = false; };
+  }, [workflow]);
 
   useEffect(() => {
     try {

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -73,19 +73,31 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
   const [showFeedback, setShowFeedback] = useState(false);
   // Persisted options (except referringUrl) saved in localStorage so they survive refresh/new chats
   const storageKey = (k) => `aiAnswers.${k}`;
-  // selectedAI: prefer a user-set value in localStorage; if none exists — or the
-  // stored value is no longer an available model — leave null so we fetch the
-  // current model.default from Settings. Mirrors the workflow handling below.
-  const [selectedAI, setSelectedAI] = useState(() => {
+  // A stored value is an *override*: this admin has deliberately chosen
+  // something other than what Settings says, and it sticks until they pick
+  // "use system settings" again. Without a stored value we follow the
+  // configured default, and the dropdown says so rather than naming a
+  // workflow/model that only looks like a deliberate choice.
+  const readStoredOverride = (key, allowed) => {
     try {
-      const val = localStorage.getItem(storageKey('selectedAI'));
-      return MODEL_VALUES.includes(val) ? val : null;
+      const val = localStorage.getItem(storageKey(key));
+      return allowed.includes(val) ? val : null;
     } catch (e) {
       return null;
     }
-  });
-  const initialModelFromLocalStorage = useRef(false);
-  const userSetModel = useRef(false);
+  };
+  const clearStoredOverride = (key) => {
+    try {
+      localStorage.removeItem(storageKey(key));
+    } catch (e) {
+      // ignore storage errors
+    }
+  };
+
+  const [selectedAI, setSelectedAI] = useState(() => readStoredOverride('selectedAI', MODEL_VALUES));
+  const [modelIsOverride, setModelIsOverride] = useState(
+    () => readStoredOverride('selectedAI', MODEL_VALUES) !== null
+  );
   const [selectedSearch, setSelectedSearch] = useState(() => {
     try {
       return localStorage.getItem(storageKey('selectedSearch')) || 'google';
@@ -93,24 +105,10 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
       return 'google';
     }
   });
-  // workflow: prefer a user-set value in localStorage; if none exists — or the
-  // stored value is no longer a valid workflow — leave null so we can fetch the
-  // public default setting and avoid persisting it unless the user explicitly
-  // chooses a workflow in the UI.
-  const [workflow, setWorkflow] = useState(() => {
-    try {
-      const val = localStorage.getItem(storageKey('workflow'));
-      return WORKFLOW_VALUES.includes(val) ? val : null;
-    } catch (e) {
-      return null;
-    }
-  });
-  // Track whether an initial value existed in localStorage and whether the user
-  // explicitly set the workflow during this session. We only persist when one
-  // of these is true so we don't overwrite the user's future changes to the
-  // public default unintentionally.
-  const initialWorkflowFromLocalStorage = useRef(false);
-  const userSetWorkflow = useRef(false);
+  const [workflow, setWorkflow] = useState(() => readStoredOverride('workflow', WORKFLOW_VALUES));
+  const [workflowIsOverride, setWorkflowIsOverride] = useState(
+    () => readStoredOverride('workflow', WORKFLOW_VALUES) !== null
+  );
   // Precedence for initial referring URL:
   // 1) saved review value (initialReferringUrl)
   // 2) pageUrl (from usePageContext)
@@ -352,10 +350,19 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     }, 100);
   };
 
+  // An empty value is the "use system settings" entry: drop the stored
+  // override and null the state so the fetch effect below reloads whatever
+  // Settings currently says.
   const handleAIToggle = (e) => {
-    userSetModel.current = true;
-    setSelectedAI(e.target.value);
-    console.log('AI toggled to:', e.target.value);
+    const value = e.target.value;
+    if (!value) {
+      clearStoredOverride('selectedAI');
+      setModelIsOverride(false);
+      setSelectedAI(null);
+      return;
+    }
+    setModelIsOverride(true);
+    setSelectedAI(value);
   };
 
   const handleSearchToggle = (e) => {
@@ -363,30 +370,18 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     console.log('Search toggled to:', e.target.value);
   };
 
-  // Record whether a model value existed in localStorage at mount, so a stored
-  // override keeps being persisted on later changes.
+  // Persist selection changes to localStorage. Only the admin's own choice is
+  // stored — never the fetched model.default, which must keep following the
+  // Settings value.
   useEffect(() => {
     try {
-      const val = localStorage.getItem(storageKey('selectedAI'));
-      if (MODEL_VALUES.includes(val)) initialModelFromLocalStorage.current = true;
-    } catch (e) {
-      // ignore
-    }
-  }, []);
-
-  // Persist selection changes to localStorage
-  useEffect(() => {
-    try {
-      // Only persist the admin's own choice — never the fetched model.default,
-      // which must keep following the Settings value.
-      if (selectedAI !== null && selectedAI !== undefined
-        && (initialModelFromLocalStorage.current || userSetModel.current)) {
+      if (modelIsOverride && selectedAI !== null && selectedAI !== undefined) {
         localStorage.setItem(storageKey('selectedAI'), selectedAI);
       }
     } catch (e) {
       // ignore storage errors
     }
-  }, [selectedAI]);
+  }, [modelIsOverride, selectedAI]);
 
   // Fetch the configured default model family from Settings on mount.
   // AVAILABLE_MODELS[0] is the canonical fallback when model.default has never
@@ -417,17 +412,6 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     }
   }, [selectedSearch]);
 
-  // Record whether a workflow value existed in localStorage at mount. This
-  // helps us decide whether to persist later changes.
-  useEffect(() => {
-    try {
-      const val = localStorage.getItem(storageKey('workflow'));
-      if (WORKFLOW_VALUES.includes(val)) initialWorkflowFromLocalStorage.current = true;
-    } catch (e) {
-      // ignore
-    }
-  }, []);
-
   // With no local override, load the configured default workflow so the Options
   // dropdown shows the workflow the server will actually run. Without this the
   // select falls back to rendering its first option, which misreports the
@@ -453,20 +437,29 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
 
   useEffect(() => {
     try {
-      // Only persist workflow when it came from localStorage initially or the
-      // user explicitly changed it during this session.
-      if (workflow !== null && (initialWorkflowFromLocalStorage.current || userSetWorkflow.current)) {
+      // Only the admin's own choice is stored — never the fetched
+      // workflow.default, which must keep following the Settings value.
+      if (workflowIsOverride && workflow !== null) {
         localStorage.setItem(storageKey('workflow'), workflow);
       }
     } catch (e) {
       // ignore storage errors
     }
-  }, [workflow]);
+  }, [workflowIsOverride, workflow]);
 
+  // An empty value is the "use system settings" entry: drop the stored
+  // override and null the state so the fetch effect above reloads whatever
+  // Settings currently says.
   const handleWorkflowChange = (e) => {
-    userSetWorkflow.current = true;
-    setWorkflow(e.target.value);
-    console.log('Workflow changed to:', e.target.value);
+    const value = e.target.value;
+    if (!value) {
+      clearStoredOverride('workflow');
+      setWorkflowIsOverride(false);
+      setWorkflow(null);
+      return;
+    }
+    setWorkflowIsOverride(true);
+    setWorkflow(value);
   };
 
   const clearInput = useCallback(() => {
@@ -1002,6 +995,9 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
 
   // Add handler for department changes
 
+  // The Options dropdowns below are passed an explicit override, or '' — the
+  // "use system settings" entry — when we are following Settings, so an admin
+  // can always tell which of the two they are looking at.
   return (
     <>
       <ChatInterface
@@ -1014,11 +1010,11 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
         handleReload={handleReload}
         handleAIToggle={handleAIToggle}
         handleSearchToggle={handleSearchToggle}
-        workflow={workflow}
+        workflowSelection={workflowIsOverride ? workflow : ''}
         handleWorkflowChange={handleWorkflowChange}
         handleReferringUrlChange={handleReferringUrlChange}
         formatAIResponse={formatAIResponse}
-        selectedAI={selectedAI}
+        modelSelection={modelIsOverride ? selectedAI : ''}
         selectedSearch={selectedSearch}
         referringUrl={referringUrl}
         chatCreatedAt={chatCreatedAt}

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -28,11 +28,11 @@ const ChatInterface = ({
   handleReload,
   handleAIToggle,
   handleSearchToggle,
-  workflow,
+  workflowSelection,
   handleWorkflowChange,
   handleReferringUrlChange,
   formatAIResponse,
-  selectedAI,
+  modelSelection,
   selectedSearch,
   referringUrl,
   chatCreatedAt,
@@ -1014,11 +1014,11 @@ const ChatInterface = ({
           )}
           <ChatOptions
             safeT={safeT}
-            selectedAI={selectedAI}
+            modelSelection={modelSelection}
             handleAIToggle={handleAIToggle}
             selectedSearch={selectedSearch}
             handleSearchToggle={handleSearchToggle}
-            workflow={workflow}
+            workflowSelection={workflowSelection}
             handleWorkflowChange={handleWorkflowChange}
             referringUrl={referringUrl}
             handleReferringUrlChange={handleReferringUrlChange}

--- a/src/components/chat/ChatOptions.js
+++ b/src/components/chat/ChatOptions.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import { GcdsDetails } from '@gcds-core/components-react';
 import { RoleBasedContent } from '../RoleBasedUI.js';
-import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES } from '../../config/workflows.js';
+import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES, MODEL_VALUES } from '../../config/workflows.js';
 
+// workflowSelection / modelSelection are what the dropdowns show, which is not
+// the same thing as what the chat will run: '' means "no override, follow the
+// system settings", and the effective value in that case lives in
+// ChatAppContainer (and is resolved server-side regardless).
 const ChatOptions = ({
   safeT,
-  selectedAI,
+  modelSelection,
   handleAIToggle,
   // selectedSearch,
   handleSearchToggle,
-  workflow,
+  workflowSelection,
   handleWorkflowChange,
   referringUrl,
   handleReferringUrlChange
@@ -29,10 +33,11 @@ const ChatOptions = ({
                 // Render blank rather than silently falling back to the first
                 // option while the configured default is still loading — an
                 // unmatched value here would misreport which workflow ran.
-                value={WORKFLOW_VALUES.includes(workflow) ? workflow : ''}
+                value={WORKFLOW_VALUES.includes(workflowSelection) ? workflowSelection : ''}
                 onChange={handleWorkflowChange}
                 className="chat-border"
               >
+                <option value="">{safeT('homepage.chat.options.useSystemSettings')}</option>
                 {WORKFLOWS.map(w => (
                   <option key={w.value} value={w.value}>{safeT(w.labelKey)}</option>
                 ))}
@@ -46,10 +51,11 @@ const ChatOptions = ({
               <select
                 id="model"
                 name="model"
-                value={selectedAI || ''}
+                value={MODEL_VALUES.includes(modelSelection) ? modelSelection : ''}
                 onChange={handleAIToggle}
                 className="chat-border"
               >
+                <option value="">{safeT('homepage.chat.options.useSystemSettings')}</option>
                 {AVAILABLE_MODELS.map(m => (
                   <option key={m.value} value={m.value}>{safeT(m.labelKey)}</option>
                 ))}

--- a/src/components/chat/ChatOptions.js
+++ b/src/components/chat/ChatOptions.js
@@ -33,6 +33,13 @@ const ChatOptions = ({
                 // Render blank rather than silently falling back to the first
                 // option while the configured default is still loading — an
                 // unmatched value here would misreport which workflow ran.
+                //
+                // TODO(follow-up, PR #1684 review): this `VALUES.includes(x) ? x
+                // : fallback` shape is repeated 6+ times across this file,
+                // ChatAppContainer.js, and SettingsPage.js. Per AGENTS.md's
+                // "prefer central fixes for shared semantics", a shared helper
+                // in src/config/workflows.js (e.g. `resolveWorkflow(value)` /
+                // `resolveModel(value)`) would keep it from drifting.
                 value={WORKFLOW_VALUES.includes(workflowSelection) ? workflowSelection : ''}
                 onChange={handleWorkflowChange}
                 className="chat-border"

--- a/src/components/chat/ChatOptions.js
+++ b/src/components/chat/ChatOptions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GcdsDetails } from '@gcds-core/components-react';
 import { RoleBasedContent } from '../RoleBasedUI.js';
-import { WORKFLOWS, AVAILABLE_MODELS } from '../../config/workflows.js';
+import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES } from '../../config/workflows.js';
 
 const ChatOptions = ({
   safeT,
@@ -26,7 +26,10 @@ const ChatOptions = ({
               <select
                 id="workflow"
                 name="workflow"
-                value={workflow}
+                // Render blank rather than silently falling back to the first
+                // option while the configured default is still loading — an
+                // unmatched value here would misreport which workflow ran.
+                value={WORKFLOW_VALUES.includes(workflow) ? workflow : ''}
                 onChange={handleWorkflowChange}
                 className="chat-border"
               >

--- a/src/components/chat/__tests__/ChatAppContainer.workflow.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.workflow.test.js
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import ChatAppContainer from '../ChatAppContainer';
 import { usePageContext } from '../../../hooks/usePageParam';
 import DataStoreService from '../../../services/DataStoreService';
+import { ChatWorkflowService } from '../../../services/ChatWorkflowService';
 
 vi.mock('../../../hooks/usePageParam', () => ({
     usePageContext: vi.fn(),
@@ -23,15 +24,45 @@ vi.mock('../../../hooks/useTranslations', () => ({
 
 vi.mock('../../../services/DataStoreService', () => ({ default: { getPublicSetting: vi.fn() } }));
 vi.mock('../../../services/SessionService', () => ({ default: { getChatId: vi.fn(() => Promise.resolve('abc')) } }));
-vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)) } }));
-vi.mock('../../../services/ChatWorkflowService', () => ({ ChatWorkflowService: { processResponse: vi.fn() }, RedactionError: class { }, ShortQueryValidation: class { }, ChatRunInProgressError: class { } }));
+vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)), getUserId: vi.fn(() => null) } }));
+vi.mock('../../../services/ChatWorkflowService', () => ({
+    ChatWorkflowService: { processResponse: vi.fn(() => new Promise(() => {})) },
+    RedactionError: class { },
+    ShortQueryValidation: class { },
+    ChatRunInProgressError: class { }
+}));
 
-// Surface the values the container hands to the Options dropdowns.
+// Surface what the Options dropdowns are told to display, and expose the
+// change handlers so tests drive the real selection logic. '' is the
+// "use system settings" entry.
 vi.mock('../ChatInterface', () => ({
-    default: ({ workflow, selectedAI }) => (
+    default: ({ workflowSelection, modelSelection, handleWorkflowChange, handleAIToggle, handleSendMessage, handleInputChange }) => (
         <>
-            <div data-testid="workflow-display">{workflow ?? ''}</div>
-            <div data-testid="model-display">{selectedAI ?? ''}</div>
+            <div data-testid="workflow-selection">{workflowSelection ?? ''}</div>
+            <div data-testid="model-selection">{modelSelection ?? ''}</div>
+            <button
+                data-testid="pick-workflow"
+                onClick={() => handleWorkflowChange({ target: { value: 'InstantAndQAGraph' } })}
+            >pick workflow</button>
+            <button
+                data-testid="clear-workflow"
+                onClick={() => handleWorkflowChange({ target: { value: '' } })}
+            >workflow: use system settings</button>
+            <button
+                data-testid="pick-model"
+                onClick={() => handleAIToggle({ target: { value: 'openai-gpt51' } })}
+            >pick model</button>
+            <button
+                data-testid="clear-model"
+                onClick={() => handleAIToggle({ target: { value: '' } })}
+            >model: use system settings</button>
+            {/* handleSendMessage closes over inputText, so typing has to be a
+                separate event from sending. */}
+            <button
+                data-testid="type"
+                onClick={() => handleInputChange({ target: { value: 'where is the rcmp headquarters' } })}
+            >type</button>
+            <button data-testid="send" onClick={() => handleSendMessage()}>send</button>
         </>
     )
 }));
@@ -42,12 +73,21 @@ const mockPublicSettings = (values) => {
     );
 };
 
+// Positional args of ChatWorkflowService.processResponse: workflow is 10th
+// (index 9), between translationF and onStatusUpdate.
+const WORKFLOW_ARG_INDEX = 9;
+const sentWorkflow = () =>
+    vi.mocked(ChatWorkflowService.processResponse).mock.calls[0][WORKFLOW_ARG_INDEX];
+
+const STORED_WORKFLOW = 'aiAnswers.workflow';
+const STORED_MODEL = 'aiAnswers.selectedAI';
+
 describe('ChatAppContainer - workflow selection', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         localStorage.clear();
         vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
-        mockPublicSettings({ 'model.default': 'azure' });
+        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
     });
 
     afterEach(() => {
@@ -55,49 +95,96 @@ describe('ChatAppContainer - workflow selection', () => {
         localStorage.clear();
     });
 
-    it('shows the configured workflow.default when there is no local override', async () => {
-        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
-
+    it('shows "use system settings" rather than naming a workflow when following the setting', async () => {
         render(<ChatAppContainer lang="en" />);
 
+        // '' is the "use system settings" entry — the dropdown must not imply
+        // the admin deliberately chose GenericWithQAGraph.
         await waitFor(() =>
-            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericWithQAGraph')
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('workflow.default', null)
         );
-        // The fetched default is not the user's own choice, so it must not be persisted.
-        expect(localStorage.getItem('aiAnswers.workflow')).toBeNull();
+        expect(screen.getByTestId('workflow-selection').textContent).toBe('');
+        expect(localStorage.getItem(STORED_WORKFLOW)).toBeNull();
+    });
+
+    it('still sends the configured workflow.default while following the setting', async () => {
+        render(<ChatAppContainer lang="en" />);
+        await waitFor(() =>
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('workflow.default', null)
+        );
+
+        fireEvent.click(screen.getByTestId('type'));
+        fireEvent.click(screen.getByTestId('send'));
+
+        await waitFor(() => expect(ChatWorkflowService.processResponse).toHaveBeenCalled());
+        expect(sentWorkflow()).toBe('GenericWithQAGraph');
     });
 
     it('falls back to DEFAULT_WORKFLOW when workflow.default is unset', async () => {
         mockPublicSettings({ 'model.default': 'azure' });
 
         render(<ChatAppContainer lang="en" />);
-
         await waitFor(() =>
-            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericGraph')
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('workflow.default', null)
         );
+
+        fireEvent.click(screen.getByTestId('type'));
+        fireEvent.click(screen.getByTestId('send'));
+        await waitFor(() => expect(ChatWorkflowService.processResponse).toHaveBeenCalled());
+        expect(sentWorkflow()).toBe('GenericGraph');
     });
 
-    it('ignores a stale localStorage workflow that is no longer a valid option', async () => {
-        localStorage.setItem('aiAnswers.workflow', 'Default');
-        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
+    it('persists an explicit pick and shows it as the selection', async () => {
+        render(<ChatAppContainer lang="en" />);
+
+        fireEvent.click(screen.getByTestId('pick-workflow'));
+
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-selection').textContent).toBe('InstantAndQAGraph')
+        );
+        expect(localStorage.getItem(STORED_WORKFLOW)).toBe('InstantAndQAGraph');
+    });
+
+    it('keeps a valid stored override instead of the setting', async () => {
+        localStorage.setItem(STORED_WORKFLOW, 'InstantAndQAGraph');
 
         render(<ChatAppContainer lang="en" />);
 
         await waitFor(() =>
-            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericWithQAGraph')
-        );
-    });
-
-    it('keeps a valid user override from localStorage', async () => {
-        localStorage.setItem('aiAnswers.workflow', 'InstantAndQAGraph');
-        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
-
-        render(<ChatAppContainer lang="en" />);
-
-        await waitFor(() =>
-            expect(screen.getByTestId('workflow-display').textContent).toBe('InstantAndQAGraph')
+            expect(screen.getByTestId('workflow-selection').textContent).toBe('InstantAndQAGraph')
         );
         expect(DataStoreService.getPublicSetting).not.toHaveBeenCalledWith('workflow.default', expect.anything());
+    });
+
+    it('ignores a stale stored workflow that is no longer a valid option', async () => {
+        localStorage.setItem(STORED_WORKFLOW, 'Default');
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('workflow.default', null)
+        );
+        expect(screen.getByTestId('workflow-selection').textContent).toBe('');
+    });
+
+    it('"use system settings" clears the stored override and follows the setting again', async () => {
+        localStorage.setItem(STORED_WORKFLOW, 'InstantAndQAGraph');
+
+        render(<ChatAppContainer lang="en" />);
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-selection').textContent).toBe('InstantAndQAGraph')
+        );
+
+        fireEvent.click(screen.getByTestId('clear-workflow'));
+
+        await waitFor(() => expect(localStorage.getItem(STORED_WORKFLOW)).toBeNull());
+        expect(screen.getByTestId('workflow-selection').textContent).toBe('');
+
+        // And the setting is what actually runs from then on.
+        fireEvent.click(screen.getByTestId('type'));
+        fireEvent.click(screen.getByTestId('send'));
+        await waitFor(() => expect(ChatWorkflowService.processResponse).toHaveBeenCalled());
+        expect(sentWorkflow()).toBe('GenericWithQAGraph');
     });
 });
 
@@ -106,6 +193,7 @@ describe('ChatAppContainer - model selection', () => {
         vi.clearAllMocks();
         localStorage.clear();
         vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        mockPublicSettings({ 'model.default': 'azure' });
     });
 
     afterEach(() => {
@@ -113,44 +201,49 @@ describe('ChatAppContainer - model selection', () => {
         localStorage.clear();
     });
 
-    it('shows the configured model.default when there is no local override', async () => {
-        mockPublicSettings({ 'model.default': 'azure' });
-
+    it('shows "use system settings" while following model.default', async () => {
         render(<ChatAppContainer lang="en" />);
 
-        await waitFor(() => expect(screen.getByTestId('model-display').textContent).toBe('azure'));
-        // The fetched default is not the admin's own choice, so it must not be persisted.
-        expect(localStorage.getItem('aiAnswers.selectedAI')).toBeNull();
+        await waitFor(() =>
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('model.default', null)
+        );
+        expect(screen.getByTestId('model-selection').textContent).toBe('');
+        expect(localStorage.getItem(STORED_MODEL)).toBeNull();
     });
 
-    it('keeps a valid user override from localStorage instead of the setting', async () => {
-        localStorage.setItem('aiAnswers.selectedAI', 'openai-gpt51');
-        mockPublicSettings({ 'model.default': 'azure' });
+    it('persists an explicit pick and keeps it over the setting', async () => {
+        render(<ChatAppContainer lang="en" />);
+
+        fireEvent.click(screen.getByTestId('pick-model'));
+
+        await waitFor(() =>
+            expect(screen.getByTestId('model-selection').textContent).toBe('openai-gpt51')
+        );
+        expect(localStorage.getItem(STORED_MODEL)).toBe('openai-gpt51');
+    });
+
+    it('ignores a stale stored model that is no longer available', async () => {
+        localStorage.setItem(STORED_MODEL, 'anthropic');
 
         render(<ChatAppContainer lang="en" />);
 
         await waitFor(() =>
-            expect(screen.getByTestId('model-display').textContent).toBe('openai-gpt51')
+            expect(DataStoreService.getPublicSetting).toHaveBeenCalledWith('model.default', null)
         );
-        expect(DataStoreService.getPublicSetting).not.toHaveBeenCalledWith('model.default', expect.anything());
+        expect(screen.getByTestId('model-selection').textContent).toBe('');
     });
 
-    it('ignores a stale localStorage model that is no longer available', async () => {
-        localStorage.setItem('aiAnswers.selectedAI', 'anthropic');
-        mockPublicSettings({ 'model.default': 'azure' });
+    it('"use system settings" clears the stored model override', async () => {
+        localStorage.setItem(STORED_MODEL, 'openai-gpt51');
 
         render(<ChatAppContainer lang="en" />);
-
-        await waitFor(() => expect(screen.getByTestId('model-display').textContent).toBe('azure'));
-    });
-
-    it('falls back to the first available model when model.default is invalid', async () => {
-        mockPublicSettings({ 'model.default': 'anthropic' });
-
-        render(<ChatAppContainer lang="en" />);
-
         await waitFor(() =>
-            expect(screen.getByTestId('model-display').textContent).toBe('openai-gpt51')
+            expect(screen.getByTestId('model-selection').textContent).toBe('openai-gpt51')
         );
+
+        fireEvent.click(screen.getByTestId('clear-model'));
+
+        await waitFor(() => expect(localStorage.getItem(STORED_MODEL)).toBeNull());
+        expect(screen.getByTestId('model-selection').textContent).toBe('');
     });
 });

--- a/src/components/chat/__tests__/ChatAppContainer.workflow.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.workflow.test.js
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import ChatAppContainer from '../ChatAppContainer';
+import { usePageContext } from '../../../hooks/usePageParam';
+import DataStoreService from '../../../services/DataStoreService';
+
+vi.mock('../../../hooks/usePageParam', () => ({
+    usePageContext: vi.fn(),
+    DEPARTMENT_MAPPINGS: {}
+}));
+
+vi.mock('../../../hooks/useTranslations', () => ({
+    useTranslations: vi.fn(() => ({
+        t: (k) => {
+            const mockT = (val) => val;
+            mockT.text = (val) => val;
+            return mockT(k);
+        }
+    }))
+}));
+
+vi.mock('../../../services/DataStoreService', () => ({ default: { getPublicSetting: vi.fn() } }));
+vi.mock('../../../services/SessionService', () => ({ default: { getChatId: vi.fn(() => Promise.resolve('abc')) } }));
+vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)) } }));
+vi.mock('../../../services/ChatWorkflowService', () => ({ ChatWorkflowService: { processResponse: vi.fn() }, RedactionError: class { }, ShortQueryValidation: class { }, ChatRunInProgressError: class { } }));
+
+// Surface the values the container hands to the Options dropdowns.
+vi.mock('../ChatInterface', () => ({
+    default: ({ workflow, selectedAI }) => (
+        <>
+            <div data-testid="workflow-display">{workflow ?? ''}</div>
+            <div data-testid="model-display">{selectedAI ?? ''}</div>
+        </>
+    )
+}));
+
+const mockPublicSettings = (values) => {
+    vi.mocked(DataStoreService.getPublicSetting).mockImplementation(
+        (key, fallback = null) => Promise.resolve(key in values ? values[key] : fallback)
+    );
+};
+
+describe('ChatAppContainer - workflow selection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        mockPublicSettings({ 'model.default': 'azure' });
+    });
+
+    afterEach(() => {
+        cleanup();
+        localStorage.clear();
+    });
+
+    it('shows the configured workflow.default when there is no local override', async () => {
+        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericWithQAGraph')
+        );
+        // The fetched default is not the user's own choice, so it must not be persisted.
+        expect(localStorage.getItem('aiAnswers.workflow')).toBeNull();
+    });
+
+    it('falls back to DEFAULT_WORKFLOW when workflow.default is unset', async () => {
+        mockPublicSettings({ 'model.default': 'azure' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericGraph')
+        );
+    });
+
+    it('ignores a stale localStorage workflow that is no longer a valid option', async () => {
+        localStorage.setItem('aiAnswers.workflow', 'Default');
+        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-display').textContent).toBe('GenericWithQAGraph')
+        );
+    });
+
+    it('keeps a valid user override from localStorage', async () => {
+        localStorage.setItem('aiAnswers.workflow', 'InstantAndQAGraph');
+        mockPublicSettings({ 'model.default': 'azure', 'workflow.default': 'GenericWithQAGraph' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('workflow-display').textContent).toBe('InstantAndQAGraph')
+        );
+        expect(DataStoreService.getPublicSetting).not.toHaveBeenCalledWith('workflow.default', expect.anything());
+    });
+});
+
+describe('ChatAppContainer - model selection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+    });
+
+    afterEach(() => {
+        cleanup();
+        localStorage.clear();
+    });
+
+    it('shows the configured model.default when there is no local override', async () => {
+        mockPublicSettings({ 'model.default': 'azure' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() => expect(screen.getByTestId('model-display').textContent).toBe('azure'));
+        // The fetched default is not the admin's own choice, so it must not be persisted.
+        expect(localStorage.getItem('aiAnswers.selectedAI')).toBeNull();
+    });
+
+    it('keeps a valid user override from localStorage instead of the setting', async () => {
+        localStorage.setItem('aiAnswers.selectedAI', 'openai-gpt51');
+        mockPublicSettings({ 'model.default': 'azure' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('model-display').textContent).toBe('openai-gpt51')
+        );
+        expect(DataStoreService.getPublicSetting).not.toHaveBeenCalledWith('model.default', expect.anything());
+    });
+
+    it('ignores a stale localStorage model that is no longer available', async () => {
+        localStorage.setItem('aiAnswers.selectedAI', 'anthropic');
+        mockPublicSettings({ 'model.default': 'azure' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() => expect(screen.getByTestId('model-display').textContent).toBe('azure'));
+    });
+
+    it('falls back to the first available model when model.default is invalid', async () => {
+        mockPublicSettings({ 'model.default': 'anthropic' });
+
+        render(<ChatAppContainer lang="en" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId('model-display').textContent).toBe('openai-gpt51')
+        );
+    });
+});

--- a/src/components/chatviewer/MetadataModal.js
+++ b/src/components/chatviewer/MetadataModal.js
@@ -1,6 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { GcdsButton } from '@gcds-core/components-react';
 import Prism from 'prismjs';
+// The json grammar is a separate component (xml is aliased in Prism core).
+// Imported here rather than relied on as a side effect of ChatViewer's own
+// import, so this modal highlights correctly wherever it gets mounted.
+import 'prismjs/components/prism-json.js';
 import { useReturnFocusOnClose } from '../../hooks/useReturnFocusOnClose.js';
 
 // Elements a keyboard user could plausibly land on inside the dialog, for
@@ -9,8 +13,26 @@ import { useReturnFocusOnClose } from '../../hooks/useReturnFocusOnClose.js';
 const FOCUSABLE_SELECTOR =
   'button, gcds-button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
+// Highlighting is done here, to an HTML string React renders itself, rather
+// than by pointing Prism.highlightElement at a live <code> node. Prism
+// rewrites the innerHTML of whatever element it is given — if React owned
+// that element's children, it would later reconcile against nodes Prism had
+// already destroyed (the same class of failure as DataTables re-parenting a
+// React-rendered <table>). dangerouslySetInnerHTML makes React the only
+// writer: it never reconciles children it did not create, so even the
+// document-wide Prism.highlightAll() in useChatLogsTable can't corrupt it.
+//
+// Safe against injection: Prism escapes & and < as it tokenizes, and the
+// no-grammar fallback escapes explicitly.
+const escapeHtml = (text) =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const highlightToHtml = (text, language) => {
+  const grammar = Prism.languages[language];
+  return grammar ? Prism.highlight(text, grammar, language) : escapeHtml(text);
+};
+
 const MetadataModal = ({ metadata, onClose, t }) => {
-  const codeRef = useRef(null);
   const dialogRef = useRef(null);
   const closeButtonRef = useRef(null);
   // The element that had focus right before the modal opened (e.g. the
@@ -35,9 +57,6 @@ const MetadataModal = ({ metadata, onClose, t }) => {
       // Must run before focus moves into the dialog below.
       triggerRef.current = document.activeElement;
       document.body.style.overflow = 'hidden';
-      if (codeRef.current) {
-        Prism.highlightElement(codeRef.current);
-      }
       closeButtonRef.current?.focus?.();
     } else {
       document.body.style.overflow = 'auto';
@@ -86,14 +105,27 @@ const MetadataModal = ({ metadata, onClose, t }) => {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [metadata]);
 
+  // Above the early return below, so the hook order stays stable whether or
+  // not the modal is open.
+  const { language, html } = useMemo(() => {
+    if (!metadata) {
+      return { language: 'json', html: '' };
+    }
+
+    const isXml =
+      typeof metadata === 'string' &&
+      metadata.trim().startsWith('<') &&
+      metadata.trim().endsWith('>');
+    const text =
+      typeof metadata === 'string' ? metadata : JSON.stringify(metadata || {}, null, 2);
+    const lang = isXml ? 'xml' : 'json';
+
+    return { language: lang, html: highlightToHtml(text, lang) };
+  }, [metadata]);
+
   if (!metadata) {
     return null;
   }
-
-  const isXml =
-    typeof metadata === 'string' &&
-    metadata.trim().startsWith('<') &&
-    metadata.trim().endsWith('>');
 
   return (
     <div
@@ -147,8 +179,12 @@ const MetadataModal = ({ metadata, onClose, t }) => {
             overflowY: 'auto',
           }}
         >
+          {/* The language- class goes on the <pre> as well as the <code>
+              because that is what prism.css themes, and it is what
+              Prism.highlightElement used to copy up from the <code> before
+              highlighting moved into the render above. */}
           <pre
-            className="whitespace-pre-wrap break-words"
+            className={`language-${language} whitespace-pre-wrap break-words`}
             style={{
               maxWidth: '100%',
               fontSize: '14px',
@@ -156,11 +192,10 @@ const MetadataModal = ({ metadata, onClose, t }) => {
               margin: 0,
             }}
           >
-            <code ref={codeRef} className={`language-${isXml ? 'xml' : 'json'}`}>
-              {typeof metadata === 'string'
-                ? metadata
-                : JSON.stringify(metadata || {}, null, 2)}
-            </code>
+            <code
+              className={`language-${language}`}
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
           </pre>
         </div>
       </div>

--- a/src/components/chatviewer/MetadataModal.js
+++ b/src/components/chatviewer/MetadataModal.js
@@ -24,6 +24,14 @@ const FOCUSABLE_SELECTOR =
 //
 // Safe against injection: Prism escapes & and < as it tokenizes, and the
 // no-grammar fallback escapes explicitly.
+//
+// TODO(follow-up, PR #1684 review): duplicates the exported escapeHtml in
+// src/utils/chatviewer/chatViewer.js (used by buildMetadataCellHtml for the
+// same underlying feature — the table's metadata cell). That one also escapes
+// quotes; this one deliberately doesn't need to since it only feeds text-node
+// content, not an HTML attribute — but the duplication risks silent
+// divergence if one gets tightened later and the other doesn't. Worth
+// consolidating into one shared helper.
 const escapeHtml = (text) =>
   text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 

--- a/src/components/chatviewer/__tests__/MetadataModal.test.js
+++ b/src/components/chatviewer/__tests__/MetadataModal.test.js
@@ -14,9 +14,9 @@ vi.mock('@gcds-core/components-react', () => ({
   }),
 }));
 
-vi.mock('prismjs', () => ({
-  default: { highlightElement: vi.fn() },
-}));
+// Prism is deliberately NOT mocked: the highlighted markup the component
+// renders is the markup a user actually gets, and the point of these tests is
+// that React owns that markup outright rather than letting Prism rewrite it.
 
 const t = (key) => key;
 // Stable reference across renders so tests isolate the onClose-identity
@@ -64,5 +64,52 @@ describe('MetadataModal', () => {
 
     expect(secondOnClose).toHaveBeenCalledTimes(1);
     expect(firstOnClose).not.toHaveBeenCalled();
+  });
+
+  it('re-renders highlighted content when metadata changes, without a DOM conflict', () => {
+    // The <code> body is written by Prism, not reconciled by React. Swapping
+    // metadata while the modal stays open is what would break if React
+    // reconciled children an external highlighter had already replaced.
+    const { rerender, container } = render(
+      <MetadataModal metadata={{ first: 'value' }} onClose={() => {}} t={t} />
+    );
+
+    const code = container.querySelector('code');
+    expect(code.textContent).toContain('first');
+
+    rerender(<MetadataModal metadata={{ second: 'other' }} onClose={() => {}} t={t} />);
+
+    const updated = container.querySelector('code');
+    expect(updated.textContent).toContain('second');
+    expect(updated.textContent).not.toContain('first');
+    // Prism ran: JSON keys are tokenized rather than left as bare text.
+    expect(updated.querySelector('.token')).toBeTruthy();
+  });
+
+  it('escapes markup in metadata rather than injecting it as HTML', () => {
+    const { container } = render(
+      <MetadataModal
+        metadata={{ note: '<img src=x onerror=alert(1)>' }}
+        onClose={() => {}}
+        t={t}
+      />
+    );
+
+    const code = container.querySelector('code');
+    expect(code.querySelector('img')).toBeNull();
+    expect(code.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('keeps the dialog free of extra focusable elements for the Tab trap', () => {
+    const { container } = render(
+      <MetadataModal metadata={{ foo: 'bar' }} onClose={() => {}} t={t} />
+    );
+
+    const dialog = container.querySelector('[role="dialog"]');
+    const focusable = dialog.querySelectorAll(
+      'button, gcds-button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    // Only the close button — highlighted content must not add tab stops.
+    expect(focusable).toHaveLength(1);
   });
 });

--- a/src/config/workflows.js
+++ b/src/config/workflows.js
@@ -19,3 +19,8 @@ export const AVAILABLE_MODELS = [
 
 export const WORKFLOW_VALUES = WORKFLOWS.map(w => w.value);
 export const MODEL_VALUES = AVAILABLE_MODELS.map(m => m.value);
+
+// Fallback used when the 'workflow.default' setting is missing or invalid.
+// Shared by the server-side resolver (api/chat/chat-graph-run.js), the Settings
+// page, and the chat Options dropdown so they can't drift apart.
+export const DEFAULT_WORKFLOW = 'GenericGraph';

--- a/src/hooks/chatviewer/useChatLogsTable.js
+++ b/src/hooks/chatviewer/useChatLogsTable.js
@@ -89,6 +89,14 @@ export function useChatLogsTable({
       pageLength: 50,
       language: { ...dataTableLanguage(lang), emptyTable: t('logging.noLogs') },
       drawCallback: function () {
+        // TODO(follow-up, PR #1684 review): document-scoped, so a logs-table
+        // redraw while MetadataModal is open also re-highlights the modal's
+        // own <code> block from outside React. MetadataModal's rewrite to
+        // dangerouslySetInnerHTML was specifically meant to make React the
+        // only writer of that markup — this doesn't corrupt it (Prism's
+        // re-tokenization of already-highlighted markup is idempotent), but it
+        // contradicts that invariant and does wasted work on every redraw.
+        // Scope with Prism.highlightAllUnder(tableRef.current) instead.
         Prism.highlightAll();
 
         $(tableRef.current).css({

--- a/src/hooks/chatviewer/useChatLogsTable.js
+++ b/src/hooks/chatviewer/useChatLogsTable.js
@@ -1,5 +1,10 @@
 import { useEffect, useRef } from 'react';
 import $ from 'jquery';
+// Registers $.fn.DataTable on the shared jQuery instance. Imported here rather
+// than relied on as a side effect of whichever other page happens to be in the
+// bundle — ChatViewer is the only consumer that drives DataTables through
+// jQuery directly, so nothing else guarantees the plugin is attached.
+import 'datatables.net-dt';
 import Prism from 'prismjs';
 import { buildMetadataCellHtml } from '../../utils/chatviewer/chatViewer.js';
 import { captureTableFocus, restoreTableFocus } from '../../utils/chatviewer/focusRestore.js';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -120,6 +120,7 @@
         "model": {
           "label": "Model family:"
         },
+        "useSystemSettings": "Use system settings",
         "referringUrl": {
           "label": "Referring Canada.ca URL (optional)"
         }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -120,6 +120,7 @@
         "model": {
           "label": "Famille de modèles :"
         },
+        "useSystemSettings": "Utiliser les paramètres système",
         "referringUrl": {
           "label": "URL de référence Canada.ca (facultatif)"
         }

--- a/src/pages/ChatViewer.js
+++ b/src/pages/ChatViewer.js
@@ -337,17 +337,31 @@ const ChatViewer = ({ lang = 'en' }) => {
                       its own localized empty state (see useChatLogsTable),
                       which keeps tableRef stable so focus can be captured
                       and restored across refreshes instead of being lost to
-                      <body> when this element used to get swapped out. */}
-                  <table ref={tableRef} className="display">
-                    <thead>
-                      <tr>
-                        <th>{t('logging.createdAt')}</th>
-                        <th>{t('logging.level')}</th>
-                        <th>{t('logging.message')}</th>
-                        <th>{t('logging.metadata')}</th>
-                      </tr>
-                    </thead>
-                  </table>
+                      <body> when this element used to get swapped out.
+
+                      The wrapper div is load-bearing: DataTables re-parents
+                      <table> into its own container element, so the table is
+                      no longer where React left it. Without this div, React
+                      would try to insert the conditional download button
+                      above using the table as its reference sibling and
+                      throw NotFoundError ("The node before which the new
+                      node is to be inserted is not a child of this node").
+                      Keeping a plain div here that React treats as a leaf —
+                      no conditional children, nothing rendered alongside the
+                      table — confines every DataTables DOM mutation inside a
+                      node React never has to reach past. */}
+                  <div>
+                    <table ref={tableRef} className="display">
+                      <thead>
+                        <tr>
+                          <th>{t('logging.createdAt')}</th>
+                          <th>{t('logging.level')}</th>
+                          <th>{t('logging.message')}</th>
+                          <th>{t('logging.metadata')}</th>
+                        </tr>
+                      </thead>
+                    </table>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -157,6 +157,14 @@ const SettingsPage = ({ lang = 'en' }) => {
     'redaction.manipulation.fr': '',
   });
 
+  // TODO(follow-up, pre-existing — not introduced by PR #1684, which only
+  // swapped the literal 'GenericGraph' for DEFAULT_WORKFLOW here): this
+  // mount-time load and the workflow dropdown's own save handler (below,
+  // around setDefaultWorkflow(v) / saveAndVerify('workflow.default', v)) both
+  // call setDefaultWorkflow with no sequencing between them. A slow initial
+  // GET that resolves after a save can revert the dropdown to the stale
+  // pre-save value. Scoped to the Settings page — tracked here for whoever
+  // picks up the separate settings-audit-history PR review, not this one.
   useEffect(() => {
     async function loadSettings() {
       const settings = await DataStoreService.getSettings(SETTINGS_LOAD_KEYS, SETTINGS_LOAD_DEFAULTS);

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { GcdsButton, GcdsContainer, GcdsDetails } from '@gcds-core/components-react';
 import DataStoreService from '../services/DataStoreService.js';
 import { useTranslations } from '../hooks/useTranslations.js';
-import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES } from '../config/workflows.js';
+import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES, DEFAULT_WORKFLOW } from '../config/workflows.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 
 const normalizeChatTransport = (value) => (
@@ -14,7 +14,7 @@ const SETTINGS_LOAD_DEFAULTS = {
   deploymentMode: 'CDS',
   vectorServiceType: 'imvectordb',
   'site.baseUrl': '',
-  'workflow.default': 'GenericGraph',
+  'workflow.default': DEFAULT_WORKFLOW,
   'model.default': 'openai-gpt51',
   'chat.transport': 'sse',
   'guardrail.indigenousLanguageBlocking': 'true',
@@ -70,7 +70,7 @@ const SettingsPage = ({ lang = 'en' }) => {
   const [savingBaseUrl, setSavingBaseUrl] = useState(false);
 
   // Global default workflow setting (Default | DefaultWithVector | DefaultWithVectorGraph)
-  const [defaultWorkflow, setDefaultWorkflow] = useState('GenericGraph');
+  const [defaultWorkflow, setDefaultWorkflow] = useState(DEFAULT_WORKFLOW);
   const [savingDefaultWorkflow, setSavingDefaultWorkflow] = useState(false);
 
   // Default model setting — decoupled from workflow so model upgrades are a Settings change
@@ -166,7 +166,7 @@ const SettingsPage = ({ lang = 'en' }) => {
       setBaseUrl(settings['site.baseUrl'] ?? '');
       const allowedWorkflows = WORKFLOW_VALUES;
       const defaultWorkflowSetting = settings['workflow.default'];
-      setDefaultWorkflow(allowedWorkflows.includes(defaultWorkflowSetting) ? defaultWorkflowSetting : 'GenericGraph');
+      setDefaultWorkflow(allowedWorkflows.includes(defaultWorkflowSetting) ? defaultWorkflowSetting : DEFAULT_WORKFLOW);
       setDefaultModel(settings['model.default'] || AVAILABLE_MODELS[0].value);
       setChatTransport(normalizeChatTransport(settings['chat.transport']));
       setIndigenousLanguageBlocking(String(settings['guardrail.indigenousLanguageBlocking'] ?? 'true'));
@@ -702,7 +702,7 @@ const SettingsPage = ({ lang = 'en' }) => {
               try {
                 const allowedWorkflows = WORKFLOW_VALUES;
                 const current = await saveAndVerify('workflow.default', v);
-                setDefaultWorkflow(allowedWorkflows.includes(current) ? current : 'GenericGraph');
+                setDefaultWorkflow(allowedWorkflows.includes(current) ? current : DEFAULT_WORKFLOW);
               } finally {
                 setSavingDefaultWorkflow(false);
               }

--- a/src/pages/UsersPage.js
+++ b/src/pages/UsersPage.js
@@ -299,9 +299,9 @@ const UsersPage = ({ lang }) => {
               };
             });
 
-            // Render Save and Delete buttons
+            // Render Save and Delete buttons. getCellRoot() clears any stale
+            // content and unmounts a prior root as needed.
             const actionsCell = row.querySelector('td:last-child');
-            actionsCell.innerHTML = '';
             // Render admin delete button (only admins should reach this page)
             getCellRoot(actionsCell).render(
               <GcdsButton

--- a/src/pages/UsersPage.js
+++ b/src/pages/UsersPage.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { createRoot } from 'react-dom/client';
 import DataTable from 'datatables.net-react';
 import 'datatables.net-dt/css/dataTables.dataTables.css';
 import DT from 'datatables.net-dt';
 import { GcdsButton, GcdsContainer, GcdsLink, GcdsText } from '@gcds-core/components-react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { dataTableLanguage } from '../utils/dataTableLanguage.js';
+import { getCellRoot } from '../utils/dataTableCellRoot.js';
 import UserService from '../services/UserService.js';
 import { useAuth } from '../contexts/AuthContext.js';
 import { usePageContext } from '../hooks/usePageParam.js';
@@ -302,9 +302,8 @@ const UsersPage = ({ lang }) => {
             // Render Save and Delete buttons
             const actionsCell = row.querySelector('td:last-child');
             actionsCell.innerHTML = '';
-            const root = createRoot(actionsCell);
             // Render admin delete button (only admins should reach this page)
-            root.render(
+            getCellRoot(actionsCell).render(
               <GcdsButton
                 size="small"
                 buttonRole="danger"

--- a/src/pages/__tests__/ChatViewer.dataTablesDom.test.js
+++ b/src/pages/__tests__/ChatViewer.dataTablesDom.test.js
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Guards the React <-> DataTables DOM ownership boundary in ChatViewer.
+ *
+ * DataTables re-parents the <table> into its own container element, so the
+ * table is no longer a child of the node React rendered it into. If React then
+ * has to insert a sibling *before* that table — which is exactly what happens
+ * when the download button appears once logs arrive — it calls
+ * parent.insertBefore(button, table) against a table that is no longer its
+ * child and throws NotFoundError, taking the whole page down.
+ *
+ * Real DataTables is used deliberately here rather than a mock: the re-parenting
+ * is the entire behaviour under test.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import ChatViewer from '../ChatViewer.js';
+import DataStoreService from '../../services/DataStoreService.js';
+
+vi.mock('../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({ t: (key) => key })
+}));
+
+vi.mock('../../services/DataStoreService.js', () => ({
+  default: { getLogs: vi.fn() }
+}));
+
+vi.mock('@gcds-core/components-react', () => ({
+  GcdsContainer: ({ children }) => <div>{children}</div>,
+  GcdsText: ({ children }) => <div>{children}</div>,
+  GcdsLink: ({ children, href }) => <a href={href}>{children}</a>,
+  GcdsButton: React.forwardRef(({ children, onClick, disabled, id }, ref) => (
+    <button ref={ref} id={id} onClick={onClick} disabled={disabled}>{children}</button>
+  ))
+}));
+
+const logEntry = (message) => ({
+  createdAt: '2026-08-12T10:00:00.000Z',
+  logLevel: 'info',
+  message,
+  metadata: { some: 'value' }
+});
+
+describe('ChatViewer - DataTables DOM ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('renders the download button once logs arrive without a DOM insert conflict', async () => {
+    DataStoreService.getLogs.mockResolvedValue({ logs: [logEntry('first'), logEntry('second')] });
+
+    render(<ChatViewer lang="en" />);
+
+    // Entering a chatId mounts the (still empty) table, which DataTables then
+    // wraps — this is the state that makes the next insert dangerous.
+    fireEvent.change(screen.getByLabelText('logging.enterChatId'), {
+      target: { value: 'chat-abc' }
+    });
+    await waitFor(() => expect(document.querySelector('table.display')).toBeTruthy());
+
+    expect(screen.queryByText('logging.download')).toBeNull();
+
+    // Logs arriving flips logs.length 0 -> 2, inserting the download button
+    // immediately before the re-parented table.
+    fireEvent.click(screen.getByText('logging.refresh'));
+
+    await waitFor(() => expect(screen.getByText('logging.download')).toBeTruthy());
+    expect(DataStoreService.getLogs).toHaveBeenCalledWith('chat-abc');
+  });
+
+  it('survives logs going back to empty and populating again', async () => {
+    DataStoreService.getLogs.mockResolvedValue({ logs: [logEntry('first')] });
+
+    render(<ChatViewer lang="en" />);
+
+    const input = screen.getByLabelText('logging.enterChatId');
+    fireEvent.change(input, { target: { value: 'chat-abc' } });
+    fireEvent.click(screen.getByText('logging.refresh'));
+    await waitFor(() => expect(screen.getByText('logging.download')).toBeTruthy());
+
+    // Switching chatId clears logs, removing the download button again.
+    fireEvent.change(input, { target: { value: 'chat-def' } });
+    await waitFor(() => expect(screen.queryByText('logging.download')).toBeNull());
+
+    fireEvent.click(screen.getByText('logging.refresh'));
+    await waitFor(() => expect(screen.getByText('logging.download')).toBeTruthy());
+  });
+});

--- a/src/utils/__tests__/dataTableCellRoot.test.js
+++ b/src/utils/__tests__/dataTableCellRoot.test.js
@@ -41,6 +41,44 @@ describe('getCellRoot', () => {
     expect(getCellRoot(undefined)).toBeNull();
   });
 
+  it('clears pre-existing non-React content (e.g. a DataTables placeholder) before the first mount', () => {
+    const cell = document.createElement('td');
+    cell.innerHTML = '<span>placeholder</span>';
+    document.body.appendChild(cell);
+
+    flush(() => getCellRoot(cell).render(<button>rendered</button>));
+
+    expect(cell.textContent).toBe('rendered');
+    expect(cell.querySelector('span')).toBeNull();
+  });
+
+  it('survives a caller clearing the cell before a later redraw finds an existing root', () => {
+    const cell = document.createElement('td');
+    document.body.appendChild(cell);
+
+    // React's commit-phase failures aren't synchronously catchable — a
+    // failed unmount is reported as an uncaught error via a window 'error'
+    // event, not thrown back through the call stack. try/catch around the
+    // call site can't detect this; only listening for the event can.
+    const onError = vi.fn();
+    window.addEventListener('error', onError);
+
+    flush(() => getCellRoot(cell).render(<button>first</button>));
+
+    // Regression scenario for the bug this test guards against: something
+    // (DataTables re-parenting, or a caller) clears the cell directly before
+    // the next redraw calls getCellRoot() again, instead of going through
+    // this module's own unmount path.
+    cell.innerHTML = '';
+
+    flush(() => getCellRoot(cell).render(<button>second</button>));
+
+    expect(cell.textContent).toBe('second');
+    expect(onError).not.toHaveBeenCalled();
+
+    window.removeEventListener('error', onError);
+  });
+
   it('survives a cell whose root was already unmounted elsewhere', () => {
     const cell = document.createElement('td');
     document.body.appendChild(cell);

--- a/src/utils/__tests__/dataTableCellRoot.test.js
+++ b/src/utils/__tests__/dataTableCellRoot.test.js
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { act } from '@testing-library/react';
+import { getCellRoot } from '../dataTableCellRoot.js';
+
+const flush = (fn) => act(() => { fn(); });
+
+describe('getCellRoot', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reuses one root per cell across repeated mounts', () => {
+    const cell = document.createElement('td');
+    document.body.appendChild(cell);
+
+    // React warns when createRoot is called twice on the same container, so a
+    // clean console is the assertion that the previous root was unmounted.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    flush(() => getCellRoot(cell).render(<button>first</button>));
+    expect(cell.textContent).toBe('first');
+
+    flush(() => getCellRoot(cell).render(<button>second</button>));
+    expect(cell.textContent).toBe('second');
+
+    flush(() => getCellRoot(cell).render(<button>third</button>));
+    expect(cell.textContent).toBe('third');
+
+    const containerWarnings = errorSpy.mock.calls.filter(([msg]) =>
+      typeof msg === 'string' && msg.includes('already been passed to createRoot')
+    );
+    expect(containerWarnings).toHaveLength(0);
+  });
+
+  it('returns null for a missing cell instead of throwing', () => {
+    expect(getCellRoot(null)).toBeNull();
+    expect(getCellRoot(undefined)).toBeNull();
+  });
+
+  it('survives a cell whose root was already unmounted elsewhere', () => {
+    const cell = document.createElement('td');
+    document.body.appendChild(cell);
+
+    const root = getCellRoot(cell);
+    flush(() => root.render(<button>first</button>));
+    flush(() => root.unmount());
+
+    // Should not throw on the double unmount inside getCellRoot.
+    flush(() => getCellRoot(cell).render(<button>second</button>));
+    expect(cell.textContent).toBe('second');
+  });
+});

--- a/src/utils/dataTableCellRoot.js
+++ b/src/utils/dataTableCellRoot.js
@@ -1,0 +1,34 @@
+import { createRoot } from 'react-dom/client';
+
+// DataTables builds its own <td> elements, so React content inside a cell has
+// to be mounted as a separate React root. DataTables re-runs createdRow for a
+// row on every draw (sort, page, filter, data refresh), which means the same
+// cell gets mounted repeatedly — and calling createRoot on a container that
+// already has a root leaks the previous one and makes React warn ("You are
+// calling createRoot() on a container that has already been passed to
+// createRoot()"). Going through here keeps one live root per cell: the
+// previous one is unmounted before a new one replaces it.
+//
+// Callers render into the returned root themselves, because which element a
+// cell shows is usually decided by branching after the root exists.
+const ROOT_KEY = '_dataTableCellRoot';
+
+export function getCellRoot(cell) {
+  if (!cell) {
+    return null;
+  }
+
+  if (cell[ROOT_KEY]) {
+    try {
+      cell[ROOT_KEY].unmount();
+    } catch (e) {
+      // A root can already be gone if DataTables discarded the cell; nothing
+      // left to clean up in that case.
+    }
+    cell[ROOT_KEY] = null;
+  }
+
+  const root = createRoot(cell);
+  cell[ROOT_KEY] = root;
+  return root;
+}

--- a/src/utils/dataTableCellRoot.js
+++ b/src/utils/dataTableCellRoot.js
@@ -9,6 +9,18 @@ import { createRoot } from 'react-dom/client';
 // createRoot()"). Going through here keeps one live root per cell: the
 // previous one is unmounted before a new one replaces it.
 //
+// The root is mounted on a wrapper <div> this function creates inside the
+// cell, not on the cell itself. That's deliberate: if a caller (or some other
+// code) clears the cell's contents directly (e.g. `cell.innerHTML = ''`)
+// before the next redraw, that only detaches the wrapper from the cell — the
+// wrapper keeps its own children, since clearing a node's innerHTML doesn't
+// touch the parent/child relationships within the subtree it removes. So
+// unmount() below, which operates relative to the wrapper, still finds the
+// nodes it expects and succeeds instead of throwing "the node to be removed
+// is not a child of this node". Mounting straight on the cell doesn't have
+// that property — DataTables (or a caller) clearing the cell removes the
+// exact nodes the root's fiber tree expects to still be there.
+//
 // Callers render into the returned root themselves, because which element a
 // cell shows is usually decided by branching after the root exists.
 const ROOT_KEY = '_dataTableCellRoot';
@@ -18,9 +30,10 @@ export function getCellRoot(cell) {
     return null;
   }
 
-  if (cell[ROOT_KEY]) {
+  const prior = cell[ROOT_KEY];
+  if (prior) {
     try {
-      cell[ROOT_KEY].unmount();
+      prior.unmount();
     } catch (e) {
       // A root can already be gone if DataTables discarded the cell; nothing
       // left to clean up in that case.
@@ -28,7 +41,16 @@ export function getCellRoot(cell) {
     cell[ROOT_KEY] = null;
   }
 
-  const root = createRoot(cell);
+  // Always rebuild the cell around a fresh wrapper. This is unconditional
+  // (not just "when there was no prior root") because the prior root's
+  // wrapper may already be detached from the cell by the time we get here —
+  // unmount() above cleaned it up regardless, so nothing of the old content
+  // is left behind either way.
+  cell.innerHTML = '';
+  const wrapper = document.createElement('div');
+  cell.appendChild(wrapper);
+
+  const root = createRoot(wrapper);
   cell[ROOT_KEY] = root;
   return root;
 }


### PR DESCRIPTION
# Summary | Résumé

Bug 1: https://github.com/cds-snc/ai-answers/issues/1681

Test reproduces the bug (3 fail before the fix, all pass after). Model selection in Options does NOT persist like Workflow does, this fix makes them behave the same. Both dropdowns now read the live Settings value when there's no local override, and both persist an explicit admin choice the same way; referring URL stays session-only as designed.

Bug 2: https://github.com/cds-snc/ai-answers/issues/1673 Full trace no longer works in Admin
Introduced by 2305be0a "fix: remove pause controls, fix chat log focus/announcement bugs" (Jennifer Mealing, 2026-08-10), shipped in v1.183.0. That commit changed:

{logs.length > 0 ? ( <div className="p-4"> …button… <table/> </div> ) : <p>no logs</p>}
to
<div className="p-4"> {logs.length > 0 && ( …button… )} <table/> </div>

The change itself was correct and deliberate — keeping the table permanently mounted is what lets focus be captured and restored across refreshes (an a11y fix, documented in useChatLogsTable.js:39-48). But it turned the table into a stable node that React must now insert siblings around, which is precisely what it can no longer do once DataTables has moved it. Before that commit the button and table always appeared and disappeared together, so React never needed the table as an insertion reference.

