### PR TITLE
Referring URL repairs for better dept selection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "eslint.nodeEnv": "development",
     "chat.tools.terminal.autoApprove": {
         "git checkout": true,
         "git add": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,12 +53,17 @@ So, when changing anything that builds an agent's messages or payload:
   certainly consumed by a prompt, not by JS. Grep the prompt files for the tag first.
 - **Carry every tag through a refactor.** When moving or rewriting message-building code,
   diff the old and new versions for tags and payload fields before you finish.
-- Keep the two paths in sync: `services/ContextAgentService.js` (context agent) and
-  `agents/graphs/workflows/GraphWorkflowHelper.js` (`deriveContext` and
-  `sendAnswerRequest`). These are where tags get attached.
+- Build every tag with the shared helpers in `api/util/prompt-tags.js` rather than
+  inlining the string. Two paths attach `<referring-url>`:
+  `services/ContextAgentService.js` (context agent) and
+  `GraphWorkflowHelper.sendAnswerRequest` (answer agent). A value can also be lost one
+  step earlier by not being *forwarded* — `GraphWorkflowHelper.deriveContext` passes
+  `referringUrl` into the context payload but builds no tag itself; both links have to
+  hold.
 - Cover the tag with a test asserting it appears in the outgoing message — see
-  `services/__tests__/ContextAgentService.test.js`. This is the only thing that turns a
-  silent regression into a loud one.
+  `services/__tests__/ContextAgentService.test.js` and the `sendAnswerRequest` block in
+  `agents/graphs/workflows/__tests__/GraphWorkflowHelper.test.js`. This is the only thing
+  that turns a silent regression into a loud one.
 
 Worked example: `<referring-url>` was passed to the context agent by the old
 `services/ContextService.js`, then lost in the migration to the graph/helper architecture.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,35 @@ So unless your task is **explicitly** prompt tuning directed by a maintainer:
 This applies to all coding work — bug fixes, refactors, new features,
 dashboards — not just prompt-adjacent areas.
 
+## Never drop a prompt tag that code has to inject
+
+Prompts refer to tags — `<referring-url>`, `<output-lang>`, `<searchResults>`,
+`<final-turn>` — that **code** has to inject into the messages sent to the model. The
+prompt names the tag; the message-building code supplies it. If code stops supplying one,
+**nothing fails**: no error, no thrown exception, no red test. The model simply never sees
+the tag, every instruction referencing it goes dead, and answers quietly get worse. This
+is the hardest class of bug to notice in this codebase.
+
+So, when changing anything that builds an agent's messages or payload:
+
+- **Never remove a field from a message/payload because it looks unused.** It is almost
+  certainly consumed by a prompt, not by JS. Grep the prompt files for the tag first.
+- **Carry every tag through a refactor.** When moving or rewriting message-building code,
+  diff the old and new versions for tags and payload fields before you finish.
+- Keep the two paths in sync: `services/ContextAgentService.js` (context agent) and
+  `agents/graphs/workflows/GraphWorkflowHelper.js` (`deriveContext` and
+  `sendAnswerRequest`). These are where tags get attached.
+- Cover the tag with a test asserting it appears in the outgoing message — see
+  `services/__tests__/ContextAgentService.test.js`. This is the only thing that turns a
+  silent regression into a loud one.
+
+Worked example: `<referring-url>` was passed to the context agent by the old
+`services/ContextService.js`, then lost in the migration to the graph/helper architecture.
+`contextSystemPrompt.js` kept telling the model to prioritize `<referring-url>` over
+`<searchResults>` — but the tag was never in the input, so the instruction did nothing and
+the agent matched departments off search results alone. It went unnoticed for months
+because no test and no error covered it.
+
 ## How to work well in this codebase
 
 1. **State assumptions early.** Before implementing anything non-trivial, say what you're assuming so we can catch misalignment before code is written.

--- a/agents/graphs/__tests__/DefaultWithLocalModel.test.js
+++ b/agents/graphs/__tests__/DefaultWithLocalModel.test.js
@@ -18,7 +18,7 @@ describe('DefaultWithLocalModel workflow', () => {
     vi.clearAllMocks();
     helper.processRedaction.mockResolvedValue({ redactedText: 'redacted' });
     helper.translateQuestion.mockResolvedValue({ translatedText: 'translated', originalLanguage: 'en' });
-    helper.deriveContext.mockResolvedValue({ topic: 'topic', department: 'dept' });
+    helper.deriveContext.mockResolvedValue({ department: 'dept' });
     helper.sendAnswerRequest.mockResolvedValue({ answerType: 'normal', content: 'generated', citationUrl: 'https://example.com' });
     helper.verifyCitation.mockResolvedValue({ url: 'https://example.com' });
     vi.spyOn(graphRequestContext, 'getStore').mockReturnValue({ user: { userId: 'user' } });

--- a/agents/graphs/services/__tests__/contextService.test.js
+++ b/agents/graphs/services/__tests__/contextService.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseContextMessage } from '../contextService.js';
+
+// The search tools pull in gaxios, which fails to load under vitest (it require()s the
+// ESM-only uuid package). Stub them with factories so the real modules are never imported.
+vi.mock('../../../tools/googleContextSearch.js', () => ({ contextSearch: vi.fn() }));
+vi.mock('../../../tools/canadaCaContextSearch.js', () => ({ contextSearch: vi.fn() }));
+vi.mock('../../../../services/ServerLoggingService.js');
+
+const parse = (message) => parseContextMessage({ message, searchResults: '' });
+
+describe('parseContextMessage', () => {
+  it('extracts department and departmentUrl from a match', () => {
+    const parsed = parse(`<analysis>
+<department>PrairiesCan</department>
+<departmentUrl>https://www.canada.ca/en/prairies-economic-development.html</departmentUrl>
+</analysis>`);
+
+    expect(parsed.department).toBe('PrairiesCan');
+    expect(parsed.departmentUrl).toBe(
+      'https://www.canada.ca/en/prairies-economic-development.html'
+    );
+  });
+
+  // contextSystemPrompt.js tells the agent to return empty tags when nothing matches
+  // (see the "recipe ideas" example in its <examples> block).
+  it('returns empty strings for the prompt\'s documented no-match response', () => {
+    const parsed = parse(`<analysis>
+<department></department>
+<departmentUrl></departmentUrl>
+</analysis>`);
+
+    expect(parsed.department).toBe('');
+    expect(parsed.departmentUrl).toBe('');
+  });
+
+  // A missing tag means the same thing as an empty one: no department. It must not
+  // become null, which interpolates into the answer prompt as the string "null".
+  it.each([
+    ['an empty response', ''],
+    ['a response with no tags at all', 'No messages available'],
+    ['a malformed response', '<analysis>garbled'],
+  ])('returns empty strings, never null, for %s', (_label, message) => {
+    const parsed = parse(message);
+
+    expect(parsed.department).toBe('');
+    expect(parsed.departmentUrl).toBe('');
+    expect(parsed.department).not.toBeNull();
+    expect(parsed.departmentUrl).not.toBeNull();
+  });
+});

--- a/agents/graphs/services/__tests__/contextService.test.js
+++ b/agents/graphs/services/__tests__/contextService.test.js
@@ -1,11 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { parseContextMessage } from '../contextService.js';
-
-// The search tools pull in gaxios, which fails to load under vitest (it require()s the
-// ESM-only uuid package). Stub them with factories so the real modules are never imported.
-vi.mock('../../../tools/googleContextSearch.js', () => ({ contextSearch: vi.fn() }));
-vi.mock('../../../tools/canadaCaContextSearch.js', () => ({ contextSearch: vi.fn() }));
-vi.mock('../../../../services/ServerLoggingService.js');
 
 const parse = (message) => parseContextMessage({ message, searchResults: '' });
 

--- a/agents/graphs/services/contextService.js
+++ b/agents/graphs/services/contextService.js
@@ -1,32 +1,3 @@
-import { AgentOrchestratorService } from '../../../agents/AgentOrchestratorService.js';
-import { createQueryRewriteAgent } from '../../../agents/AgentFactory.js';
-import { queryRewriteStrategy } from '../../../agents/strategies/queryRewriteStrategy.js';
-import { contextSearch as canadaContextSearch } from '../../../agents/tools/canadaCaContextSearch.js';
-import { contextSearch as googleContextSearch } from '../../../agents/tools/googleContextSearch.js';
-import { invokeContextAgent } from '../../../services/ContextAgentService.js';
-import loadContextSystemPrompt from '../../prompts/contextSystemPrompt.js';
-import ServerLoggingService from '../../../services/ServerLoggingService.js';
-
-async function exponentialBackoff(fn, retries = 5, initialDelay = 500) {
-  for (let i = 0; i < retries; i++) {
-    try {
-      return await fn();
-    } catch (error) {
-      await ServerLoggingService.error('Context search attempt failed', 'system', error);
-      if (i < retries - 1) {
-        const delay = initialDelay * Math.pow(2, i);
-        await new Promise(resolve => setTimeout(resolve, delay));
-      } else {
-        throw error;
-      }
-    }
-  }
-}
-
-function determineOutputLang(translationData) {
-  return translationData?.originalLanguage || 'eng';
-}
-
 export function parseContextMessage(context) {
   const departmentMatch = context.message.match(/<department>([\s\S]*?)<\/department>/);
   const departmentUrlMatch = context.message.match(/<departmentUrl>([\s\S]*?)<\/departmentUrl>/);
@@ -43,64 +14,5 @@ export function parseContextMessage(context) {
     model: context.model,
     inputTokens: context.inputTokens,
     outputTokens: context.outputTokens,
-  };
-}
-
-async function performSearch(query, lang, searchService = 'canadaca', chatId = 'system') {
-  const searchFn = searchService?.toLowerCase() === 'google' ? googleContextSearch : canadaContextSearch;
-  return exponentialBackoff(() => searchFn(query, lang), 5, 500);
-}
-
-export async function deriveContext({
-  agentType,
-  translatedQuestion,
-  pageLang = 'en',
-  department = '',
-  referringUrl = '',
-  searchProvider = 'canadaca',
-  conversationHistory = [],
-  chatId = 'system',
-  translationData = null,
-}) {
-  await ServerLoggingService.info('ContextService: deriving context', chatId, { searchProvider, pageLang });
-
-  const rewrite = await AgentOrchestratorService.invokeWithStrategy({
-    chatId,
-    agentType,
-    request: { translationData, referringUrl, pageLanguage: pageLang },
-    createAgentFn: createQueryRewriteAgent,
-    strategy: queryRewriteStrategy,
-  });
-
-  const searchQuery = rewrite?.query || translatedQuestion;
-  const langForSearch = pageLang.toLowerCase().includes('fr') ? 'fr' : 'en';
-  const searchResults = await performSearch(searchQuery, langForSearch, searchProvider, chatId);
-
-  const systemPrompt = rewrite?.systemPrompt || await loadContextSystemPrompt(pageLang);
-  const contextResponse = await invokeContextAgent(agentType, {
-    chatId,
-    message: translatedQuestion,
-    systemPrompt,
-    searchResults,
-    conversationHistory,
-    referringUrl,
-  });
-
-  const parsed = parseContextMessage({
-    message: contextResponse?.message || '',
-    searchResults,
-    searchProvider,
-    model: contextResponse?.model,
-    inputTokens: contextResponse?.inputTokens,
-    outputTokens: contextResponse?.outputTokens,
-  });
-
-  return {
-    ...parsed,
-    query: searchQuery,
-    translatedQuestion,
-    lang: pageLang,
-    outputLang: determineOutputLang(translationData),
-    originalLang: translationData?.originalLanguage || pageLang,
   };
 }

--- a/agents/graphs/services/contextService.js
+++ b/agents/graphs/services/contextService.js
@@ -83,6 +83,7 @@ export async function deriveContext({
     systemPrompt,
     searchResults,
     conversationHistory,
+    referringUrl,
   });
 
   const parsed = parseContextMessage({

--- a/agents/graphs/services/contextService.js
+++ b/agents/graphs/services/contextService.js
@@ -28,14 +28,10 @@ function determineOutputLang(translationData) {
 }
 
 export function parseContextMessage(context) {
-  const topicMatch = context.message.match(/<topic>([\s\S]*?)<\/topic>/);
-  const topicUrlMatch = context.message.match(/<topicUrl>([\s\S]*?)<\/topicUrl>/);
   const departmentMatch = context.message.match(/<department>([\s\S]*?)<\/department>/);
   const departmentUrlMatch = context.message.match(/<departmentUrl>([\s\S]*?)<\/departmentUrl>/);
 
   return {
-    topic: topicMatch ? topicMatch[1] : null,
-    topicUrl: topicUrlMatch ? topicUrlMatch[1] : null,
     department: departmentMatch ? departmentMatch[1] : null,
     departmentUrl: departmentUrlMatch ? departmentUrlMatch[1] : null,
     searchResults: context.searchResults,

--- a/agents/graphs/services/contextService.js
+++ b/agents/graphs/services/contextService.js
@@ -31,9 +31,13 @@ export function parseContextMessage(context) {
   const departmentMatch = context.message.match(/<department>([\s\S]*?)<\/department>/);
   const departmentUrlMatch = context.message.match(/<departmentUrl>([\s\S]*?)<\/departmentUrl>/);
 
+  // The context prompt's response format returns empty tags (<department></department>)
+  // when nothing matches, so a missing tag means the same thing: no department. Return ''
+  // rather than null — null gets interpolated into the answer prompt as the literal
+  // string "null", which reads as a department actually named "null".
   return {
-    department: departmentMatch ? departmentMatch[1] : null,
-    departmentUrl: departmentUrlMatch ? departmentUrlMatch[1] : null,
+    department: departmentMatch ? departmentMatch[1] : '',
+    departmentUrl: departmentUrlMatch ? departmentUrlMatch[1] : '',
     searchResults: context.searchResults,
     searchProvider: context.searchProvider,
     model: context.model,

--- a/agents/graphs/workflows/GraphWorkflowHelper.js
+++ b/agents/graphs/workflows/GraphWorkflowHelper.js
@@ -347,8 +347,6 @@ export class GraphWorkflowHelper {
       conversationHistory,
       lang,
       department: context.department,
-      topic: context.topic,
-      topicUrl: context.topicUrl,
       departmentUrl: context.departmentUrl,
       searchResults: context.searchResults || [],
       scenarioOverrideText: context.systemPrompt || '',

--- a/agents/graphs/workflows/GraphWorkflowHelper.js
+++ b/agents/graphs/workflows/GraphWorkflowHelper.js
@@ -116,6 +116,7 @@ export class GraphWorkflowHelper {
       searchResults: searchResult.results || searchResult.searchResults || [],
       provider: selectedAI,
       language: lang,
+      referringUrl,
     };
 
     // Invoke Context Agent via Service directly

--- a/agents/graphs/workflows/GraphWorkflowHelper.js
+++ b/agents/graphs/workflows/GraphWorkflowHelper.js
@@ -20,6 +20,7 @@ import { UrlValidationService } from '../../../services/UrlValidationService.js'
 import { InteractionPersistenceService } from '../../../services/InteractionPersistenceService.js';
 import { invokeContextAgent } from '../../../services/ContextAgentService.js';
 import { exponentialBackoff } from '../../../api/util/backoff.js';
+import { referringUrlTag } from '../../../api/util/prompt-tags.js';
 
 export class GraphWorkflowHelper {
   async validateShortQuery(conversationHistory, userMessage, lang, department) {
@@ -333,7 +334,7 @@ export class GraphWorkflowHelper {
     const outputLangToken = normalizeOutputLang(context.outputLang || context.originalLang || lang);
     const header = `\n<output-lang>${outputLangToken}</output-lang>`;
     let message = `${baseMessage}${header}`;
-    message = `${message}${referringUrl && String(referringUrl).trim() ? `\n<referring-url>${String(referringUrl).trim()}</referring-url>` : ''}`;
+    message = `${message}${referringUrlTag(referringUrl)}`;
 
     const maxTurns = 3;
     const currentTurn = (conversationHistory || []).length + 1;

--- a/agents/graphs/workflows/__tests__/GraphWorkflowHelper.test.js
+++ b/agents/graphs/workflows/__tests__/GraphWorkflowHelper.test.js
@@ -4,10 +4,12 @@ import { GraphWorkflowHelper } from '../GraphWorkflowHelper.js';
 import { SearchContextService } from '../../../../services/SearchContextService.js';
 import { invokeContextAgent } from '../../../../services/ContextAgentService.js';
 import { InteractionPersistenceService } from '../../../../services/InteractionPersistenceService.js';
+import { AnswerGenerationService } from '../../../../services/AnswerGenerationService.js';
 
 vi.mock('../../../../services/SearchContextService.js');
 vi.mock('../../../../services/ContextAgentService.js');
 vi.mock('../../../../services/InteractionPersistenceService.js');
+vi.mock('../../../../services/AnswerGenerationService.js');
 vi.mock('../../../../services/ServerLoggingService.js');
 
 // The search tools pull in gaxios, which fails to load under vitest (it require()s the
@@ -35,7 +37,7 @@ describe('GraphWorkflowHelper', () => {
             SearchContextService.search.mockResolvedValue(mockSearchResult);
 
             invokeContextAgent.mockResolvedValue({
-                message: '<topic>test topic</topic>',
+                message: '<department>EDSC-ESDC</department>',
                 model: 'gpt-4',
                 inputTokens: 10,
                 outputTokens: 10,
@@ -88,6 +90,71 @@ describe('GraphWorkflowHelper', () => {
                 'openai',
                 expect.objectContaining({ referringUrl })
             );
+        });
+    });
+
+    // The answer agent's prompts (agenticBase.js, safety.js, citationInstructions.js) all
+    // reference tags that only this method injects. Nothing throws if one goes missing, so
+    // these assertions are the only thing standing between a refactor and a silent
+    // regression. See "Never drop a prompt tag that code has to inject" in AGENTS.md.
+    describe('sendAnswerRequest', () => {
+        const sendWith = (overrides = {}) => {
+            AnswerGenerationService.generateAnswer.mockResolvedValue({ content: 'an answer' });
+            return helper.sendAnswerRequest({
+                selectedAI: 'openai',
+                conversationHistory: [],
+                lang: 'en',
+                context: { translatedQuestion: 'How do I apply?', outputLang: 'eng' },
+                chatId: 'test-chat-id',
+                ...overrides,
+            });
+        };
+
+        const sentMessage = () => AnswerGenerationService.generateAnswer.mock.calls[0][0].message;
+
+        it('appends a <referring-url> tag to the outgoing message', async () => {
+            const referringUrl = 'https://www.canada.ca/en/services/benefits.html';
+
+            await sendWith({ referringUrl });
+
+            expect(sentMessage()).toContain(`<referring-url>${referringUrl}</referring-url>`);
+        });
+
+        it('trims surrounding whitespace from the referring URL', async () => {
+            await sendWith({ referringUrl: '  https://www.canada.ca/en.html\n' });
+
+            expect(sentMessage()).toContain(
+                '<referring-url>https://www.canada.ca/en.html</referring-url>'
+            );
+        });
+
+        it.each([
+            ['undefined', undefined],
+            ['an empty string', ''],
+            ['whitespace only', '   '],
+        ])('emits no <referring-url> tag when the URL is %s', async (_label, referringUrl) => {
+            await sendWith({ referringUrl });
+
+            expect(sentMessage()).not.toContain('<referring-url>');
+        });
+
+        it('always sends an <output-lang> tag', async () => {
+            await sendWith({ referringUrl: 'https://www.canada.ca/en.html' });
+
+            expect(sentMessage()).toContain('<output-lang>eng</output-lang>');
+        });
+
+        it('sends <final-turn> once the user reaches the last allowed turn', async () => {
+            // maxTurns is 3, and currentTurn counts this question on top of the history
+            await sendWith({ conversationHistory: [{}, {}] });
+
+            expect(sentMessage()).toContain('<final-turn>true</final-turn>');
+        });
+
+        it('does not send <final-turn> on earlier turns', async () => {
+            await sendWith({ conversationHistory: [] });
+
+            expect(sentMessage()).not.toContain('<final-turn>');
         });
     });
 });

--- a/agents/graphs/workflows/__tests__/GraphWorkflowHelper.test.js
+++ b/agents/graphs/workflows/__tests__/GraphWorkflowHelper.test.js
@@ -10,6 +10,11 @@ vi.mock('../../../../services/ContextAgentService.js');
 vi.mock('../../../../services/InteractionPersistenceService.js');
 vi.mock('../../../../services/ServerLoggingService.js');
 
+// The search tools pull in gaxios, which fails to load under vitest (it require()s the
+// ESM-only uuid package). Stub them with factories so the real modules are never imported.
+vi.mock('../../../tools/googleContextSearch.js', () => ({ contextSearch: vi.fn() }));
+vi.mock('../../../tools/canadaCaContextSearch.js', () => ({ contextSearch: vi.fn() }));
+
 describe('GraphWorkflowHelper', () => {
     let helper;
 
@@ -49,6 +54,40 @@ describe('GraphWorkflowHelper', () => {
             });
 
             expect(context).toHaveProperty('searchQuery', 'test query');
+        });
+
+        it('should forward referringUrl to the context agent', async () => {
+            SearchContextService.search.mockResolvedValue({
+                results: 'some results',
+                query: 'test query',
+            });
+
+            invokeContextAgent.mockResolvedValue({
+                message: '<department>PrairiesCan</department>',
+                model: 'gpt-4',
+                inputTokens: 10,
+                outputTokens: 10,
+            });
+
+            const referringUrl =
+                'https://test.canada.ca/experimental/en/aia/prairies-economic-development.html';
+
+            await helper.deriveContext({
+                selectedAI: 'openai',
+                translationData: {},
+                lang: 'en',
+                department: 'dept',
+                referringUrl,
+                searchProvider: 'google',
+                conversationHistory: [],
+                chatId: 'test-chat-id',
+                userMessage: 'test question',
+            });
+
+            expect(invokeContextAgent).toHaveBeenCalledWith(
+                'openai',
+                expect.objectContaining({ referringUrl })
+            );
         });
     });
 });

--- a/agents/prompts/contextSystemPrompt.js
+++ b/agents/prompts/contextSystemPrompt.js
@@ -42,9 +42,11 @@ ${departmentsString}
 1. Extract key topics and entities from the user's question and context
 - <searchResults> contains Title/Link/Summary entries from a search query run before your turn. Use them as supporting signal.
 - Prioritize your analysis of the question and <referring-url> (url of page user was on when they launched AI Answers) over <searchResults> as search results can be unreliable
-- <referring-url> often identifies the department or topic. Very occasionally it may betray a misunderstanding. For example, the user was on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through the CRA account. 
+- <referring-url> often identifies the department or topic with some exceptions: 
+1. Occasionally <referring-url> may betray a misunderstanding. E.g. user was on MSCA sign in page but question is how to sign in to get their Notice of Assessment, which is done through CRA account (department would be CRA-ARC). Or the user is on a jobs or tax page for Canada but is asking about immigrating or work permits (department would be IRCC)
+2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the question and search-results should be prioritized. Eg. user is asking about calling for CPP help on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC)
 
-2. Compare and select an organization from <departments_list> or from the list of CEO-BEC cross-department canada.ca pages below
+2. Compare and select the best matching organization from <departments_list>: 
 - You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above
 - You MUST output BOTH the department abbreviation AND the matching URL from the same entry
 - You CANNOT use program names, service names, or benefit names as department codes unless they are listed in the <departments_list>

--- a/agents/prompts/contextSystemPrompt.js
+++ b/agents/prompts/contextSystemPrompt.js
@@ -44,7 +44,7 @@ ${departmentsString}
 - Prioritize your analysis of the question and <referring-url> (url of page user was on when they launched AI Answers) over <searchResults> as search results can be unreliable
 - <referring-url> often identifies the department or topic with some exceptions: 
 1. Occasionally <referring-url> may betray a misunderstanding. E.g. user was on MSCA sign in page but question is how to sign in to get their Notice of Assessment, which is done through CRA account (department would be CRA-ARC). Or the user is on a jobs or tax page for Canada but is asking about immigrating or work permits (department would be IRCC)
-2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the question and search-results should be prioritized. Eg. user is asking about calling for CPP help on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC)
+2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the key topics and entities should be prioritized. Eg. user is asking about calling for CPP or EI on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC) etc.
 
 2. Compare and select the best matching organization from <departments_list>: 
 - You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above
@@ -54,11 +54,13 @@ ${departmentsString}
 
 3a. If multiple organizations could be responsible, select the one that most likely directly administers and delivers web content for the program/service.
 
-3b. If the question doesn't mention a specific service/dept (e.g., CPP, EI, passport, MSCA, CRA account) AND is about one of these cross-department services → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
+3b. If the question doesn't mention a specific service/dept/program or benefit (e.g., CPP, EI, passport, MSCA, CRA account, immigration) AND is about or on one of these cross-department services managed by CEO-BEC → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
       - Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
       - All Government of Canada contacts: https://www.canada.ca/en/contact.html or fr: https://www.canada.ca/fr/contact.html
       - All Government of Canada departments and agencies: https://www.canada.ca/en/government/dept.html or fr: https://www.canada.ca/fr/gouvernement/min.html
       - All Government of Canada services: https://www.canada.ca/en/services.html or fr: https://www.canada.ca/fr/services.html
+      - Home page: https://www.canada.ca/en.html https://www.canada.ca/fr.html
+      - Sign in to Government of Canada online accounts: https://www.canada.ca/en/government/sign-in-online-account.html or fr: https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne.html
       - This AI Answers service for Canada.ca, Canada.ca design guidance for pages, alerts, AI help applications, Canada.ca blog posts (e.g. AI trust study,AI Answers trial results), top pages, analytics https://www.canada.ca/en/government/about-canada-ca.html or fr: https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html
 
 3c. If steps 3a and 3b produce no match but <referring-url> is a Government of Canada page whose administering organization could plausibly own the question's topic, select that organization's Bilingual Abbr Key and URL from <departments_list>. Prefer this over returning empty values.

--- a/agents/prompts/contextSystemPrompt.js
+++ b/agents/prompts/contextSystemPrompt.js
@@ -41,8 +41,8 @@ ${departmentsString}
 ## Matching Algorithm:
 1. Extract key topics and entities from the user's question and context
 - <searchResults> contains Title/Link/Summary entries from a search query run before your turn. Use them as supporting signal.
-- Prioritize your analysis of the question and <referring-url>  (the page the user was on when they launched AI Answers) over <searchResults>
-- <referring-url> often helps identify the department or topic. It occasionally may betray a misunderstanding. For example, the user was on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through the CRA account. 
+- Prioritize your analysis of the question and <referring-url> (url of page user was on when they launched AI Answers) over <searchResults> as search results can be unreliable
+- <referring-url> often identifies the department or topic. Very occasionally it may betray a misunderstanding. For example, the user was on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through the CRA account. 
 
 2. Compare and select an organization from <departments_list> or from the list of CEO-BEC cross-department canada.ca pages below
 - You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above

--- a/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-scenarios.js
+++ b/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-scenarios.js
@@ -32,9 +32,10 @@ export const DND_MDN_SCENARIOS = `
     - https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-1-administration.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-1-administration.html
     - https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-2-disciplinary.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-2-discipline.html
     - https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-3-financial.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-3-finances.html
-<   -https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-4-appendices.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-4-appendices.html
+    - https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-4-appendices.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-4-appendices.html
 * Cadet https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders-canadian-cadet-organizations.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux-cadets-canada.html
 * CAFRD https://www.canada.ca/en/department-national-defence/corporate/policies-standards/relocation-directive/cafrd.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/directives-reinstallation/drfac.html
+
 ## Defence organizations
 * CAF/FAC https://www.canada.ca/en/services/defence/caf.html https://www.canada.ca/fr/services/defense/fac.html
 * Defence construction Canada, crown corporation https://www.dcc-cdc.gc.ca/ https://www.cdc-dcc.gc.ca/

--- a/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-scenarios.js
+++ b/agents/prompts/scenarios/context-dnd-mdn/dnd-mdn-scenarios.js
@@ -34,7 +34,7 @@ export const DND_MDN_SCENARIOS = `
     - https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-3-financial.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-3-finances.html
 <   -https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders/vol-4-appendices.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux/vol-4-appendices.html
 * Cadet https://www.canada.ca/en/department-national-defence/corporate/policies-standards/queens-regulations-orders-canadian-cadet-organizations.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/ordonnances-reglements-royaux-cadets-canada.html
-
+* CAFRD https://www.canada.ca/en/department-national-defence/corporate/policies-standards/relocation-directive/cafrd.html https://www.canada.ca/fr/ministere-defense-nationale/organisation/politiques-normes/directives-reinstallation/drfac.html
 ## Defence organizations
 * CAF/FAC https://www.canada.ca/en/services/defence/caf.html https://www.canada.ca/fr/services/defense/fac.html
 * Defence construction Canada, crown corporation https://www.dcc-cdc.gc.ca/ https://www.cdc-dcc.gc.ca/

--- a/agents/prompts/scenarios/context-tc/tc-scenarios.js
+++ b/agents/prompts/scenarios/context-tc/tc-scenarios.js
@@ -23,4 +23,6 @@ export const TC_SCENARIOS = `
 * Importing a vehicle https://tc.canada.ca/en/road-transportation/importing-vehicle https://tc.canada.ca/fr/transport-routier/importer-vehicule
 * Rail Grade crossings https://tc.canada.ca/en/rail-transportation/grade-crossings https://tc.canada.ca/fr/transport-ferroviaire/passages-niveau
 * Railway Operating Certificates, noise and vibration requirements, work/rest and medical rules, accounting, rates. https://tc.canada.ca/en/rail-transportation/operating-federal-railway https://tc.canada.ca/fr/transport-ferroviaire/exploitation-chemin-fer-federal
+* Pleasure craft operator card (PCOC) https://tc.canada.ca/en/marine-transportation/preparing-operate-your-vessel/pleasure-craft-operator-card-pcoc https://tc.canada.ca/fr/transport-maritime/se-preparer-utiliser-son-embarcation/carte-conducteur-embarcation-plaisance-ccep
+* Navigation and marine conditions https://tc.canada.ca/en/marine-transportation/navigation-marine-conditions https://tc.canada.ca/fr/transport-maritime/navigation-conditions-maritimes
 `;

--- a/agents/prompts/systemPrompt.js
+++ b/agents/prompts/systemPrompt.js
@@ -7,7 +7,7 @@ import ServerLoggingService from '../../services/ServerLoggingService.js';
 
 export async function buildAnswerSystemPrompt(language = 'en', options = {}) {
   try {
-    const { department = '', departmentUrl = '', topic = '', topicUrl = '', searchResults = '', scenarioOverrideText = '', similarQuestions = '' } = options || {};
+    const { department = '', departmentUrl = '', searchResults = '', scenarioOverrideText = '', similarQuestions = '' } = options || {};
 
     const isFr = String(language || '').toLowerCase().startsWith('fr');
 
@@ -50,7 +50,7 @@ export async function buildAnswerSystemPrompt(language = 'en', options = {}) {
       : "<page-language>en</page-language>";
 
     // add context from contextService call into system prompt (preserve formatting)
-    const contextPrompt = `\n    <department>${department}</department>\n    <topic>${topic}</topic>\n    <topic-url>${topicUrl}</topic-url>\n    <department-url>${departmentUrl}</department-url>\n    <searchResults>\n${searchResults}\n</searchResults>\n    `;
+    const contextPrompt = `\n    <department>${department}</department>\n    <department-url>${departmentUrl}</department-url>\n    <searchResults>\n${searchResults}\n</searchResults>\n    `;
 
     const fullPrompt = `\n      ${ROLE}\n\n      
     ## Current date\n      <current-date>${currentDate}</current-date>

--- a/agents/prompts/systemPrompt.js
+++ b/agents/prompts/systemPrompt.js
@@ -50,7 +50,7 @@ export async function buildAnswerSystemPrompt(language = 'en', options = {}) {
       : "<page-language>en</page-language>";
 
     // add context from contextService call into system prompt (preserve formatting)
-    const contextPrompt = `\n    Department: ${department}\n    Topic: ${topic}\n    Topic URL: ${topicUrl}\n    Department URL: ${departmentUrl}\n    Search Results: ${searchResults}\n    `;
+    const contextPrompt = `\n    <department>${department}</department>\n    <topic>${topic}</topic>\n    <topic-url>${topicUrl}</topic-url>\n    <department-url>${departmentUrl}</department-url>\n    <searchResults>\n${searchResults}\n</searchResults>\n    `;
 
     const fullPrompt = `\n      ${ROLE}\n\n      
     ## Current date\n      <current-date>${currentDate}</current-date>

--- a/api/util/prompt-tags.js
+++ b/api/util/prompt-tags.js
@@ -1,0 +1,26 @@
+/**
+ * Builders for the tags that code has to inject into an agent's user message.
+ *
+ * The prompts name these tags and instruct the model to rely on them, but nothing in the
+ * prompt can supply them — code must. When a refactor drops one, nothing throws and no
+ * test fails; the model just stops receiving it. `<referring-url>` was lost that way once
+ * already. Keeping one builder shared by every path that sends a tag makes "keep them in
+ * sync" structural instead of aspirational. See "Never drop a prompt tag that code has to
+ * inject" in AGENTS.md.
+ */
+
+/**
+ * Build the `<referring-url>` tag for the page the user launched AI Answers from.
+ *
+ * Sent by both the context agent (services/ContextAgentService.js) and the answer agent
+ * (GraphWorkflowHelper.sendAnswerRequest). Returns '' when there is no usable URL — the
+ * prompts treat an absent tag as "no referring page", so callers concatenate directly
+ * rather than emitting an empty tag.
+ *
+ * @param {string} referringUrl
+ * @returns {string} '\n<referring-url>…</referring-url>', or '' when there is nothing to send
+ */
+export function referringUrlTag(referringUrl) {
+  const trimmed = String(referringUrl || '').trim();
+  return trimmed ? `\n<referring-url>${trimmed}</referring-url>` : '';
+}

--- a/docs/agents-prompts/system-prompt-documentation.md
+++ b/docs/agents-prompts/system-prompt-documentation.md
@@ -1,7 +1,7 @@
 # AI Answers System Prompt Documentation
 ## DefaultWorkflow Pipeline
 
-**Generated:** 2026-08-05
+**Generated:** 2026-08-13
 **Language:** en
 **Example Department:** EDSC-ESDC
 
@@ -499,10 +499,10 @@ Question: "How do I apply for EI?"
 Output Language: eng
 Referring URL: https://www.canada.ca/en.html
 Context (from Step 1):
-  Department: EDSC-ESDC
-  Topic: Employment and Social Development
-  Department URL: https://www.canada.ca/en/employment-social-development.html
-  Search Results: [Example results]
+  <department>EDSC-ESDC</department>
+  <topic>Employment and Social Development</topic>
+  <department-url>https://www.canada.ca/en/employment-social-development.html</department-url>
+  <searchResults>[Example results]</searchResults>
 ```
 
 ### Answer System Prompt:
@@ -617,18 +617,20 @@ CRITICAL: Before answering Qs on deadlines, dates, or time-sensitive events:
 
 
 ## Current date
-Today is Wednesday, August 5, 2026.
+Today is Thursday, August 13, 2026.
 
 ## Official language context:
 <page-language>English</page-language>
 
 ## Tagged context for question from previous AI service
 
-Department: EDSC-ESDC
-Topic: Employment and Social Development
-Topic URL: https://www.canada.ca/en/services/benefits.html
-Department URL: https://www.canada.ca/en/employment-social-development.html
-Search Results: [Example search results would appear here]
+<department>EDSC-ESDC</department>
+<topic>Employment and Social Development</topic>
+<topic-url>https://www.canada.ca/en/services/benefits.html</topic-url>
+<department-url>https://www.canada.ca/en/employment-social-development.html</department-url>
+<searchResults>
+[Example search results would appear here]
+</searchResults>
 
 
 

--- a/docs/agents-prompts/system-prompt-documentation.md
+++ b/docs/agents-prompts/system-prompt-documentation.md
@@ -1,7 +1,7 @@
 # AI Answers System Prompt Documentation
 ## DefaultWorkflow Pipeline
 
-**Generated:** 2026-08-13
+**Generated:** 2026-08-14
 **Language:** en
 **Example Department:** EDSC-ESDC
 
@@ -313,69 +313,79 @@ Page Language: en
 ```
 
       ## Role
-      You are a department matching expert for the AI Answers application on Canada.ca. Your role is to match user questions to departments listed in the departments_list section below, following a specific matching algorithm. This will help narrow in to the department most likely to hold the answer to the user's question.
+      You are a department matching agent for the AI Answers service on Canada.ca. Your role is to match user questions and their context to departments listed in the departments_list section below, following a specific matching algorithm. This will help narrow in to the department most likely to hold the answer to the user's question.
 
-      <page-language>English</page-language>
-        User asked their question on the official English AI Answers page>
+      <page-language>en</page-language>
+        User asked their question on the official English AI Answers page
 
 <departments_list>
 ## List of Government of Canada departments, agencies, organizations, and partnerships
 
-**Note:** The complete department list is dynamically loaded from departments_EN.js and departments_FR.js at runtime and contains 221 entries. Each entry shows:
-• Organization name
-• Unilingual Abbr: Language-specific abbreviation (may be null)
-• Bilingual Abbr Key: The ONLY valid value to use in your response (unique identifier)
-• URL: The corresponding URL (must match the selected organization)
-</departments_list>
+**Note:** The complete department list is dynamically loaded from departments_EN.js and departments_FR.js at runtime and contains 221 entries. Each entry is one line:
+`Bilingual Abbr Key | Organization Name | URL`
+- Bilingual Abbr Key: The ONLY valid value to use in your response (unique identifier)
+- URL: The corresponding URL (must match the selected organization)
+</departments_list> 
 
 ## Matching Algorithm:
 1. Extract key topics and entities from the user's question and context
-- Prioritize your analysis of the question and context, including referring-url (the page the user was on when they asked the question) over the <searchResults>
-- <referring-url> often identifies the department in a segment but occasionally may betray a misunderstanding. For example, the user may be on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through their CRA account.
+- <searchResults> contains Title/Link/Summary entries from a search query run before your turn. Use them as supporting signal.
+- Prioritize your analysis of the question and <referring-url> (url of page user was on when they launched AI Answers) over <searchResults> as search results can be unreliable
+- <referring-url> often identifies the department or topic with some exceptions: 
+1. Occasionally <referring-url> may betray a misunderstanding. E.g. user was on MSCA sign in page but question is how to sign in to get their Notice of Assessment, which is done through CRA account (department would be CRA-ARC). Or the user is on a jobs or tax page for Canada but is asking about immigrating or work permits (department would be IRCC)
+2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the question and search-results should be prioritized. Eg. user is asking about calling for CPP help on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC)
 
-2. Compare and select an organization from <departments_list> or from the list of CDS-SNC cross-department canada.ca pages below
+2. Compare and select the best matching organization from <departments_list>: 
 - You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above
 - You MUST output BOTH the department abbreviation AND the matching URL from the same entry
 - You CANNOT use program names, service names, or benefit names as department codes unless they are listed in the <departments_list>
 - Examples of INVALID responses: "PASSPORT" (program name,not in the list), "CRA" or "ESDC" (unilingual abbreviations)
 
-4. If multiple organizations could be responsible:
-   - Select the organization that most likely directly administers and delivers web content for the program/service
-   - OR if no organization is mentioned or fits the criteria, and the question is about one of the cross-department services below, set the bilingual abbreviation key to CDS-SNC and select one of these cross-department canada.ca urls as the departmentUrl in the matching page-language (CDS-SNC is responsible for these cross-department services):
+3a. If multiple organizations could be responsible, select the one that most likely directly administers and delivers web content for the program/service.
+
+3b. If the question doesn't mention a specific service/dept (e.g., CPP, EI, passport, MSCA, CRA account) AND is about one of these cross-department services → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
       - Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
-      - GCKey help/Aide pour GCKey: https://www.canada.ca/en/government/sign-in-online-account/gckey.html or fr: https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne/clegc.html
-      - Response to US tariffs: https://international.canada.ca/en/global-affairs/campaigns/canada-us-engagement or fr: https://international.canada.ca/fr/affaires-mondiales/campagnes/engagement-canada-etats-unis
       - All Government of Canada contacts: https://www.canada.ca/en/contact.html or fr: https://www.canada.ca/fr/contact.html
       - All Government of Canada departments and agencies: https://www.canada.ca/en/government/dept.html or fr: https://www.canada.ca/fr/gouvernement/min.html
-      - All Government of Canada services (updated April 2025): https://www.canada.ca/en/services.html or fr: https://www.canada.ca/fr/services.html
+      - All Government of Canada services: https://www.canada.ca/en/services.html or fr: https://www.canada.ca/fr/services.html
+      - This AI Answers service for Canada.ca, Canada.ca design guidance for pages, alerts, AI help applications, Canada.ca blog posts (e.g. AI trust study,AI Answers trial results), top pages, analytics https://www.canada.ca/en/government/about-canada-ca.html or fr: https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html
 
-5. If no clear organization match exists and no cross-department canada.ca url is relevant, return empty values for both department and departmentUrl
+3c. If steps 3a and 3b produce no match but <referring-url> is a Government of Canada page whose administering organization could plausibly own the question's topic, select that organization's Bilingual Abbr Key and URL from <departments_list>. Prefer this over returning empty values.
 
-## Examples of Program-to-Department Mapping:
-- Canada Pension Plan (CPP), OAS, Disability pension, EI, Canadian Dental Care Plan → EDSC-ESDC (administering department)
-- Canada Child Benefit → CRA-ARC (administering department)
-- Job Bank, Apprenticeships, Student Loans→ EDSC-ESDC (administering department)
-- Weather Forecasts → ECCC (administering department)
-- My Service Canada Account (MSCA) → EDSC-ESDC (administering department)
-- Visa, ETA, entry to Canada, immigration, refugees, citizenship → IRCC (administering department)
-- Canadian passports → IRCC (administering department)
-- Ontario Trillium Benefit → CRA-ARC (administering department)
-- Canadian Armed Forces Pensions → PSPC-SPAC (administering department)
-- Veterans benefits → VAC-ACC (administering department)
-- Public service group insurance health,dental and disability benefit plans → TBS-SCT (administering department)
-- Public service collective agreements → TBS-SCT (administering department)
-- Public service pay system → PSPC-SPAC (administering department)
-- Public service jobs, language requirements, tests, applications and GC Jobs → PSC-CFP (administering department)
-- International students study permits and visas → IRCC (administering department)
+4. Return empty values for department and departmentUrl ONLY as a last resort — when steps 2, 3a, 3b, and 3c all yield no match (e.g., the question is clearly off-topic for the Government of Canada, such as recipes or general trivia, and <referring-url> offers no plausible org).
+
+## Examples of Program to Administering Department Mapping:
+- Canada Pension Plan (CPP), OAS, Disability pension, EI, Canadian Dental Care Plan → EDSC-ESDC
+- Payroll deductions for tax, CPP, EI → CRA-ARC
+- Canada Child Benefit, Groceries and Essentials Benefit→ CRA-ARC
+- Job Bank, Apprenticeships, Student Loans→ EDSC-ESDC  
+- Weather Forecasts → ECCC  
+- My Service Canada Account (MSCA) → EDSC-ESDC  
+- Visa, ETA, entry/visit Canada, work/study permits,immigrate, refugees, citizenship → IRCC  
+- Canadian passports → IRCC  
+- Ontario Trillium Benefit → CRA-ARC  
+- Canadian Armed Forces Pensions → PSPC-SPAC  
+- Veterans benefits → VAC-ACC  
+- Public service group insurance health,dental and disability benefit plans → TBS-SCT  
+- Public service collective agreements, early retirement incentives, pension, work force adjustment → TBS-SCT  
+- Public service pay system → PSPC-SPAC  
+- Public service jobs, language requirements, tests, applications and GC Jobs → PSC-CFP  
+- International students study permits and visas → IRCC  
 - International students find schools and apply for scholarships on Educanada → EDU (separate official website administered by GAC-AMC)
 - Travel advice and travel advisories for Canadians travelling abroad → GAC-AMC (on GAC's travel.gc.ca site)
-- Collection and assessment of duties and import taxes, CARM (GRCA in French) → CBSA-ASFC (administering department)
-- Find a member of Parliament →  HOC-CDC (administering department)
-- Find permits and licences to start or grow a business → BIZPAL-PERLE (federal/provincial/territorial/municipal partnership administered by ISED-ISDE)
-- Access to Information requests (ATIP), AIPRP (Accès à l'information et protection des renseignements personnels) → TBS-SCT (administering department)
+- Collection and assessment of duties and import taxes, import-export program account (RM number), CARM (GRCA in French) → CBSA-ASFC  
+- Find a member of Parliament →  HOC-CDC  
+- Find permits & licences to start or grow a business → BIZPAL-PERLE (federal/provincial/territorial/municipal partnership administered by ISED-ISDE)
+- Find funding, insurance, licensing for agriculture and agri-food businesses → AGPAL (federal/provincial/territorial partnership administered by AAFC-AAC)
+- Access to Information requests (ATIP), AIPRP (Accès à l'information et protection des renseignements personnels) → TBS-SCT  
 - Summaries of completed ATIP requests, mandatory reports and other datasets on open.canada.ca  → TBS-SCT (administering department for open.canada.ca)
-- Questions about the AI Answers product itself (how it works, its features, feedback, technical issues, bug reports) → CDS-SNC (product owner)
-- Questions about Budget 2025 or 'the budget', even if asking about topics in the budget related to other departments → FIN (Finance Canada is the administering dept)
+- Budget or 'the budget', even if asking about topics in the budget related to other departments → FIN (Finance Canada is the administering dept)
+- EI report in French is déclaration de l'assurance emploi (AE) → EDSC-ESDC  
+- "CanadaLogin" digital credentials program, GC Issue and Verify, GC Forms, GC Notify → CDS-SNC
+- AI Answers - this service (how you work, models,features, languages, feedback, technical issues, bug or 404 reports) → CEO-BEC (service owner)
+- Canadian business seeking to export, build partnerships → TCS-SDC (trade commissioners help Canadians)
+- International business seeking help to sell into Canada → ISED-ISDE (has importers database)
+- Find a tariff → TARIFF-TARIF (joint initiative BDC,EDC & TCS)
 
 ## Response Format:
 <analysis>
@@ -394,7 +404,7 @@ Page Language: en
 </example>
 
 <example>
-* A question about recipe ideas doesn't match any government departments:
+* A question about recipe ideas doesn't match any government department's mandate:
 <analysis>
 <department></department>
 <departmentUrl></departmentUrl>
@@ -402,7 +412,7 @@ Page Language: en
 </example>
 
 <example>
-* A question about taxes (asked on the English page) would match CRA-ARC:
+* A question about taxes (asked on an English page) would match CRA-ARC:
 <analysis>
 <department>CRA-ARC</department>
 <departmentUrl>https://www.canada.ca/en/revenue-agency.html</departmentUrl>
@@ -410,17 +420,34 @@ Page Language: en
 </example>
 
 <example>
-* A question about employment benefits (asked on the French page) would match EDSC-ESDC:
+* A question in French on the French page about déclaration when <referring-url> contains AE would match EDSC-ESDC:
 <analysis>
 <department>EDSC-ESDC</department>
 <departmentUrl>https://www.canada.ca/fr/emploi-developpement-social.html</departmentUrl>
 </analysis>
 </example>
+
+<example>
+* A question in French on the French page about déclaration when <referring-url> contains impot would match CRA-ARC:
+<analysis>
+<department>CRA-ARC</department>
+<departmentUrl>https://www.canada.ca/fr/agence-revenu.html</departmentUrl>
+</analysis>
+</example>
+
 <example>
 * A question about dental coverage asked on an english public service, government or TBS page would match TBS-SCT:
 <analysis>
 <department>TBS-SCT</department>
 <departmentUrl>https://www.canada.ca/en/treasury-board-secretariat.html</departmentUrl>
+</analysis>
+</example>
+
+<example>
+* A question about release process asked on an english military transition page with search results that include Treasury Board results would match DND-MDN, not TBS-SCT, because question and referring-url take priority over search results, military topic aligns with question:
+<analysis>
+<department>DND-MDN</department>
+<departmentUrl>https://www.canada.ca/en/department-national-defence.html</departmentUrl>
 </analysis>
 </example>
 </examples>

--- a/docs/agents-prompts/system-prompt-documentation.md
+++ b/docs/agents-prompts/system-prompt-documentation.md
@@ -299,7 +299,7 @@ Rules:
 - Provide search context for answer generation
 
 **Service:** ContextService.deriveContext()
-**File:** src/services/contextSystemPrompt.js
+**File:** agents/prompts/contextSystemPrompt.js
 
 ### Example User Input:
 ```
@@ -333,7 +333,7 @@ Page Language: en
 - Prioritize your analysis of the question and <referring-url> (url of page user was on when they launched AI Answers) over <searchResults> as search results can be unreliable
 - <referring-url> often identifies the department or topic with some exceptions: 
 1. Occasionally <referring-url> may betray a misunderstanding. E.g. user was on MSCA sign in page but question is how to sign in to get their Notice of Assessment, which is done through CRA account (department would be CRA-ARC). Or the user is on a jobs or tax page for Canada but is asking about immigrating or work permits (department would be IRCC)
-2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the question and search-results should be prioritized. Eg. user is asking about calling for CPP help on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC)
+2. <referring-url> is a top-level canada.ca page managed by CEO-BEC (e.g. home,all services, contact, sign-in etc) that is a cross-dept page - your analysis of the key topics and entities should be prioritized. Eg. user is asking about calling for CPP or EI on the contact page (department is ESDC, not CEO-BEC) or citizenship on the sign-in page (IRCC not CEO-BEC) etc.
 
 2. Compare and select the best matching organization from <departments_list>: 
 - You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above
@@ -343,11 +343,13 @@ Page Language: en
 
 3a. If multiple organizations could be responsible, select the one that most likely directly administers and delivers web content for the program/service.
 
-3b. If the question doesn't mention a specific service/dept (e.g., CPP, EI, passport, MSCA, CRA account) AND is about one of these cross-department services → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
+3b. If the question doesn't mention a specific service/dept/program or benefit (e.g., CPP, EI, passport, MSCA, CRA account, immigration) AND is about or on one of these cross-department services managed by CEO-BEC → set department to CEO-BEC (Canada.ca Experience Office) and select URL matching <page-language>:
       - Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
       - All Government of Canada contacts: https://www.canada.ca/en/contact.html or fr: https://www.canada.ca/fr/contact.html
       - All Government of Canada departments and agencies: https://www.canada.ca/en/government/dept.html or fr: https://www.canada.ca/fr/gouvernement/min.html
       - All Government of Canada services: https://www.canada.ca/en/services.html or fr: https://www.canada.ca/fr/services.html
+      - Home page: https://www.canada.ca/en.html https://www.canada.ca/fr.html
+      - Sign in to Government of Canada online accounts: https://www.canada.ca/en/government/sign-in-online-account.html or fr: https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne.html
       - This AI Answers service for Canada.ca, Canada.ca design guidance for pages, alerts, AI help applications, Canada.ca blog posts (e.g. AI trust study,AI Answers trial results), top pages, analytics https://www.canada.ca/en/government/about-canada-ca.html or fr: https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html
 
 3c. If steps 3a and 3b produce no match but <referring-url> is a Government of Canada page whose administering organization could plausibly own the question's topic, select that organization's Bilingual Abbr Key and URL from <departments_list>. Prefer this over returning empty values.
@@ -1065,7 +1067,7 @@ User submits question
 - `src/services/ChatWorkflowService.js` - Workflow service helpers
 - `src/services/ContextService.js` - Context/department matching
 - `src/services/AnswerService.js` - Answer generation
-- `src/services/contextSystemPrompt.js` - Context prompt builder
+- `agents/prompts/contextSystemPrompt.js` - Context prompt builder
 - `src/services/systemPrompt.js` - Answer prompt builder
 - `src/services/systemPrompt/agenticBase.js` - Core workflow instructions
 - `src/services/systemPrompt/scenarios-all.js` - General scenarios

--- a/docs/agents-prompts/system-prompt-documentation.md
+++ b/docs/agents-prompts/system-prompt-documentation.md
@@ -432,8 +432,6 @@ Page Language: en
 <analysis>
 <department>EDSC-ESDC</department>
 <departmentUrl>https://www.canada.ca/en/employment-social-development.html</departmentUrl>
-<topic>Employment and Social Development</topic>
-<topicUrl>https://www.canada.ca/en/services/benefits.html</topicUrl>
 </analysis>
 ```
 
@@ -500,7 +498,6 @@ Output Language: eng
 Referring URL: https://www.canada.ca/en.html
 Context (from Step 1):
   <department>EDSC-ESDC</department>
-  <topic>Employment and Social Development</topic>
   <department-url>https://www.canada.ca/en/employment-social-development.html</department-url>
   <searchResults>[Example results]</searchResults>
 ```
@@ -625,8 +622,6 @@ Today is Thursday, August 13, 2026.
 ## Tagged context for question from previous AI service
 
 <department>EDSC-ESDC</department>
-<topic>Employment and Social Development</topic>
-<topic-url>https://www.canada.ca/en/services/benefits.html</topic-url>
 <department-url>https://www.canada.ca/en/employment-social-development.html</department-url>
 <searchResults>
 [Example search results would appear here]

--- a/scripts/generate-system-prompt-documentation.js
+++ b/scripts/generate-system-prompt-documentation.js
@@ -232,12 +232,15 @@ You are an AI assistant named "AI Answers" located on a Canada.ca page. You spec
     day: 'numeric',
   });
 
+  // Keep in sync with the contextPrompt built in agents/prompts/systemPrompt.js
   const contextPrompt = `
-Department: ${contextData.department}
-Topic: ${contextData.topic}
-Topic URL: ${contextData.topicUrl}
-Department URL: ${contextData.departmentUrl}
-Search Results: ${contextData.searchResults}
+<department>${contextData.department}</department>
+<topic>${contextData.topic}</topic>
+<topic-url>${contextData.topicUrl}</topic-url>
+<department-url>${contextData.departmentUrl}</department-url>
+<searchResults>
+${contextData.searchResults}
+</searchResults>
 `;
 
   return `${ROLE}
@@ -523,10 +526,10 @@ Question: "How do I apply for EI?"
 Output Language: ${lang === 'fr' ? 'fra' : 'eng'}
 Referring URL: https://www.canada.ca/en.html
 Context (from Step 1):
-  Department: ${department}
-  Topic: ${exampleContext.topic}
-  Department URL: ${exampleContext.departmentUrl}
-  Search Results: [Example results]
+  <department>${department}</department>
+  <topic>${exampleContext.topic}</topic>
+  <department-url>${exampleContext.departmentUrl}</department-url>
+  <searchResults>[Example results]</searchResults>
 \`\`\`
 
 ### Answer System Prompt:

--- a/scripts/generate-system-prompt-documentation.js
+++ b/scripts/generate-system-prompt-documentation.js
@@ -235,8 +235,6 @@ You are an AI assistant named "AI Answers" located on a Canada.ca page. You spec
   // Keep in sync with the contextPrompt built in agents/prompts/systemPrompt.js
   const contextPrompt = `
 <department>${contextData.department}</department>
-<topic>${contextData.topic}</topic>
-<topic-url>${contextData.topicUrl}</topic-url>
 <department-url>${contextData.departmentUrl}</department-url>
 <searchResults>
 ${contextData.searchResults}
@@ -292,8 +290,8 @@ async function generateDocumentation() {
   // Example context data (would normally come from ContextService)
   const exampleContext = {
     department: department,
-    topic: department === 'EDSC-ESDC' ? 'Employment and Social Development' : 'Taxes and Income',
-    topicUrl: department === 'EDSC-ESDC'
+    // Sample URL used only to illustrate a citation in the example answer below.
+    citationUrl: department === 'EDSC-ESDC'
       ? 'https://www.canada.ca/en/services/benefits.html'
       : 'https://www.canada.ca/en/services/taxes.html',
     departmentUrl: department === 'EDSC-ESDC'
@@ -478,8 +476,6 @@ ${contextPrompt}
 <analysis>
 <department>${department}</department>
 <departmentUrl>${exampleContext.departmentUrl}</departmentUrl>
-<topic>${exampleContext.topic}</topic>
-<topicUrl>${exampleContext.topicUrl}</topicUrl>
 </analysis>
 \`\`\`
 
@@ -527,7 +523,6 @@ Output Language: ${lang === 'fr' ? 'fra' : 'eng'}
 Referring URL: https://www.canada.ca/en.html
 Context (from Step 1):
   <department>${department}</department>
-  <topic>${exampleContext.topic}</topic>
   <department-url>${exampleContext.departmentUrl}</department-url>
   <searchResults>[Example results]</searchResults>
 \`\`\`
@@ -548,7 +543,7 @@ ${answerPrompt}
 - <department-url>${exampleContext.departmentUrl}</department-url>
 - <is-gc>yes</is-gc>
 - <is-pt-muni>no</is-pt-muni>
-- <possible-citations>${exampleContext.topicUrl}</possible-citations>
+- <possible-citations>${exampleContext.citationUrl}</possible-citations>
 </preliminary-checks>
 
 <english-answer>

--- a/scripts/generate-system-prompt-documentation.js
+++ b/scripts/generate-system-prompt-documentation.js
@@ -23,6 +23,7 @@ import { departments_FR } from '../agents/prompts/scenarios/departments_FR.js';
 import { PROMPT as PII_PROMPT } from '../agents/prompts/piiAgentPrompt.js';
 import { PROMPT as TRANSLATION_PROMPT } from '../agents/prompts/translationPrompt.js';
 import { PROMPT as QUERY_REWRITE_PROMPT } from '../agents/prompts/queryRewriteAgentPrompt.js';
+import loadContextSystemPrompt from '../agents/prompts/contextSystemPrompt.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -83,136 +84,6 @@ function getDepartmentDisplayName(contextCode) {
   return nameMap[contextCode] || contextCode;
 }
 
-/**
- * Build context system prompt directly without database dependencies
- * This replicates the logic from contextSystemPrompt.js but without ServerLoggingService
- */
-function buildContextSystemPrompt(language = 'en') {
-  const departmentsList = language === 'fr' ? departments_FR : departments_EN;
-  const departmentsString = departmentsList
-    .map((dept) => `• ${dept.name}\n  Unilingual Abbr: ${dept.abbr || 'None'}\n  Bilingual Abbr Key: ${dept.abbrKey}\n  URL: ${dept.url}`)
-    .join('\n\n');
-
-  return `
-      ## Role
-      You are a department matching expert for the AI Answers application on Canada.ca. Your role is to match user questions to departments listed in the departments_list section below, following a specific matching algorithm. This will help narrow in to the department most likely to hold the answer to the user's question.
-
-      ${
-        language === 'fr'
-          ? `<page-language>French</page-language>\n        User asked their question on the official French AI Answers page`
-          : `<page-language>English</page-language>\n        User asked their question on the official English AI Answers page>`
-      }
-
-<departments_list>
-## List of Government of Canada departments, agencies, organizations, and partnerships
-This list contains ALL valid options. You MUST select ONLY from the "Bilingual Abbr Key" and URL values shown below.
-Each entry shows:
-• Organization name
-• Unilingual Abbr: Language-specific abbreviation (may be null)
-• Bilingual Abbr Key: The ONLY valid value to use in your response (unique identifier)
-• URL: The corresponding URL (must match the selected organization)
-
-${departmentsString}
-</departments_list>
-
-## Matching Algorithm:
-1. Extract key topics and entities from the user's question and context
-- Prioritize your analysis of the question and context, including referring-url (the page the user was on when they asked the question) over the <searchResults>
-- <referring-url> often identifies the department in a segment but occasionally may betray a misunderstanding. For example, the user may be on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through their CRA account.
-
-2. Compare and select an organization from <departments_list> or from the list of CDS-SNC cross-department canada.ca pages below
-- You MUST ONLY use the exact "Bilingual Abbr Key" values from the departments_list above
-- You MUST output BOTH the department abbreviation AND the matching URL from the same entry
-- You CANNOT use program names, service names, or benefit names as department codes unless they are listed in the <departments_list>
-- Examples of INVALID responses: "PASSPORT" (program name,not in the list), "CRA" or "ESDC" (unilingual abbreviations)
-
-4. If multiple organizations could be responsible:
-   - Select the organization that most likely directly administers and delivers web content for the program/service
-   - OR if no organization is mentioned or fits the criteria, and the question is about one of the cross-department services below, set the bilingual abbreviation key to CDS-SNC and select one of these cross-department canada.ca urls as the departmentUrl in the matching page-language (CDS-SNC is responsible for these cross-department services):
-      - Change of address/Changement d'adresse: https://www.canada.ca/en/government/change-address.html or fr: https://www.canada.ca/fr/gouvernement/changement-adresse.html
-      - GCKey help/Aide pour GCKey: https://www.canada.ca/en/government/sign-in-online-account/gckey.html or fr: https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne/clegc.html
-      - Response to US tariffs: https://international.canada.ca/en/global-affairs/campaigns/canada-us-engagement or fr: https://international.canada.ca/fr/affaires-mondiales/campagnes/engagement-canada-etats-unis
-      - All Government of Canada contacts: https://www.canada.ca/en/contact.html or fr: https://www.canada.ca/fr/contact.html
-      - All Government of Canada departments and agencies: https://www.canada.ca/en/government/dept.html or fr: https://www.canada.ca/fr/gouvernement/min.html
-      - All Government of Canada services (updated April 2025): https://www.canada.ca/en/services.html or fr: https://www.canada.ca/fr/services.html
-
-5. If no clear organization match exists and no cross-department canada.ca url is relevant, return empty values for both department and departmentUrl
-
-## Examples of Program-to-Department Mapping:
-- Canada Pension Plan (CPP), OAS, Disability pension, EI, Canadian Dental Care Plan → EDSC-ESDC (administering department)
-- Canada Child Benefit → CRA-ARC (administering department)
-- Job Bank, Apprenticeships, Student Loans→ EDSC-ESDC (administering department)
-- Weather Forecasts → ECCC (administering department)
-- My Service Canada Account (MSCA) → EDSC-ESDC (administering department)
-- Visa, ETA, entry to Canada, immigration, refugees, citizenship → IRCC (administering department)
-- Canadian passports → IRCC (administering department)
-- Ontario Trillium Benefit → CRA-ARC (administering department)
-- Canadian Armed Forces Pensions → PSPC-SPAC (administering department)
-- Veterans benefits → VAC-ACC (administering department)
-- Public service group insurance health,dental and disability benefit plans → TBS-SCT (administering department)
-- Public service collective agreements → TBS-SCT (administering department)
-- Public service pay system → PSPC-SPAC (administering department)
-- Public service jobs, language requirements, tests, applications and GC Jobs → PSC-CFP (administering department)
-- International students study permits and visas → IRCC (administering department)
-- International students find schools and apply for scholarships on Educanada → EDU (separate official website administered by GAC-AMC)
-- Travel advice and travel advisories for Canadians travelling abroad → GAC-AMC (on GAC's travel.gc.ca site)
-- Collection and assessment of duties and import taxes, CARM (GRCA in French) → CBSA-ASFC (administering department)
-- Find a member of Parliament →  HOC-CDC (administering department)
-- Find permits and licences to start or grow a business → BIZPAL-PERLE (federal/provincial/territorial/municipal partnership administered by ISED-ISDE)
-- Access to Information requests (ATIP), AIPRP (Accès à l'information et protection des renseignements personnels) → TBS-SCT (administering department)
-- Summaries of completed ATIP requests, mandatory reports and other datasets on open.canada.ca  → TBS-SCT (administering department for open.canada.ca)
-- Questions about the AI Answers product itself (how it works, its features, feedback, technical issues, bug reports) → CDS-SNC (product owner)
-- Questions about Budget 2025 or 'the budget', even if asking about topics in the budget related to other departments → FIN (Finance Canada is the administering dept)
-
-## Response Format:
-<analysis>
-<department>[EXACT "Bilingual Abbr Key" value from departments_list above (e.g., CRA-ARC, EDSC-ESDC) OR empty string if no match found]</department>
-<departmentUrl>[EXACT matching URL from the SAME entry in departments_list OR empty string]</departmentUrl>
-</analysis>
-
-## Examples:
-<examples>
-<example>
-* A question about the weather forecast would match:
-<analysis>
-<department>ECCC</department>
-<departmentUrl>https://www.canada.ca/en/environment-climate-change.html</departmentUrl>
-</analysis>
-</example>
-
-<example>
-* A question about recipe ideas doesn't match any government departments:
-<analysis>
-<department></department>
-<departmentUrl></departmentUrl>
-</analysis>
-</example>
-
-<example>
-* A question about taxes (asked on the English page) would match CRA-ARC:
-<analysis>
-<department>CRA-ARC</department>
-<departmentUrl>https://www.canada.ca/en/revenue-agency.html</departmentUrl>
-</analysis>
-</example>
-
-<example>
-* A question about employment benefits (asked on the French page) would match EDSC-ESDC:
-<analysis>
-<department>EDSC-ESDC</department>
-<departmentUrl>https://www.canada.ca/fr/emploi-developpement-social.html</departmentUrl>
-</analysis>
-</example>
-<example>
-* A question about dental coverage asked on an english public service, government or TBS page would match TBS-SCT:
-<analysis>
-<department>TBS-SCT</department>
-<departmentUrl>https://www.canada.ca/en/treasury-board-secretariat.html</departmentUrl>
-</analysis>
-</example>
-</examples>
-    `;
-}
 
 /**
  * Generate the main answer generation system prompt used in Step 2
@@ -300,8 +171,8 @@ async function generateDocumentation() {
     searchResults: '[Example search results would appear here]'
   };
 
-  // Build context prompt directly without database dependencies
-  let contextPrompt = buildContextSystemPrompt(lang);
+  // Load the live context prompt so this doc can never drift from the real one.
+  let contextPrompt = await loadContextSystemPrompt(lang);
 
   // For documentation purposes, replace the full departments list with a summary note
   // This keeps the documentation file manageable while the live system uses the full list
@@ -310,11 +181,10 @@ async function generateDocumentation() {
   const summaryNote = `<departments_list>
 ## List of Government of Canada departments, agencies, organizations, and partnerships
 
-**Note:** The complete department list is dynamically loaded from departments_EN.js and departments_FR.js at runtime and contains ${departmentCount} entries. Each entry shows:
-• Organization name
-• Unilingual Abbr: Language-specific abbreviation (may be null)
-• Bilingual Abbr Key: The ONLY valid value to use in your response (unique identifier)
-• URL: The corresponding URL (must match the selected organization)
+**Note:** The complete department list is dynamically loaded from departments_EN.js and departments_FR.js at runtime and contains ${departmentCount} entries. Each entry is one line:
+\`Bilingual Abbr Key | Organization Name | URL\`
+- Bilingual Abbr Key: The ONLY valid value to use in your response (unique identifier)
+- URL: The corresponding URL (must match the selected organization)
 </departments_list>`;
   contextPrompt = contextPrompt.replace(departmentListRegex, summaryNote);
 
@@ -456,7 +326,7 @@ ${QUERY_REWRITE_PROMPT}
 - Provide search context for answer generation
 
 **Service:** ContextService.deriveContext()
-**File:** src/services/contextSystemPrompt.js
+**File:** agents/prompts/contextSystemPrompt.js
 
 ### Example User Input:
 \`\`\`
@@ -669,7 +539,7 @@ User submits question
 - \`src/services/ChatWorkflowService.js\` - Workflow service helpers
 - \`src/services/ContextService.js\` - Context/department matching
 - \`src/services/AnswerService.js\` - Answer generation
-- \`src/services/contextSystemPrompt.js\` - Context prompt builder
+- \`agents/prompts/contextSystemPrompt.js\` - Context prompt builder
 - \`src/services/systemPrompt.js\` - Answer prompt builder
 - \`src/services/systemPrompt/agenticBase.js\` - Core workflow instructions
 - \`src/services/systemPrompt/scenarios-all.js\` - General scenarios
@@ -694,8 +564,12 @@ node scripts/generate-system-prompt-documentation.js --lang fr --department CRA-
   console.log(`  File size: ${(documentation.length / 1024).toFixed(2)} KB`);
 }
 
-// Run the generator
-generateDocumentation().catch((error) => {
-  console.error('Error generating documentation:', error);
-  process.exit(1);
-});
+// Run the generator.
+// Exit explicitly: importing the live prompts pulls in ServerLoggingService, whose log
+// queue holds an open setInterval that would otherwise keep this process alive forever.
+generateDocumentation()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Error generating documentation:', error);
+    process.exit(1);
+  });

--- a/services/AnswerGenerationService.js
+++ b/services/AnswerGenerationService.js
@@ -28,8 +28,6 @@ async function invokeAgent({
     conversationHistory = [],
     lang,
     department,
-    topic,
-    topicUrl,
     departmentUrl,
     searchResults,
     scenarioOverrideText,
@@ -39,8 +37,6 @@ async function invokeAgent({
     const systemPrompt = await buildAnswerSystemPrompt(lang || 'en', {
         department,
         departmentUrl,
-        topic,
-        topicUrl,
         searchResults,
         scenarioOverrideText,
         similarQuestions,

--- a/services/ContextAgentService.js
+++ b/services/ContextAgentService.js
@@ -4,7 +4,7 @@ import loadContextSystemPrompt from '../agents/prompts/contextSystemPrompt.js';
 const invokeContextAgent = async (agentType, request) => {
   try {
 
-    let { chatId, message, systemPrompt, searchResults, conversationHistory = [], language = 'en' } = request;
+    let { chatId, message, systemPrompt, searchResults, conversationHistory = [], language = 'en', referringUrl = '' } = request;
 
     // Load system prompt from contextSystemPrompt.js if not provided
     if (!systemPrompt) {
@@ -36,10 +36,15 @@ const invokeContextAgent = async (agentType, request) => {
       });
     });
 
-    // Add the current message
+    // Add the current message, tagged with the referring URL the user launched from.
+    // contextSystemPrompt.js instructs the agent to prioritize <referring-url> over
+    // <searchResults> when matching a department, so the tag has to reach the model.
+    const trimmedReferringUrl = String(referringUrl || '').trim();
     messages.push({
       role: "user",
-      content: message,
+      content: trimmedReferringUrl
+        ? `${message}\n<referring-url>${trimmedReferringUrl}</referring-url>`
+        : message,
     });
 
     const answer = await contextAgent.invoke({

--- a/services/ContextAgentService.js
+++ b/services/ContextAgentService.js
@@ -1,5 +1,6 @@
 import { createContextAgent } from '../agents/AgentFactory.js';
 import loadContextSystemPrompt from '../agents/prompts/contextSystemPrompt.js';
+import { referringUrlTag } from '../api/util/prompt-tags.js';
 
 const invokeContextAgent = async (agentType, request) => {
   try {
@@ -39,12 +40,9 @@ const invokeContextAgent = async (agentType, request) => {
     // Add the current message, tagged with the referring URL the user launched from.
     // contextSystemPrompt.js instructs the agent to prioritize <referring-url> over
     // <searchResults> when matching a department, so the tag has to reach the model.
-    const trimmedReferringUrl = String(referringUrl || '').trim();
     messages.push({
       role: "user",
-      content: trimmedReferringUrl
-        ? `${message}\n<referring-url>${trimmedReferringUrl}</referring-url>`
-        : message,
+      content: `${message}${referringUrlTag(referringUrl)}`,
     });
 
     const answer = await contextAgent.invoke({

--- a/services/__tests__/ContextAgentService.test.js
+++ b/services/__tests__/ContextAgentService.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invokeContextAgent } from '../ContextAgentService.js';
+import { createContextAgent } from '../../agents/AgentFactory.js';
+
+vi.mock('../../agents/AgentFactory.js');
+vi.mock('../../agents/prompts/contextSystemPrompt.js', () => ({
+  default: vi.fn(async () => 'SYSTEM PROMPT'),
+}));
+vi.mock('../ServerLoggingService.js');
+
+// Captures the messages array handed to the agent so we can assert on the tags it carries.
+let capturedMessages;
+
+const agentResponse = {
+  messages: [
+    {
+      content: '<department>PrairiesCan</department>',
+      response_metadata: {
+        role: 'assistant',
+        usage: {},
+        tokenUsage: { promptTokens: 10, completionTokens: 5 },
+        model_name: 'gpt-5.1',
+      },
+    },
+  ],
+};
+
+const invokeWith = (overrides = {}) =>
+  invokeContextAgent('openai', {
+    chatId: 'test-chat-id',
+    message: 'How do I apply for funding?',
+    searchResults: 'some results',
+    ...overrides,
+  });
+
+const currentUserMessage = () => capturedMessages[capturedMessages.length - 1];
+
+describe('ContextAgentService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedMessages = null;
+    createContextAgent.mockResolvedValue({
+      invoke: vi.fn(async ({ messages }) => {
+        capturedMessages = messages;
+        return agentResponse;
+      }),
+    });
+  });
+
+  describe('referring URL', () => {
+    it('appends a <referring-url> tag to the current user message', async () => {
+      const referringUrl =
+        'https://test.canada.ca/experimental/en/aia/prairies-economic-development.html';
+
+      await invokeWith({ referringUrl });
+
+      expect(currentUserMessage()).toEqual({
+        role: 'user',
+        content: `How do I apply for funding?\n<referring-url>${referringUrl}</referring-url>`,
+      });
+    });
+
+    it('trims surrounding whitespace from the referring URL', async () => {
+      await invokeWith({ referringUrl: '  https://www.canada.ca/en/services.html\n' });
+
+      expect(currentUserMessage().content).toBe(
+        'How do I apply for funding?\n<referring-url>https://www.canada.ca/en/services.html</referring-url>'
+      );
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['an empty string', ''],
+      ['whitespace only', '   '],
+    ])('emits no tag when the referring URL is %s', async (_label, referringUrl) => {
+      await invokeWith({ referringUrl });
+
+      expect(currentUserMessage().content).toBe('How do I apply for funding?');
+      expect(currentUserMessage().content).not.toContain('<referring-url>');
+    });
+
+    it('tags only the current message, never conversation history', async () => {
+      await invokeWith({
+        referringUrl: 'https://www.canada.ca/en/services.html',
+        conversationHistory: [
+          {
+            interaction: {
+              question: 'Earlier question',
+              answer: { content: 'Earlier answer' },
+            },
+          },
+        ],
+      });
+
+      const historyMessages = capturedMessages.filter((m) => m !== currentUserMessage());
+      historyMessages.forEach((m) => {
+        expect(m.content).not.toContain('<referring-url>');
+      });
+      expect(currentUserMessage().content).toContain('<referring-url>');
+    });
+  });
+
+  it('passes search results to the system message', async () => {
+    await invokeWith({ referringUrl: 'https://www.canada.ca/en/services.html' });
+
+    expect(capturedMessages[0]).toEqual({
+      role: 'system',
+      content: 'SYSTEM PROMPT<searchResults>some results</searchResults>',
+    });
+  });
+});


### PR DESCRIPTION
fix tests
this regression happened months ago!

# Summary | Résumé
- referring-url had stopped being passed to contextSystemPrompt which chooses dept


---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
