### PR TITLE
fix: staff account page accessibility follow-ups

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2005,6 +2005,11 @@
     "message": "We can't find the page you're looking for.",
     "homeLink": "Return to AI Answers"
   },
+  "aboutPage": {
+    "loading": "Loading...",
+    "title": "About",
+    "loadError": "Unable to load content."
+  },
   "experimental": {
     "datasets": {
       "title": "Experimental Datasets",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2005,6 +2005,11 @@
     "message": "Nous ne trouvons pas la page que vous cherchez.",
     "homeLink": "Retourner à Réponses IA"
   },
+  "aboutPage": {
+    "loading": "Chargement...",
+    "title": "À propos",
+    "loadError": "Impossible de charger le contenu."
+  },
   "experimental": {
     "datasets": {
       "title": "Ensembles de données expérimentaux",

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -20,9 +20,11 @@
 import React, { useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useMarkdownWithFrontmatter } from '../hooks/useMarkdownWithFrontmatter.js';
+import { useTranslations } from '../hooks/useTranslations.js';
 import { DCTERMS } from '../config/metadata.js';
 
 const AboutPage = ({ lang = 'en' }) => {
+  const { t } = useTranslations(lang);
   const filename = lang === 'fr' ? 'about-fr.md' : 'about-en.md';
   const { frontmatter, sections, loading, error } = useMarkdownWithFrontmatter(filename);
 
@@ -113,7 +115,7 @@ const AboutPage = ({ lang = 'en' }) => {
   if (loading) {
     return (
       <div className="mb-600 container-custom">
-        <p>{lang === 'fr' ? 'Chargement...' : 'Loading...'}</p>
+        <p>{t('aboutPage.loading')}</p>
       </div>
     );
   }
@@ -122,12 +124,8 @@ const AboutPage = ({ lang = 'en' }) => {
   if (error) {
     return (
       <div className="mb-600 container-custom">
-        <h1>{lang === 'fr' ? 'À propos' : 'About'}</h1>
-        <p>
-          {lang === 'fr'
-            ? 'Impossible de charger le contenu.'
-            : 'Unable to load content.'}
-        </p>
+        <h1>{t('aboutPage.title')}</h1>
+        <p>{t('aboutPage.loadError')}</p>
       </div>
     );
   }
@@ -165,7 +163,7 @@ const AboutPage = ({ lang = 'en' }) => {
 
     {/* Accessibility and Usability Section */}
     {sections[sectionKeys.accessibility] && (
-      <details tabIndex={0}>
+      <details>
         <summary>{sections[sectionKeys.accessibility].heading}</summary>
         <ReactMarkdown
           components={{
@@ -180,7 +178,7 @@ const AboutPage = ({ lang = 'en' }) => {
 
     {/* Privacy & Terms Section */}
     {sections[sectionKeys.privacy] && (
-      <details tabIndex={0}>
+      <details>
         <summary>{sections[sectionKeys.privacy].heading}</summary>
         <ReactMarkdown
           components={{

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -9,6 +9,7 @@ import AnnouncedError from '../components/auth/AnnouncedError.js';
 import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
 import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
 import { normalizeEmail } from '../utils/auth/validateEmail.js';
+import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
 import { GcdsNotice, GcdsText } from '@gcds-core/components-react';
 
 const LoginPage = ({ lang = 'en' }) => {
@@ -66,6 +67,12 @@ const LoginPage = ({ lang = 'en' }) => {
     setError: setTwoStepError,
     clearError: clearTwoStepError,
   } = useAnnouncedError();
+  // The credentials form (and whatever had focus in it) unmounts when the
+  // 2FA view mounts in its place, so focus would otherwise revert to <body>
+  // with no signal to AT users that the view changed. Move focus onto the
+  // new view's intro text — role="status" also announces it as a live
+  // region, matching FeedbackComponent's thank-you-message pattern.
+  const twoStepIntroRef = useFocusOnChange(showTwoStep);
 
   const verifyTwoStep = async () => {
     setIsLoading(true);
@@ -123,7 +130,9 @@ const LoginPage = ({ lang = 'en' }) => {
       {/* When in 2FA flow show only the 2FA UI */}
       {showTwoStep ? (
         <div>
-          <p>{t('login.2fa.sentToEmail')}</p>
+          <p role="status" aria-live="polite" tabIndex={-1} ref={twoStepIntroRef}>
+            {t('login.2fa.sentToEmail')}
+          </p>
           {twoStepError && (
             <AnnouncedError
               id="login-2fa-error"
@@ -134,7 +143,14 @@ const LoginPage = ({ lang = 'en' }) => {
           )}
           <div className="auth-form-group">
             <label htmlFor="code">{t('login.2fa.code')}</label>
-            <input id="code" value={code} onChange={(e) => setCode(e.target.value)} disabled={isLoading} />
+            <input
+              id="code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              disabled={isLoading}
+              aria-describedby={twoStepError ? 'login-2fa-error' : undefined}
+              aria-invalid={!!twoStepError}
+            />
           </div>
           <div>
             <button onClick={verifyTwoStep} disabled={isLoading} className="btn-primary-sm auth-submit-button">

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -72,6 +72,9 @@ const LoginPage = ({ lang = 'en' }) => {
   // with no signal to AT users that the view changed. Move focus onto the
   // new view's intro text — role="status" also announces it as a live
   // region, matching FeedbackComponent's thank-you-message pattern.
+  // NOTE: showTwoStep stays `true` across a resend (requestTwoStep calls
+  // setShowTwoStep(true) again, a no-op), so this effect won't refire then —
+  // don't rely on it to announce resend-specific feedback.
   const twoStepIntroRef = useFocusOnChange(showTwoStep);
 
   const verifyTwoStep = async () => {
@@ -101,13 +104,13 @@ const LoginPage = ({ lang = 'en' }) => {
   const requestTwoStep = async () => {
     if (!email) return;
     setIsLoading(true);
-    clearError();
+    clearTwoStepError();
     try {
       // backend method remains send2FA
       await AuthService.send2FA(email);
       setShowTwoStep(true);
     } catch (err) {
-      setError(t('login.2fa.sendError'));
+      setTwoStepError(t('login.2fa.sendError'));
     } finally {
       setIsLoading(false);
     }
@@ -130,7 +133,7 @@ const LoginPage = ({ lang = 'en' }) => {
       {/* When in 2FA flow show only the 2FA UI */}
       {showTwoStep ? (
         <div>
-          <p role="status" aria-live="polite" tabIndex={-1} ref={twoStepIntroRef}>
+          <p role="status" tabIndex={-1} ref={twoStepIntroRef}>
             {t('login.2fa.sentToEmail')}
           </p>
           {twoStepError && (

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -67,7 +67,7 @@ const ResetCompletePage = ({ lang = 'en' }) => {
       {error && (
         <AnnouncedError id="reset-complete-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={submit}>
+      <form onSubmit={submit} noValidate>
         {/* No code/OTP field — link verification is sufficient to set a new password */}
         <PasswordInput
           id="password"

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -5,7 +5,7 @@ import AuthService from '../services/AuthService.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
-import { useAnnouncedError } from '../hooks/auth/useAnnouncedError.js';
+import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
 
 const ResetCompletePage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -15,7 +15,7 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
-  const { error, errorCount, errorRef, setError, clearError } = useAnnouncedError();
+  const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
@@ -29,12 +29,15 @@ const ResetCompletePage = ({ lang = 'en' }) => {
     e && e.preventDefault();
     setSuccessMessage('');
     clearError();
-    if (!password || password.length < 8) {
-      setError(t('reset.complete.passwordTooShort'));
+    if (!validate({ password, confirm }, t)) {
+      return;
+    }
+    if (password.length < 8) {
+      setError(t('reset.complete.passwordTooShort'), ['password']);
       return;
     }
     if (password !== confirm) {
-      setError(t('reset.complete.passwordMismatch'));
+      setError(t('reset.complete.passwordMismatch'), ['password', 'confirm']);
       return;
     }
     setIsLoading(true);
@@ -79,7 +82,7 @@ const ResetCompletePage = ({ lang = 'en' }) => {
           disabled={isLoading}
           autoComplete="new-password"
           ariaDescribedBy={error ? 'reset-complete-error' : undefined}
-          ariaInvalid={!!error}
+          ariaInvalid={isFieldInvalid('password')}
           lang={lang}
         />
         <PasswordInput
@@ -92,7 +95,7 @@ const ResetCompletePage = ({ lang = 'en' }) => {
           disabled={isLoading}
           autoComplete="new-password"
           ariaDescribedBy={error ? 'reset-complete-error' : undefined}
-          ariaInvalid={!!error}
+          ariaInvalid={isFieldInvalid('confirm')}
           lang={lang}
         />
 


### PR DESCRIPTION
  fix: staff account page accessibility follow-ups

  - LoginPage: move focus into the 2FA view on transition (was dropping to
    <body> with no AT announcement); wire aria-describedby/aria-invalid on
    the 2FA code input to twoStepError
  - AboutPage: drop redundant tabIndex={0} on <details>; route loading/error
    fallback text through t() instead of inline lang ternaries
  - ResetCompletePage: add noValidate to the password form so validation
    errors go through the AnnouncedError pattern instead of the browser's
    native popup