### PR TITLE
feat: create partial downloaded pill

### DIFF
--- a/__tests__/api.eval-dashboard.filters.test.js
+++ b/__tests__/api.eval-dashboard.filters.test.js
@@ -90,7 +90,7 @@ describe('api/eval/eval-dashboard - per-filter pipeline creation', () => {
     expect(ChatModel.Chat.aggregate).toHaveBeenCalled();
     expect(pipelineIncludes('downloadWebPage')).toBe(true);
     expect(pipelineIncludes('hasDownload')).toBe(true);
-    expect(pipelineIncludes('firstToolId')).toBe(true);
+    expect(pipelineIncludes('answerToolIds')).toBe(true);
   });
 
   it('calls aggregate exactly once, not twice', async () => {

--- a/__tests__/integration.eval-dashboard-download-status.test.js
+++ b/__tests__/integration.eval-dashboard-download-status.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import handler from '../api/eval/eval-dashboard.js';
+
+import { Chat } from '../models/chat.js';
+import { Interaction } from '../models/interaction.js';
+import { Context } from '../models/context.js';
+import { Answer } from '../models/answer.js';
+import { Tool } from '../models/tool.js';
+import { User } from '../models/user.js';
+
+vi.mock('../middleware/auth.js', () => ({
+    withProtection: (fn) => fn,
+    authMiddleware: (req, res, next) => next(),
+    adminMiddleware: (req, res, next) => next(),
+    partnerOrAdminMiddleware: (req, res, next) => next()
+}));
+
+vi.mock('../api/db/db-connect.js', () => ({
+    default: async () => { }
+}));
+
+// Regression coverage for the hasDownload 'success' | 'partial' | 'fail' | ''
+// $switch in api/eval/eval-dashboard.js. The existing unit test for this
+// endpoint (__tests__/api.eval-dashboard.filters.test.js) mocks
+// Chat.aggregate to return [] and only string-matches the pipeline shape, so
+// it can't catch a broken $switch branch or a wrong $$tool.tool filter - this
+// seeds real Tool docs through a real aggregation to verify the classification
+// itself.
+describe('Integration: eval-dashboard hasDownload status', () => {
+    let mongoServer;
+    const dateRange = {
+        startDate: '2020-01-01',
+        endDate: '2030-01-01',
+    };
+
+    const makeTool = (error) => Tool.create({ tool: 'downloadWebPage', status: error === 'none' ? 'completed' : 'error', error });
+
+    // toolErrors: array of 'none' (succeeded) / anything else (failed) for
+    // each downloadWebPage call on this interaction's answer. Empty array =
+    // no downloads attempted at all.
+    const makeInteraction = async (chatId, toolErrors) => {
+        const context = await Context.create({ pageLanguage: 'en', department: 'IRCC' });
+        const tools = await Promise.all(toolErrors.map(makeTool));
+        const answer = await Answer.create({
+            content: 'Test answer',
+            answerType: 'normal',
+            tools: tools.map((t) => t._id),
+        });
+        return Interaction.create({
+            context: context._id,
+            answer: answer._id,
+            question: new mongoose.Types.ObjectId(),
+            createdAt: new Date(),
+        });
+    };
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        await mongoose.connect(mongoServer.getUri());
+    }, 60000);
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    // The project's global test setup (test/vitest-hooks.js) clears every
+    // collection on the active mongoose connection before each test - so
+    // seeding has to happen here, in a beforeEach that runs after that
+    // global one, not once in beforeAll (which would get wiped before the
+    // first test body ever runs).
+    beforeEach(async () => {
+        const user = await User.create({ email: 'reviewer@example.com', password: 'password123' });
+
+        const [success, partial, fail, none] = await Promise.all([
+            makeInteraction('chat-success', ['none', 'none']),
+            makeInteraction('chat-partial', ['none', 'download failed: timeout']),
+            makeInteraction('chat-fail', ['download failed: timeout']),
+            makeInteraction('chat-none', []),
+        ]);
+
+        await Promise.all([
+            Chat.create({ chatId: 'chat-success', user: user._id, interactions: [success._id], createdAt: new Date(), pageLanguage: 'en' }),
+            Chat.create({ chatId: 'chat-partial', user: user._id, interactions: [partial._id], createdAt: new Date(), pageLanguage: 'en' }),
+            Chat.create({ chatId: 'chat-fail', user: user._id, interactions: [fail._id], createdAt: new Date(), pageLanguage: 'en' }),
+            Chat.create({ chatId: 'chat-none', user: user._id, interactions: [none._id], createdAt: new Date(), pageLanguage: 'en' }),
+        ]);
+    });
+
+    const callHandler = async (query) => {
+        const req = { method: 'GET', query: { ...dateRange, ...query } };
+        let jsonBody;
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn((body) => { jsonBody = body; return res; }),
+        };
+        await handler(req, res);
+        return jsonBody;
+    };
+
+    it('classifies every download outcome correctly', async () => {
+        const body = await callHandler({});
+        const byChatId = Object.fromEntries(body.rows.map((r) => [r.chatId, r.hasDownload]));
+
+        expect(byChatId['chat-success']).toBe('success');
+        expect(byChatId['chat-partial']).toBe('partial');
+        expect(byChatId['chat-fail']).toBe('fail');
+        expect(byChatId['chat-none']).toBe('');
+    });
+
+    // These only assert inclusion, not exclusivity: the free-text "yes"/"no"
+    // shortcut is a combined $or across several unrelated boolean columns
+    // (hasAutoEval, hasExpertEval, processed, hasMatches), so a row can
+    // legitimately match via one of those instead of hasDownload. That's
+    // pre-existing, orthogonal behavior - what these regression-test is
+    // specifically that hasDownload's own $in clause now includes 'partial'
+    // under "yes" (previously only reachable by typing the literal word).
+    it('finds the partial row via the free-text "yes" shortcut', async () => {
+        const body = await callHandler({ search: 'yes' });
+        const chatIds = body.rows.map((r) => r.chatId);
+
+        expect(chatIds).toContain('chat-success');
+        expect(chatIds).toContain('chat-partial');
+    });
+
+    it('finds the fail and none rows via the free-text "no" shortcut', async () => {
+        const body = await callHandler({ search: 'no' });
+        const chatIds = body.rows.map((r) => r.chatId);
+
+        expect(chatIds).toContain('chat-fail');
+        expect(chatIds).toContain('chat-none');
+    });
+
+    it('finds only the partial row via a column search, without being coerced to a boolean', async () => {
+        const body = await callHandler({ columnSearch: JSON.stringify({ hasDownload: 'partial' }) });
+        const chatIds = body.rows.map((r) => r.chatId);
+
+        expect(chatIds).toEqual(['chat-partial']);
+    });
+});

