### PR TITLE
feat: update accessibility, design md skill

### DIFF
--- a/.claude/skills/accessibility-review/SKILL.md
+++ b/.claude/skills/accessibility-review/SKILL.md
@@ -11,23 +11,73 @@ the bar for every finding, not "best practice."
 
 ## Scope
 
-There are three modes. Infer which one from the request; ask if it's
+There are four modes. Infer which one from the request; ask if it's
 ambiguous whether "everything" means the diff or the whole app.
 
 - **Diff review (default)** — `git diff` against the base branch, UI code
   only (`src/pages/`, `src/components/`, `src/hooks/`, CSS). If the diff
   touches only non-UI code (API, services, agents, prompts), say so and skip
-  the review rather than forcing findings.
+  the review rather than forcing findings. **New vs. pre-existing:** an
+  issue in code the diff *adds or changes* is blocking — new features must
+  pass the checklist before merge. An issue in code the diff merely
+  *touches* (a line near the change, but the defect itself predates this
+  PR) is not this PR's job to fix — call it out as a `// TODO(a11y):` (or
+  equivalent tracked note) pointing at the WCAG criterion, rather than
+  blocking the PR on unrelated pre-existing debt, unless the fix is trivial
+  enough to bundle in. Say explicitly which findings are which.
 - **Targeted review** — the user names a specific page/component/route;
   scope to that.
 - **Full app audit** — triggered by phrasing like "audit everything",
-  "whole app", "full accessibility audit", or an explicit `full` arg. Covers
-  every route, not just what changed. See below.
+  "whole app", "full accessibility audit", or an explicit `full` arg, and
+  by named-area shortcuts (see below). Covers every route in scope, not
+  just what changed. See below.
+- **Audit re-verification / update** — triggered by "update the audit",
+  "is this still accurate", "re-check against main", or asking to refresh a
+  previously-published audit artifact. Different task from a full audit and
+  from a diff review — see below. **Do not treat this as "diff review of the
+  audit artifact's own claims."** It must re-examine the actual application
+  code, not just the doc's bookkeeping.
 
 ### Full app audit
 
 This is a large task — confirm scope with the user before starting if it's
 not obvious (e.g. "just public-facing pages, or admin/partner tools too?").
+
+**Named-area shortcuts** — the audit doesn't have to mean literally every
+route; the user can scope it to a named area, checked against
+`roles`/`RoleProtectedRoute` in `src/App.js`:
+
+- **"public chat"** — `HomePage.js` + `src/components/chat/*` only. This
+  area has its own completed, passed audit as of this doc's last update —
+  confirm with the user that they actually want it re-audited (cost) rather
+  than assuming stale.
+- **"auth" / "staff account"** — Login/Register/Logout/ResetRequest/
+  ResetVerify/ResetComplete/About/HowTo/404 — no `roles` restriction on the
+  route itself, but these are **not public-user pages**: this app has no
+  public account system at all. The public only ever interacts
+  anonymously through the chat UI (`HomePage.js` +
+  `src/components/chat/*`, the separate "public chat" area above) — no
+  login, no account. Login/Register/reset-password exist solely for GC
+  staff (admin/partner) accounts; "unauthenticated route" here means
+  "the page you hit *before* staff auth," not "public-facing."
+- **"admin"** — means **everything behind auth**, not just `AdminPage.js`
+  and its immediate children. Every route in `src/App.js` carrying a
+  `roles` array (`['admin']` or `['admin', 'partner']`) is in scope:
+  dashboards, chat/session/batch tooling, eval tooling, admin utility
+  pages, experimental tooling, and the partner-shared pages below. Don't
+  narrow this to literally the admin shell page unless the user says so.
+- **"partner"** — the subset of the above where `roles` includes
+  `'partner'` (e.g. ChatDashboardPage, AdminPage shell, BatchPage,
+  ChatViewer, EvalDashboardPage, PublicEvalPage, Metrics/PublicDashboard/
+  PartnerDashboard/TechnicalMetrics, ScenarioOverridesPage). Partner is a
+  *role*, not a separate set of pages — most partner-visible pages are
+  shared with admin, just narrower (e.g. Users/Settings/Database/Vector/
+  Connectivity/Sessions/AutoEvalDashboard/EvalPage are `['admin']`-only and
+  excluded from a partner-scoped audit).
+- **"experimental"** — `src/pages/experimental/*` + `src/components/experimental/*`.
+
+If none of these match what was asked, fall back to enumerating the full
+surface per step 1 below.
 
 1. Enumerate the surface: read `src/utils/routes.js` for the full
    `ROUTE_SLUGS` list, then map each route to its page component in