--- a/api/chat/chat-dashboard.js
+++ b/api/chat/chat-dashboard.js
@@ -2,7 +2,7 @@
 import { Chat } from '../../models/chat.js';
 import mongoose from 'mongoose';
 import { authMiddleware, partnerOrAdminMiddleware, withProtection } from '../../middleware/auth.js';
-import { getPartnerEvalAggregationExpression, getAiEvalAggregationExpression, getPartnerContentIssueAggregationExpression, getChatFilterConditions } from '../util/chat-filters.js';
+import { getPartnerEvalAggregationExpression, getAiEvalAggregationExpression, getPartnerContentIssueAggregationExpression, getChatFilterConditions, getFeedbackDataProjection } from '../util/chat-filters.js';
 
 const DATE_TIME_REGEX = /^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?)?$/;
 
@@ -238,18 +238,7 @@ async function chatDashboardHandler(req, res) {
     pipeline.push({
       $addFields: {
         'interactions.expertEmail': { $ifNull: [{ $arrayElemAt: ['$expertFeedbackDocs.expertEmail', 0] }, ''] },
-        'interactions.expertFeedbackData': {
-          totalScore: { $arrayElemAt: ['$expertFeedbackDocs.totalScore', 0] },
-          sentence1Score: { $arrayElemAt: ['$expertFeedbackDocs.sentence1Score', 0] },
-          sentence2Score: { $arrayElemAt: ['$expertFeedbackDocs.sentence2Score', 0] },
-          sentence3Score: { $arrayElemAt: ['$expertFeedbackDocs.sentence3Score', 0] },
-          sentence4Score: { $arrayElemAt: ['$expertFeedbackDocs.sentence4Score', 0] },
-          citationScore: { $arrayElemAt: ['$expertFeedbackDocs.citationScore', 0] },
-          sentence1Harmful: { $arrayElemAt: ['$expertFeedbackDocs.sentence1Harmful', 0] },
-          sentence2Harmful: { $arrayElemAt: ['$expertFeedbackDocs.sentence2Harmful', 0] },
-          sentence3Harmful: { $arrayElemAt: ['$expertFeedbackDocs.sentence3Harmful', 0] },
-          sentence4Harmful: { $arrayElemAt: ['$expertFeedbackDocs.sentence4Harmful', 0] }
-        }
+        'interactions.expertFeedbackData': getFeedbackDataProjection('$expertFeedbackDocs', { includeContentIssue: true })
       }
     });
 
@@ -281,18 +270,7 @@ async function chatDashboardHandler(req, res) {
     // Extract only needed fields for aiEval computation
     pipeline.push({
       $addFields: {
-        'interactions.autoEvalFeedbackData': {
-          totalScore: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.totalScore', 0] },
-          sentence1Score: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence1Score', 0] },
-          sentence2Score: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence2Score', 0] },
-          sentence3Score: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence3Score', 0] },
-          sentence4Score: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence4Score', 0] },
-          citationScore: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.citationScore', 0] },
-          sentence1Harmful: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence1Harmful', 0] },
-          sentence2Harmful: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence2Harmful', 0] },
-          sentence3Harmful: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence3Harmful', 0] },
-          sentence4Harmful: { $arrayElemAt: ['$autoEvalExpertFeedbackDocs.sentence4Harmful', 0] }
-        }
+        'interactions.autoEvalFeedbackData': getFeedbackDataProjection('$autoEvalExpertFeedbackDocs')
       }
     });
 
@@ -332,7 +310,8 @@ async function chatDashboardHandler(req, res) {
           redactedQuestion: '$interactions.redactedQuestion',
           answerType: '$interactions.answerType',
           partnerEval: '$interactions.partnerEval',
-          aiEval: '$interactions.aiEval'
+          aiEval: '$interactions.aiEval',
+          partnerHasContentIssue: '$interactions.partnerHasContentIssue'
         }
       }
     });

--- a/api/chat/chat-dashboard.js
+++ b/api/chat/chat-dashboard.js
@@ -303,6 +303,12 @@ async function chatDashboardHandler(req, res) {
         createdAt: 1,
         pageLanguage: 1,
         totalInteractionCount: 1,
+        // Inclusion-only list - any field added to 'interactions' by the two
+        // $addFields stages above (lines ~290-296 computing
+        // partnerEval/aiEval/partnerHasContentIssue, and any earlier stage
+        // adding an interactions.* field this pipeline needs downstream)
+        // must be re-listed here too, or it's silently stripped before
+        // $group. (partnerHasContentIssue was dropped this way until fixed.)
         interactions: {
           department: '$interactions.department',
           expertEmail: '$interactions.expertEmail',

--- a/api/eval/eval-dashboard.js
+++ b/api/eval/eval-dashboard.js
@@ -133,7 +133,13 @@ async function evalDashboardHandler(req, res) {
       }
     });
 
-    // Lookup every tool call for the answer, not just the first
+    // Lookup every tool call for the answer, not just the first. Plain
+    // localField/foreignField array $lookup - the same shape already
+    // proven above (interactionIds -> interactions), not the newer
+    // combined pipeline form, so this introduces no new DocumentDB
+    // compatibility risk. Trade-off: joins full tool docs (including
+    // input/output) before filtering to downloadWebPage below, rather
+    // than filtering/projecting in the join itself.
     pipeline.push({
       $lookup: {
         from: 'tools',
@@ -162,6 +168,10 @@ async function evalDashboardHandler(req, res) {
       }
     });
     // hasDownload: 'success' | 'partial' | 'fail' | '' (no downloads)
+    // TODO: this classification is duplicated 3x (this $switch, plain JS in
+    // DownloadPanel.js, hardcoded again in EvalDashboardPage.js's render) -
+    // consider sharing it across the api/src boundary like getItemVerdict
+    // in batchItems.js does.
     pipeline.push({
       $addFields: {
         hasDownload: {
@@ -451,6 +461,8 @@ async function evalDashboardHandler(req, res) {
         orClauses.push({ hasExpertEval: boolSearch });
         orClauses.push({ processed: boolSearch });
         orClauses.push({ hasMatches: boolSearch });
+        // hasDownload isn't boolean anymore, but "yes"/"no" still needs to work
+        orClauses.push({ hasDownload: boolSearch ? 'success' : { $in: ['fail', ''] } });
       }
 
       pipeline.push({ $match: { $or: orClauses } });

--- a/api/eval/eval-dashboard.js
+++ b/api/eval/eval-dashboard.js
@@ -140,6 +140,12 @@ async function evalDashboardHandler(req, res) {
     // compatibility risk. Trade-off: joins full tool docs (including
     // input/output) before filtering to downloadWebPage below, rather
     // than filtering/projecting in the join itself.
+    // TODO: a `pipeline: [{ $project: { tool: 1, error: 1 } }]` form of this
+    // $lookup would avoid shipping full tool payloads per row. Deliberately
+    // deferred - the leaner sub-pipeline $lookup form was tried and reverted
+    // earlier because it couldn't be validated against real DocumentDB;
+    // don't re-open this without running explain("executionStats") against
+    // an actual DocumentDB cluster first.
     pipeline.push({
       $lookup: {
         from: 'tools',
@@ -171,7 +177,11 @@ async function evalDashboardHandler(req, res) {
     // TODO: this classification is duplicated 3x (this $switch, plain JS in
     // DownloadPanel.js, hardcoded again in EvalDashboardPage.js's render) -
     // consider sharing it across the api/src boundary like getItemVerdict
-    // in batchItems.js does.
+    // in batchItems.js does. Deliberately deferred rather than consolidated
+    // now: the planned "show all matching pills" work changes the
+    // classification shape itself (single winner -> set of applicable
+    // states), so a shared module should be designed once that scope is
+    // defined, not built twice.
     pipeline.push({
       $addFields: {
         hasDownload: {
@@ -439,8 +449,11 @@ async function evalDashboardHandler(req, res) {
         orClauses.push({ hasExpertEval: boolSearch });
         orClauses.push({ processed: boolSearch });
         orClauses.push({ hasMatches: boolSearch });
-        // hasDownload isn't boolean anymore, but "yes"/"no" still needs to work
-        orClauses.push({ hasDownload: boolSearch ? 'success' : { $in: ['fail', ''] } });
+        // hasDownload isn't boolean anymore, but "yes"/"no" still needs to work.
+        // "yes" means "some download worked" (success or partial), so partial
+        // rows stay reachable via the same shortcut instead of only by typing
+        // the literal word "partial".
+        orClauses.push({ hasDownload: boolSearch ? { $in: ['success', 'partial'] } : { $in: ['fail', ''] } });
       }
 
       pipeline.push({ $match: { $or: orClauses } });
@@ -456,13 +469,17 @@ async function evalDashboardHandler(req, res) {
         columnSearch = null;
       }
     }
+    // Columns that hold a status string rather than a real boolean - never
+    // coerce their search value to true/false, always fall through to the
+    // regex/text branch below.
+    const stringStatusColumns = new Set(['hasDownload']);
     if (columnSearch && typeof columnSearch === 'object' && Object.keys(columnSearch).length) {
       const andClauses = [];
       for (const [col, val] of Object.entries(columnSearch)) {
         const v = String(val || '').trim();
         if (!v) continue;
         const low = v.toLowerCase();
-        if (['true', 'false', '1', '0', 'yes', 'no', 'y', 'n'].includes(low)) {
+        if (!stringStatusColumns.has(col) && ['true', 'false', '1', '0', 'yes', 'no', 'y', 'n'].includes(low)) {
           const boolVal = ['true', '1', 'yes', 'y'].includes(low);
           andClauses.push({ [col]: boolVal });
         } else {

--- a/api/eval/eval-dashboard.js
+++ b/api/eval/eval-dashboard.js
@@ -125,30 +125,54 @@ async function evalDashboardHandler(req, res) {
       }
     });
 
-    // Extract answerType and first tool ID immediately
+    // Extract answerType and the full tool ID list for this answer
     pipeline.push({
       $addFields: {
         'interactions.answerType': { $ifNull: [{ $arrayElemAt: ['$answerDoc.answerType', 0] }, ''] },
-        firstToolId: { $arrayElemAt: [{ $ifNull: [{ $arrayElemAt: ['$answerDoc.tools', 0] }, []] }, 0] }
+        answerToolIds: { $ifNull: [{ $arrayElemAt: ['$answerDoc.tools', 0] }, []] }
       }
     });
 
-    // Lookup the first tool document to check for downloadWebPage
+    // Lookup every tool call for the answer, not just the first
     pipeline.push({
       $lookup: {
         from: 'tools',
-        localField: 'firstToolId',
+        localField: 'answerToolIds',
         foreignField: '_id',
-        as: 'firstToolDoc'
+        as: 'answerToolDocs'
       }
     });
     pipeline.push({
       $addFields: {
+        downloadTools: {
+          $filter: {
+            input: '$answerToolDocs',
+            as: 'tool',
+            cond: { $eq: ['$$tool.tool', 'downloadWebPage'] }
+          }
+        }
+      }
+    });
+    pipeline.push({
+      $addFields: {
+        downloadSucceededCount: {
+          $size: { $filter: { input: '$downloadTools', as: 't', cond: { $eq: ['$$t.error', 'none'] } } }
+        },
+        downloadTotalCount: { $size: '$downloadTools' }
+      }
+    });
+    // hasDownload: 'success' | 'partial' | 'fail' | '' (no downloads)
+    pipeline.push({
+      $addFields: {
         hasDownload: {
-          $and: [
-            { $eq: [{ $arrayElemAt: ['$firstToolDoc.tool', 0] }, 'downloadWebPage'] },
-            { $eq: [{ $arrayElemAt: ['$firstToolDoc.error', 0] }, 'none'] }
-          ]
+          $switch: {
+            branches: [
+              { case: { $eq: ['$downloadTotalCount', 0] }, then: '' },
+              { case: { $eq: ['$downloadSucceededCount', '$downloadTotalCount'] }, then: 'success' },
+              { case: { $eq: ['$downloadSucceededCount', 0] }, then: 'fail' }
+            ],
+            default: 'partial'
+          }
         }
       }
     });
@@ -296,8 +320,11 @@ async function evalDashboardHandler(req, res) {
         contextDoc: 0,
         interactionExpertDocs: 0,
         evalExpertDocs: 0,
-        firstToolId: 0,
-        firstToolDoc: 0,
+        answerToolIds: 0,
+        answerToolDocs: 0,
+        downloadTools: 0,
+        downloadSucceededCount: 0,
+        downloadTotalCount: 0,
         publicFeedbackDoc: 0
       }
     });
@@ -388,7 +415,7 @@ async function evalDashboardHandler(req, res) {
         hasMatches: '$eval.hasMatches',
         fallbackType: { $ifNull: ['$eval.fallbackType', ''] },
         noMatchReasonType: { $ifNull: ['$eval.noMatchReasonType', ''] },
-        hasDownload: { $ifNull: ['$hasDownload', false] },
+        hasDownload: { $ifNull: ['$hasDownload', ''] },
         feedback: { $ifNull: ['$feedbackValue', ''] }
       }
     });
@@ -413,7 +440,9 @@ async function evalDashboardHandler(req, res) {
         { creatorEmail: { $regex: esc, $options: 'i' } },
         { fallbackType: { $regex: esc, $options: 'i' } },
         { noMatchReasonType: { $regex: esc, $options: 'i' } },
-        { feedback: { $regex: esc, $options: 'i' } }
+        { feedback: { $regex: esc, $options: 'i' } },
+        // hasDownload is a status string now, not a boolean, so it's a text match
+        { hasDownload: { $regex: esc, $options: 'i' } }
       ];
 
       // If the user searched a boolean-like term, also match boolean columns directly
@@ -422,7 +451,6 @@ async function evalDashboardHandler(req, res) {
         orClauses.push({ hasExpertEval: boolSearch });
         orClauses.push({ processed: boolSearch });
         orClauses.push({ hasMatches: boolSearch });
-        orClauses.push({ hasDownload: boolSearch });
       }
 
       pipeline.push({ $match: { $or: orClauses } });
@@ -512,7 +540,7 @@ async function evalDashboardHandler(req, res) {
       hasMatches: typeof r.hasMatches === 'boolean' ? r.hasMatches : false,
       fallbackType: r.fallbackType || '',
       noMatchReasonType: r.noMatchReasonType || '',
-      hasDownload: r.hasDownload || false,
+      hasDownload: r.hasDownload || '',
       feedback: r.feedback || '',
       date: r.createdAt ? r.createdAt.toISOString() : null
     }));

--- a/api/eval/eval-dashboard.js
+++ b/api/eval/eval-dashboard.js
@@ -1,7 +1,7 @@
 import dbConnect from '../db/db-connect.js';
 import { Chat } from '../../models/chat.js';
 import { withProtection, authMiddleware, partnerOrAdminMiddleware } from '../../middleware/auth.js';
-import { getChatFilterConditions, getPartnerEvalAggregationExpression, getAiEvalAggregationExpression, getPartnerContentIssueAggregationExpression } from '../util/chat-filters.js';
+import { getChatFilterConditions, getPartnerEvalAggregationExpression, getAiEvalAggregationExpression, getPartnerContentIssueAggregationExpression, getFeedbackDataProjection } from '../util/chat-filters.js';
 import { frForProgram, frForAction } from '../util/programActionFr.js';
 
 const HOURS_IN_DAY = 24;
@@ -261,18 +261,7 @@ async function evalDashboardHandler(req, res) {
           overallRating: { $arrayElemAt: ['$interactionExpertDocs.overallRating', 0] }
         },
         hasInteractionExpert: { $gt: [{ $size: '$interactionExpertDocs' }, 0] },
-        expertFeedbackData: {
-          totalScore: { $arrayElemAt: ['$interactionExpertDocs.totalScore', 0] },
-          sentence1Score: { $arrayElemAt: ['$interactionExpertDocs.sentence1Score', 0] },
-          sentence2Score: { $arrayElemAt: ['$interactionExpertDocs.sentence2Score', 0] },
-          sentence3Score: { $arrayElemAt: ['$interactionExpertDocs.sentence3Score', 0] },
-          sentence4Score: { $arrayElemAt: ['$interactionExpertDocs.sentence4Score', 0] },
-          citationScore: { $arrayElemAt: ['$interactionExpertDocs.citationScore', 0] },
-          sentence1Harmful: { $arrayElemAt: ['$interactionExpertDocs.sentence1Harmful', 0] },
-          sentence2Harmful: { $arrayElemAt: ['$interactionExpertDocs.sentence2Harmful', 0] },
-          sentence3Harmful: { $arrayElemAt: ['$interactionExpertDocs.sentence3Harmful', 0] },
-          sentence4Harmful: { $arrayElemAt: ['$interactionExpertDocs.sentence4Harmful', 0] }
-        }
+        expertFeedbackData: getFeedbackDataProjection('$interactionExpertDocs', { includeContentIssue: true })
       }
     });
 
@@ -291,18 +280,7 @@ async function evalDashboardHandler(req, res) {
         evalExpert: {
           expertEmail: { $arrayElemAt: ['$evalExpertDocs.expertEmail', 0] }
         },
-        autoEvalFeedbackData: {
-          totalScore: { $arrayElemAt: ['$evalExpertDocs.totalScore', 0] },
-          sentence1Score: { $arrayElemAt: ['$evalExpertDocs.sentence1Score', 0] },
-          sentence2Score: { $arrayElemAt: ['$evalExpertDocs.sentence2Score', 0] },
-          sentence3Score: { $arrayElemAt: ['$evalExpertDocs.sentence3Score', 0] },
-          sentence4Score: { $arrayElemAt: ['$evalExpertDocs.sentence4Score', 0] },
-          citationScore: { $arrayElemAt: ['$evalExpertDocs.citationScore', 0] },
-          sentence1Harmful: { $arrayElemAt: ['$evalExpertDocs.sentence1Harmful', 0] },
-          sentence2Harmful: { $arrayElemAt: ['$evalExpertDocs.sentence2Harmful', 0] },
-          sentence3Harmful: { $arrayElemAt: ['$evalExpertDocs.sentence3Harmful', 0] },
-          sentence4Harmful: { $arrayElemAt: ['$evalExpertDocs.sentence4Harmful', 0] }
-        }
+        autoEvalFeedbackData: getFeedbackDataProjection('$evalExpertDocs')
       }
     });
 

--- a/api/util/chat-filters.js
+++ b/api/util/chat-filters.js
@@ -81,6 +81,40 @@ const filterInteractionsByCategory = (chat, category, evaluator) => {
 // Filtering now happens in the aggregation pipeline using computed fields
 // via getPartnerEvalAggregationExpression() and getAiEvalAggregationExpression().
 
+// Shared shape for pulling an expert-feedback doc's score/harmful/content-
+// issue fields off a single-element $lookup array into a flat object -
+// the input getPartnerEvalAggregationExpression / getAiEvalAggregationExpression
+// / getPartnerContentIssueAggregationExpression below all read. docsField is
+// the $lookup's `as` array (e.g. '$interactionExpertDocs'). Previously this
+// object was copy-pasted separately in eval-dashboard.js and chat-dashboard.js
+// (4 near-identical copies total, 2 per file for partner + AI eval) - one of
+// those copies silently dropped the ContentIssue fields, so the Content
+// issue pill/filter never worked. One shared definition instead.
+// includeContentIssue defaults false: there's no AI-eval equivalent of that
+// tag (see getPartnerContentIssueAggregationExpression), so only pass true
+// for partner-facing feedback.
+export function getFeedbackDataProjection(docsField, { includeContentIssue = false } = {}) {
+  const projection = {
+    totalScore: { $arrayElemAt: [`${docsField}.totalScore`, 0] },
+    sentence1Score: { $arrayElemAt: [`${docsField}.sentence1Score`, 0] },
+    sentence2Score: { $arrayElemAt: [`${docsField}.sentence2Score`, 0] },
+    sentence3Score: { $arrayElemAt: [`${docsField}.sentence3Score`, 0] },
+    sentence4Score: { $arrayElemAt: [`${docsField}.sentence4Score`, 0] },
+    citationScore: { $arrayElemAt: [`${docsField}.citationScore`, 0] },
+    sentence1Harmful: { $arrayElemAt: [`${docsField}.sentence1Harmful`, 0] },
+    sentence2Harmful: { $arrayElemAt: [`${docsField}.sentence2Harmful`, 0] },
+    sentence3Harmful: { $arrayElemAt: [`${docsField}.sentence3Harmful`, 0] },
+    sentence4Harmful: { $arrayElemAt: [`${docsField}.sentence4Harmful`, 0] }
+  };
+  if (includeContentIssue) {
+    projection.sentence1ContentIssue = { $arrayElemAt: [`${docsField}.sentence1ContentIssue`, 0] };
+    projection.sentence2ContentIssue = { $arrayElemAt: [`${docsField}.sentence2ContentIssue`, 0] };
+    projection.sentence3ContentIssue = { $arrayElemAt: [`${docsField}.sentence3ContentIssue`, 0] };
+    projection.sentence4ContentIssue = { $arrayElemAt: [`${docsField}.sentence4ContentIssue`, 0] };
+  }
+  return projection;
+}
+
 // JS mirror of getPartnerEvalAggregationExpression below — the exact same
 // score signals and priority (harmful > hasCitationError > hasError >
 // needsImprovement > correct), for consumers that categorize in Node instead

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -24,11 +24,15 @@ const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
     };
 
     // 'success' | 'partial' | 'fail' - matches the eval table's hasDownload status
+    // TODO: duplicated 3x (this, the $switch in eval-dashboard.js, and
+    // EvalDashboardPage.js's render) - share across the api/src boundary
+    // like getItemVerdict in batchItems.js.
     const succeededCount = downloads.filter(d => d.error === 'none').length;
     const downloadStatus = succeededCount === 0
         ? 'fail'
         : succeededCount === downloads.length ? 'success' : 'partial';
     // Text, not color alone, for WCAG 1.4.1 - reuses .label.correct/.error/.partial
+    // TODO: two lookups keyed by the same three strings - could be one table.
     const statusPillClass = { success: 'correct', partial: 'partial', fail: 'error' }[downloadStatus];
     const titleStatus = {
         success: t('reviewPanels.downloadSuccess'),

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -26,13 +26,17 @@ const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
     // 'success' | 'partial' | 'fail' - matches the eval table's hasDownload status
     // TODO: duplicated 3x (this, the $switch in eval-dashboard.js, and
     // EvalDashboardPage.js's render) - share across the api/src boundary
-    // like getItemVerdict in batchItems.js.
+    // like getItemVerdict in batchItems.js. Deliberately deferred - see the
+    // matching TODO in eval-dashboard.js for why (the "pills together" work
+    // will change the classification shape itself).
     const succeededCount = downloads.filter(d => d.error === 'none').length;
     const downloadStatus = succeededCount === 0
         ? 'fail'
         : succeededCount === downloads.length ? 'success' : 'partial';
     // Text, not color alone, for WCAG 1.4.1 - reuses .label.correct/.error/.partial
     // TODO: two lookups keyed by the same three strings - could be one table.
+    // Deliberately deferred alongside the classification-duplication TODO
+    // above - same reshaping work will likely touch this too.
     const statusPillClass = { success: 'correct', partial: 'partial', fail: 'error' }[downloadStatus];
     const titleStatus = {
         success: t('reviewPanels.downloadSuccess'),

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -23,28 +23,25 @@ const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
         }
     };
 
-    // TODO: review and confirm \u2014 .some() means the Success pill shows if
-    // even one of several downloads succeeded, e.g. 1-of-3 still reads
-    // "Success" overall. Pre-existing logic (unchanged by this PR), but the
-    // pill treatment makes that reading more prominent than the checkmark
-    // it replaced. Confirm this is the intended meaning of "Success" here
-    // before changing it \u2014 not fixing without that confirmation.
-    const hasSuccess = downloads.some(d => d.error === 'none');
-    // Text, not a bare glyph or color alone \u2014 a checkmark/x-mark with no
-    // label isn't reliably announced by screen readers, and green/red alone
-    // fails WCAG 1.4.1 (use of color). Reuses the same .label.correct/
-    // .label.error pill pair already used for eval verdicts elsewhere
-    // (DatabasePage.js, SuiteGridTable.js) \u2014 but "Success"/"Failed" wording
-    // here specifically, not the "Pass"/"Fail" used for those verdicts,
-    // since this is a download outcome, not a scored evaluation.
-    const titleStatus = hasSuccess ? t('reviewPanels.downloadSuccess') : t('reviewPanels.fail');
+    // 'success' | 'partial' | 'fail' - matches the eval table's hasDownload status
+    const succeededCount = downloads.filter(d => d.error === 'none').length;
+    const downloadStatus = succeededCount === 0
+        ? 'fail'
+        : succeededCount === downloads.length ? 'success' : 'partial';
+    // Text, not color alone, for WCAG 1.4.1 - reuses .label.correct/.error/.partial
+    const statusPillClass = { success: 'correct', partial: 'partial', fail: 'error' }[downloadStatus];
+    const titleStatus = {
+        success: t('reviewPanels.downloadSuccess'),
+        partial: t('reviewPanels.downloadPartial'),
+        fail: t('reviewPanels.fail')
+    }[downloadStatus];
     const title = withAnswerNumber(t('reviewPanels.downloadedPagesTitle') || 'Downloaded pages');
 
     return (
         <details className="review-details">
             <summary>
                 {title}
-                <span className={`label label--summary-status ${hasSuccess ? 'correct' : 'error'}`}>{titleStatus}</span>
+                <span className={`label label--summary-status ${statusPillClass}`}>{titleStatus}</span>
             </summary>
             <div className="review-panel download-panel">
                 {downloads.map((d, i) => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1313,6 +1313,7 @@
     "pass": "Pass",
     "fail": "Failed",
     "downloadSuccess": "Succeeded",
+    "downloadPartial": "Partial",
     "details": "Details",
     "fallbackCompareRaw": "Fallback compare raw",
     "expertFeedbackId": "Expert evaluation id",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1329,6 +1329,7 @@
     "pass": "Réussite",
     "fail": "Échoué",
     "downloadSuccess": "Réussi",
+    "downloadPartial": "Partiel",
     "details": "Détails",
     "expertFeedbackId": "ID d'évaluation d'expert",
     "fallbackSourceChatId": "ID de chat source pour le repli",

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -140,6 +140,9 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       title: t('admin.evalDashboard.columns.download', 'Download'),
       data: 'hasDownload',
       // hasDownload: 'success' | 'partial' | 'fail' | '' (see api/eval/eval-dashboard.js)
+      // TODO: near-duplicate icon+hidden-text markup per branch - a small
+      // helper would collapse this (see matching TODO in eval-dashboard.js
+      // about the 3x-duplicated status classification).
       render: v => {
         // No GC DS check/half-circle icon, so FA + hidden text alternative
         if (v === 'success') {
@@ -147,6 +150,9 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         }
         if (v === 'partial') {
           return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
+        }
+        if (v === 'fail') {
+          return `<span class="text-status--negative"><i class="fa-solid fa-xmark" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.fail'))}</span></span>`;
         }
         return '';
       },

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -149,7 +149,9 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
           return `<span class="text-status--positive"><i class="fa-solid fa-check" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}</span></span>`;
         }
         if (v === 'partial') {
-          return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
+          // Smaller than the other two icons - a filled circle shape reads
+          // visually larger than the check/x glyphs at the same font-size.
+          return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke" style="font-size: 1.2em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
         }
         if (v === 'fail') {
           return `<span class="text-status--negative"><i class="fa-solid fa-xmark" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.fail'))}</span></span>`;

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -137,15 +137,20 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       }, searchable: false, orderable: true
     },
     {
-      title: t('admin.evalDashboard.columns.download', 'Download'), data: 'hasDownload', render: v => v
-        // GC DS's icon set has no bare checkmark (only checkmark-circle),
-        // so this falls back to Font Awesome per the "GC DS first, FA when
-        // no GC DS equivalent exists" rule. Decorative icon + a visually-
-        // hidden text alternative, rather than relying on aria-label (which
-        // some AT/browser combinations handle inconsistently for <i> icon
-        // fonts) — same effect, more broadly reliable.
-        ? `<span class="text-status--positive"><i class="fa-solid fa-check" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}</span></span>`
-        : '', width: '50px', searchable: false, orderable: true
+      title: t('admin.evalDashboard.columns.download', 'Download'),
+      data: 'hasDownload',
+      // hasDownload: 'success' | 'partial' | 'fail' | '' (see api/eval/eval-dashboard.js)
+      render: v => {
+        // No GC DS check/half-circle icon, so FA + hidden text alternative
+        if (v === 'success') {
+          return `<span class="text-status--positive"><i class="fa-solid fa-check" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}</span></span>`;
+        }
+        if (v === 'partial') {
+          return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke" style="font-size: 1.4em;" aria-hidden="true"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
+        }
+        return '';
+      },
+      width: '50px', searchable: false, orderable: true
     },
     { title: t('admin.evalDashboard.columns.department', 'Department'), data: 'department', searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.program', 'Program'), data: 'program', render: (v, type, row) => { const d = (lang === 'fr' && row && row.programFr) ? row.programFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: true, orderable: true },

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -142,7 +142,8 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       // hasDownload: 'success' | 'partial' | 'fail' | '' (see api/eval/eval-dashboard.js)
       // TODO: near-duplicate icon+hidden-text markup per branch - a small
       // helper would collapse this (see matching TODO in eval-dashboard.js
-      // about the 3x-duplicated status classification).
+      // about the 3x-duplicated status classification). Deliberately
+      // deferred alongside that TODO - see its comment for why.
       render: v => {
         // No GC DS check/half-circle icon, so FA + hidden text alternative
         if (v === 'success') {
@@ -309,8 +310,12 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
                   try {
                     setLoading(true);
                     setError(null);
-                    const dtOrder = Array.isArray(dtParams.order) && dtParams.order.length > 0 ? dtParams.order[0] : { column: 13, dir: 'desc' };
-                    const orderByMap = ['chatId', 'questionNumber', 'partnerEval', 'aiEval', 'feedback', 'hasDownload', 'department', 'program', 'action', 'referringUrl', 'pageLanguage', 'creatorEmail', 'expertEmail', 'createdAt'];
+                    const dtOrder = Array.isArray(dtParams.order) && dtParams.order.length > 0 ? dtParams.order[0] : { column: columns.length - 1, dir: 'desc' };
+                    // Derived from `columns` (in scope above) rather than hand-listed, so
+                    // inserting/removing a column can't silently desync this mapping from
+                    // the actual column positions. Only the last column's row-data key
+                    // ('date') differs from the backend sort field name ('createdAt').
+                    const orderByMap = columns.map((c) => (c.data === 'date' ? 'createdAt' : c.data));
                     const orderBy = orderByMap[dtOrder.column] || 'createdAt';
                     const orderDir = dtOrder.dir || 'desc';
                     const searchValue = (dtParams.search && dtParams.search.value) || '';

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -18,8 +18,11 @@
    NOT the same as .label.correct/.hasError etc. below: those are bg+text
    pill pairs with their own contrast-tuned hex per background, not a
    duplicate of this text-only set. Prefer these for new plain-text call
-   sites. --warning is #a14b00 (not a GC DS token), matching
-   .label.hasContentIssue's amber; clears 4.5:1 on both backgrounds. */
+   sites. --warning is #915700 (not a GC DS token), matching
+   .label.hasContentIssue's amber; clears 4.5:1 on both white (5.89:1) and
+   the amber pill fill (4.64:1). Was #a14b00 - same contrast tier, but a
+   higher green:red ratio (0.60 vs 0.47) so it reads as orange rather than
+   red/brown at a small icon size. */
 .text-status--positive {
   color: var(--gcds-color-green-700);
 }
@@ -29,7 +32,7 @@
 }
 
 .text-status--warning {
-  color: #a14b00;
+  color: #915700;
 }
 
 .text-status--neutral {
@@ -934,10 +937,12 @@
 
 /* Content issue (amber) — independent per-sentence tag, own colour like
    .label.admin/.clarifying-question/.not-gc/.pt-muni above (no matching
-   GC DS token). #a14b00 clears 4.70:1 on #FFE0B2 (old #e65100 was 2.99:1). */
+   GC DS token). #915700 clears 4.64:1 on #FFE0B2 (old #a14b00 was 4.70:1;
+   #e65100 before that was 2.99:1) - shares .text-status--warning's hex,
+   tuned for a higher green:red ratio so it reads orange, not red/brown. */
 .label.hasContentIssue {
   background-color: #FFE0B2;
-  color: #a14b00;
+  color: #915700;
 }
 
 /* Table summary stats */

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -895,7 +895,8 @@
 
 .label.needsImprovement,
 .label.incomplete,
-.verdict-cell--mixed {
+.verdict-cell--mixed,
+.label.partial {
   background-color: var(--gcds-color-yellow-100);
   color: #7a5a00;
 }


### PR DESCRIPTION
  Add "Partial" status for page downloads

  Previously, a question's citation-download outcome was tracked as a boolean checking only the first downloadWebPage tool call. If a question triggered multiple downloads and some succeeded while others failed, it either read as fully "Succeeded" (eval detail pill, .some() logic) or silently checked only one of several calls (eval dashboard table). This adds a third partial state so mixed outcomes are represented accurately.

  Download status:
  - api/eval/eval-dashboard.js — hasDownload now aggregates over all downloadWebPage calls for an answer, not just the first, returning 'success' |  'partial' | 'fail' | ''. Uses the same localField/foreignField array $lookup shape already proven elsewhere in this pipeline (not a newer sub-pipeline form), and boolean search (yes/no) still works against the new string values.
  - Eval chat view (DownloadPanel.js) — the "Downloaded pages" summary pill now shows Succeeded/Partial/Failed instead of collapsing partial success to  "Succeeded".
  - Eval dashboard table (EvalDashboardPage.js) — Download column shows a checkmark (success), amber half-circle (partial, fa-circle-half-stroke), or X (fail), each with the same aria-hidden-icon + hidden-text pattern.
  - admin.css — .label.partial added to the existing pale-orange/amber pill tier; .text-status--warning/.label.hasContentIssue's amber tuned from #a14b00 to #915700 (same AA contrast on white and on the pill fill, higher green:red ratio so it reads as orange rather than red/brown at icon size).
  - Locale keys reviewPanels.downloadPartial added to en.json/fr.json.

  Content issue pill (found while testing, fixed alongside):
  - api/util/chat-filters.js — added getFeedbackDataProjection(), a shared helper replacing 4 near-identical copy-pasted score/harmful/content-issue projection blocks across eval-dashboard.js and chat-dashboard.js.
  - That dedup surfaced two real bugs: the projection never included sentence1-4ContentIssue at all (so the Content issue pill/filter always evaluated false, in both dashboards), and chat-dashboard.js had a second, separate bug where a downstream inclusion-only $project silently dropped the computed partnerHasContentIssue field before it reached the $group stage. Both fixed.