@@ -50,6 +100,93 @@ not obvious (e.g. "just public-facing pages, or admin/partner tools too?").
    (a scannable report grouped by page/component with severity, WCAG
    criterion, and fix) rather than a long chat wall of text — offer this,
    don't assume it.
+6. **Propagate confirmed anti-patterns across the whole codebase, not just
+   the file where you found them.** Once a finding is verified as real (not
+   assumed), `grep` the rest of the in-scope surface — and ideally the whole
+   repo, noting anything found outside the requested scope even if it isn't
+   logged as an in-scope finding — for the same code shape before moving on.
+   Example from this app's history: a redundant `tabIndex="0"` on
+   `<GcdsDetails>` (it already renders its own focusable toggle, so this
+   just inserts a dead extra tab stop) was correctly caught in one page but
+   missed in two others using the identical pattern, because each file was
+   reviewed independently with no cross-file pattern search once the bug
+   was confirmed. A per-file line review will not surface this on its own.
+
+### Audit re-verification
+
+Two **separate, independently-triggerable requests**, not one bundled task —
+running both together is expensive and usually more than the user asked for.
+Ask which one is wanted if it's ambiguous ("update the audit" on its own
+usually means Request A only). The failure mode this section guards against
+isn't "not knowing WCAG" — it's silently trusting old conclusions instead of
+rereading the code:
+
+- An "updated" pass once re-verified whether previously-*logged* findings
+  were fixed (checking PR diffs against claim text) but never re-scanned
+  already-in-scope files for genuinely new code that had landed since the
+  last pass — so a new feature added to an already-audited file, one day
+  after the first pass, sat un-flagged through a second pass that claimed
+  to have re-checked that same file.
+- A long-standing, pre-existing behaviour (autosave triggered on every
+  keystroke, no explicit confirm) went unflagged for months across every
+  pass, because no version of the checklist asked the SC 3.2.2 question at
+  all (see the new Forms bullet above) — the file-by-file review had a
+  category-level blind spot, not just a coverage gap. Only Request B below
+  would ever have caught that; Request A cannot, by design.
+
+**Request A — revalidate the work in progress.** Cheaper, faster. Walk the
+existing audit's own scope: every finding it logged (open or fixed) and
+every file/pattern it already tracks. For each, re-verify against current
+`main` — is it still accurate, still open, actually fixed, or has the
+surrounding code moved out from under it? This is bookkeeping hygiene: it
+keeps the existing document honest, but it cannot surface anything the
+original audit never saw in the first place. Trigger phrases: "update the
+audit," "is this still accurate," "re-check the findings against main."
+
+**Request B — recheck the whole audit against changes since it was first
+made.** More expensive, treat it as closer in cost to a fresh full audit.
+Independent of what the audit document says, re-run the actual checklist
+(Sections 1-8) over the audit's full declared scope (every route and shared
+component it claims to cover, per "Full app audit" above), specifically
+targeting what's changed since the audit's first pass: new code added to
+already-covered files (drift — rule 1 below) and categories of problem the
+checklist itself didn't have language for last time (a blind spot doesn't
+show up in a diff, so this can't be scoped to "just the diff" — see rule 2).
+Trigger phrases: "recheck against changes since it started," "full drift
+check," "re-audit for anything new." Confirm with the user before starting
+given the cost, same as a fresh Full app audit.
+
+Rules — apply whichever of A/B was actually requested:
+
+1. **Re-read in-scope file content — don't diff against the audit doc's own
+   claims.** For each file the existing audit covers (findings *and* things
+   marked clean), run `git log --oneline <since-last-audit-date>.. -- <file>`
+   to see if *anything* landed in it since the last pass, independent of
+   whether a tracked PR touched it. If yes, read the current file in full
+   against the whole checklist (Sections 1-8) — not just the lines related
+   to the tracked finding. A file being "already audited" is not a reason to
+   skip new code inside it. (Request B only, since Request A is scoped to
+   already-tracked findings.)
+2. **Don't assume new-looking code is new.** Before writing off a finding
+   as "this is new code that arrived after the audit, not a miss," check
+   when it actually landed (`git log -1 --format=%ad -- <file>` or
+   `git log -S"<anchor string>" -- <file>`) against the audit's own pass
+   dates. Code that landed between two passes — even one day after the
+   first — was in scope for the later pass and should be treated as a
+   miss, not excused as out-of-window.
+3. **Verify claims against current file content, not against whether a
+   tracked PR merged.** "PR #1234 merged" is not proof a specific finding
+   is fixed — re-read the actual lines. PRs get scope trimmed, rebased, or
+   split before landing; a finding attributed to a PR can be absent from
+   what actually merged.
+4. Apply the "propagate confirmed anti-patterns" step from Full app audit
+   above — Request B is exactly when a pattern fixed in one file during the
+   interim is most likely to still be lurking, unflagged, in a sibling file.
+5. Record what was actually re-checked vs. carried forward unverified, per
+   finding — don't let a doc's confidence silently outrun what was actually
+   re-read this pass. State plainly at the end which of A/B this was, so a
+   future pass doesn't mistake a Request A refresh for a full Request B
+   drift check.
 
 ## What to check
 
@@ -105,6 +242,19 @@ commits) — check new code follows it rather than reinventing it:
   announced (see Focus management above), not conveyed by colour alone.
 - Radio/checkbox groups have a group label (`<fieldset>`/`<legend>` or
   `role="group"` + `aria-label`).
+- **Persisted changes need an explicit trigger, not just an announcement.**
+  If typing/selecting alone (no Save/Submit click) commits a change to the
+  server — save-per-keystroke, save-on-blur with no undo — that's a
+  candidate SC 3.2.2 (On Input) failure: a change of state the user didn't
+  explicitly ask for, and nothing in the UI advised them it would happen
+  automatically. This is a **separate finding from SC 4.1.3** (was the
+  change announced?) — an autosave that announces itself perfectly is still
+  a 3.2.2 problem if there's no way to review/confirm before it's
+  committed, and fixing the announcement does not fix this. Flag both
+  independently; don't let one absorb the other. Prefer explicit
+  save-on-demand with dirty-state tracking (stage changes locally, commit
+  on a real Save action) over autosave-on-input for anything consequential
+  (settings, redaction rules, anything hard to undo).
 
 ### 6. Colour & contrast
 - Text and meaningful icons meet 4.5:1 (normal text) / 3:1 (large text, UI

--- a/docs/coding-agent-docs/design-system.md
+++ b/docs/coding-agent-docs/design-system.md
@@ -131,17 +131,21 @@ import { COLOURS, QUALITY_COLOURS } from 'src/constants/dashboardColours.js';
 
 Greys and borders used only for structural layout (not data encoding) may stay local.
 
-## Status/outcome message box styles
+## Status/outcome message states
 
-`StatusMessage` (see AGENTS.md's "Announcing status, errors, and async outcomes") doesn't yet style itself — three GC DS-token box classes in `admin.css` cover this today and should be reused rather than duplicated with a new one-off style:
+`src/components/admin/StatusMessage.js` is the single component every save/delete/import/export/test-run/upload outcome, autosave failure, loading state, or async result should render through (see AGENTS.md's "Announcing status, errors, and async outcomes" for the usage-level API — `message`/`isError`/`loading`/`variant`/`persistent`/`id`). It now has **five built-in states**, each pulling its box styling from GC DS-token classes in `admin.css` — reuse one of these, don't hand-roll a new colour/icon combination for a sixth:
 
-| Class | Tokens | Use |
-|---|---|---|
-| `dashboard-error` | `--gcds-color-red-100/500/700` | Failures |
-| `dashboard-warning-box` | `--gcds-color-yellow-100/500/700` | Cautions (e.g. unsaved changes) |
-| `dashboard-info-box` | `--gcds-color-blue-100/500/700` | Neutral confirmations |
+| State | How to render it | Class | Tokens | Icon | Use |
+|---|---|---|---|---|---|
+| Loading | `<StatusMessage loading message={...} />` | `status-message--loading` | none yet — class exists as a styling hook, no rule defined in any stylesheet | none yet — spinner is a TODO | In-progress state, not a completed result |
+| Error | `<StatusMessage variant="error" message={...} />` | `dashboard-error` | `--gcds-color-red-100/500/700` | `GcdsIcon warning-triangle` | Failures |
+| Warning | `<StatusMessage variant="warning" message={...} />` | `dashboard-warning-box` | `--gcds-color-yellow-100/500/700` | `GcdsIcon warning-triangle` | Cautions (e.g. unsaved changes) |
+| Info | `<StatusMessage variant="info" message={...} />` | `dashboard-info-box` | `--gcds-color-blue-100/500/700` | `GcdsIcon info-circle` | Neutral confirmations |
+| Success | `<StatusMessage variant="success" message={...} />` | `dashboard-success-box` | `--gcds-color-green-100/500/700` | raw `fa-solid fa-check-circle` span (GC DS's icon font has no checkmark glyph, matching the existing precedent in `BatchUpload.js`) | Completed saves |
 
-Each pairs with a `GcdsIcon` (`warning-triangle` for error/warning, `info-circle` for info) passed as `children`, not `message` — the box only renders once there's actual content. `dashboard-error--inline` (`width: fit-content`) keeps a short message from stretching to its container's full width. These are expected to fold into a `variant` prop on `StatusMessage` itself eventually — extend or reuse the three, don't add a fourth. The class names themselves (`dashboard-*`) are also expected to be revised/generalized once more use cases beyond dashboards clarify what the shared naming should actually be — don't treat them as final.
+`variant` builds the icon + text content itself from a plain `message` string — pass `children` instead only when the content is genuinely richer than "icon + one string" (e.g. a follow-up bullet list), in which case you're responsible for your own icon. `isError`/a manual box-modifier `className` still work but are the pre-`variant` calling convention — only still needed for call sites that haven't migrated; use `variant` for anything new. `dashboard-error--inline` (`width: fit-content`) keeps a short error from stretching to its container's full width, composable with `variant="error"` via `className`. `persistent` keeps the live region mounted while empty so a call site's *first* message is announced as a change rather than missed as an insertion — worth reaching for on anything where the first-ever outcome matters (e.g. a page's initial load error).
+
+Two open TODOs on the component itself, not blocking use: the `loading` state has no spinner markup yet (text-only), and a few older call sites still pass their own `style` prop instead of a token-backed `variant` — migrate those to `variant` as they're touched rather than copying the old pattern forward. The whole 5-state system (colours, icon choices, spacing) was built engineering-led, not through a design pass — functional but provisional, per `StatusMessage.js`'s own comments and AGENTS.md.
 
 ## GC DS utility classes
 


### PR DESCRIPTION
Update to skills to improve results:

Artifact updated and republished. Same URL. Summary of the Request B aggregation:

  - 54 open findings now (up from 18): 3 critical, 7 serious, 21 moderate, 11 minor, 12 note.
  - BatchList.js corrected, not just supplemented — was marked "fixed and merged," confirmed still broken (its own unresolved TODO(a11y) says so). This  is the exact scenario the skill's Request A/B split exists to catch.
  - New Shared-problems entry: the nav-wrapper aria-label fix that landed on one experimental page but was left as a TODO comment on three siblings (a  fourth wasn't even TODO'd) — a live example of the propagation gap now written into the skill.
  - Terminology fixed throughout: "Staff account pages," not "public."
  - New methodology paragraph documents exactly what Request A vs. Request B each covered, so a future pass can tell them apart.