### PR TITLE
Fix/admin-page-a11y

### DIFF
--- a/src/components/DeleteExpertEval.js
+++ b/src/components/DeleteExpertEval.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import EvaluationService from '../services/EvaluationService.js';
 import DeleteByChatIdSection from './admin/DeleteByChatIdSection.js';
+import { formatNumber } from '../utils/numberFormat.js';
 
 const DeleteExpertEval = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -11,11 +12,12 @@ const DeleteExpertEval = ({ lang = 'en' }) => {
       const data = await EvaluationService.deleteExpertEval(chatId);
       if (data.deletedCount > 0) {
         // data.message is server-built, untranslated English text — use the
-        // translated key instead. deletedCount/chatId are a number and a
-        // UUID-validated string, so plain replace is safe here (no `$` risk
-        // like raw exception text below).
+        // translated key instead. chatId is a UUID-validated string (no `$`
+        // risk like raw exception text below); the count goes through
+        // formatNumber per AGENTS.md — French/English format numbers
+        // differently, even a small one like this.
         const text = t('admin.deleteExpertEval.success')
-          .replace('{count}', data.deletedCount)
+          .replace('{count}', formatNumber(data.deletedCount, lang))
           .replace('{chatId}', chatId);
         return { isError: false, text };
       }
@@ -34,6 +36,19 @@ const DeleteExpertEval = ({ lang = 'en' }) => {
       // admin would otherwise hear it announced as French). Split the
       // translated template around the placeholder instead, so the detail
       // can be wrapped in its own lang="en" span (mirrors DeleteChatSection.js).
+      //
+      // TODO (Official Languages): this treats every failure here as
+      // unbounded free text, but the 404 race case specifically (the
+      // pre-check passed, then the chat was deleted before this call
+      // completed — EvaluationService.deleteExpertEval throws 'Chat not
+      // found.' for that, services/EvaluationService.js:89) is actually a
+      // known, bounded outcome and could be a real translated key instead
+      // of a lang="en"-wrapped English string — same reasoning as
+      // admin.deleteExpertEval.notEvaluated just above. Needs the backend
+      // to return a stable error code (not just message text) so this catch
+      // block can tell that case apart from a genuinely unbounded failure
+      // (network drop, unexpected 500). Not done: touches both layers plus
+      // a test rewrite, not just this file — see PR discussion.
       const [prefix, suffix] = t('admin.deleteExpertEval.error').split('{message}');
       return { isError: true, prefix, detail: <span lang="en">{err.message || String(err)}</span>, suffix };
     }
@@ -48,6 +63,12 @@ const DeleteExpertEval = ({ lang = 'en' }) => {
       loadingLabelKey="admin.deleteExpertEval.loading"
       fieldId="expertEvalChatId"
       onDelete={handleDelete}
+      // The chat existing isn't this consumer's real precondition — it can
+      // exist with zero expert feedback. getChat()'s response already fully
+      // populates expertFeedback per interaction (db-chat.js), so this
+      // checks the thing that actually matters, from data already fetched.
+      validateChat={(chat) => chat.interactions?.some((i) => i.expertFeedback)}
+      invalidChatMessageKey="admin.deleteExpertEval.notEvaluated"
     />
   );
 };

--- a/src/components/DeleteExpertEval.js
+++ b/src/components/DeleteExpertEval.js
@@ -1,95 +1,54 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslations } from '../hooks/useTranslations.js';
-import { GcdsButton } from '@gcds-core/components-react';
 import EvaluationService from '../services/EvaluationService.js';
-import StatusMessage from './admin/StatusMessage.js';
+import DeleteByChatIdSection from './admin/DeleteByChatIdSection.js';
 
 const DeleteExpertEval = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
-  const [chatId, setChatId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [resultMsg, setResultMsg] = useState(null);
 
-  const handleInputChange = (event) => {
-    const value = event?.target?.value || '';
-    setChatId(value);
-    // A stale success/error message from the last delete describes an
-    // action the admin is no longer taking, once they've started typing a
-    // new chat ID — same reasoning as SettingsPage.js's stageChange
-    // clearing a section's stale save-outcome message on edit.
-    setResultMsg(null);
-  };
-
-  const handleDelete = async (e) => {
-    e.preventDefault();
-    if (!chatId.trim()) return;
-    if (!window.confirm(t('common.confirmDelete'))) return;
-
-    setLoading(true);
-    setResultMsg(null);
+  const handleDelete = async (chatId) => {
     try {
       const data = await EvaluationService.deleteExpertEval(chatId);
       if (data.deletedCount > 0) {
-        setResultMsg({ type: 'success', message: data.message });
-      } else {
-        // The API returns 200 with deletedCount: 0 when the chat exists but
-        // had nothing to delete (no interactions, or none with expert
-        // feedback) — not a network/server failure, but from the admin's
-        // point of view it's the same as "failed to delete an expert
-        // evaluation" (there wasn't one), so it's announced the same way as
-        // the catch block below, same as DeleteChatSection.js's pattern.
-        // "Not evaluated" is a known, translated reason (not raw exception
-        // text), so — unlike the catch block — it doesn't need a lang="en"
-        // wrapper.
-        const [prefix, suffix] = t('admin.deleteExpertEval.error').split('{message}');
-        setResultMsg({ type: 'error', prefix, suffix, detail: t('admin.deleteExpertEval.notEvaluated') });
+        // data.message is server-built, untranslated English text — use the
+        // translated key instead. deletedCount/chatId are a number and a
+        // UUID-validated string, so plain replace is safe here (no `$` risk
+        // like raw exception text below).
+        const text = t('admin.deleteExpertEval.success')
+          .replace('{count}', data.deletedCount)
+          .replace('{chatId}', chatId);
+        return { isError: false, text };
       }
-      setChatId('');
+      // The API returns 200 with deletedCount: 0 when the chat exists but
+      // had nothing to delete (no interactions, or none with expert
+      // feedback) — not a network/server failure, but from the admin's
+      // point of view it's the same as "failed to delete an expert
+      // evaluation" (there wasn't one). "Not evaluated" is a known,
+      // translated reason (not raw exception text), so — unlike the catch
+      // block below — it doesn't need a lang="en" wrapper.
+      const [prefix, suffix] = t('admin.deleteExpertEval.error').split('{message}');
+      return { isError: true, prefix, detail: t('admin.deleteExpertEval.notEvaluated'), suffix };
     } catch (err) {
       // err.message is raw, untranslated exception text — never run it
       // through the {message} template as a plain string substitution (a FR
       // admin would otherwise hear it announced as French). Split the
       // translated template around the placeholder instead, so the detail
-      // can be wrapped in its own lang="en" span below (mirrors
-      // DeleteChatSection.js).
+      // can be wrapped in its own lang="en" span (mirrors DeleteChatSection.js).
       const [prefix, suffix] = t('admin.deleteExpertEval.error').split('{message}');
-      setResultMsg({ type: 'error', prefix, suffix, detail: <span lang="en">{err.message || String(err)}</span> });
-    } finally {
-      setLoading(false);
+      return { isError: true, prefix, detail: <span lang="en">{err.message || String(err)}</span>, suffix };
     }
   };
 
   return (
-    <div className="bg-white shadow rounded-lg p-4">
-      <h2 className="mt-400 mb-400">{t('admin.deleteExpertEval.title')}</h2>
-      <div className="flex gap-400">
-        <input
-          type="text"
-          id="expertEvalChatId"
-          className="form-control"
-          value={chatId}
-          onChange={handleInputChange}
-          placeholder={t('admin.deleteExpertEval.idLabel')}
-          disabled={loading}
-          required
-        />
-        <GcdsButton
-          onClick={handleDelete}
-          buttonRole="danger"
-          disabled={loading || !chatId.trim()}
-          className="me-400 hydrated mrgn-tp-1r"
-        >
-          {loading ? t('admin.deleteExpertEval.loading') : t('admin.deleteExpertEval.button')}
-        </GcdsButton>
-      </div>
-      {resultMsg?.type === 'error' ? (
-        <StatusMessage variant="error">
-          {resultMsg.prefix}{resultMsg.detail}{resultMsg.suffix}
-        </StatusMessage>
-      ) : (
-        <StatusMessage variant={resultMsg?.type} message={resultMsg?.message} />
-      )}
-    </div>
+    <DeleteByChatIdSection
+      lang={lang}
+      titleKey="admin.deleteExpertEval.title"
+      idLabelKey="admin.deleteExpertEval.idLabel"
+      buttonLabelKey="admin.deleteExpertEval.button"
+      loadingLabelKey="admin.deleteExpertEval.loading"
+      fieldId="expertEvalChatId"
+      onDelete={handleDelete}
+    />
   );
 };
 

--- a/src/components/__tests__/DeleteExpertEval.test.js
+++ b/src/components/__tests__/DeleteExpertEval.test.js
@@ -13,7 +13,7 @@ const TRANSLATIONS = {
   'admin.deleteExpertEval.loading': 'Deleting...',
   'admin.deleteExpertEval.error': 'Failed to delete expert evaluation: {message}',
   'admin.deleteExpertEval.notEvaluated': 'Not evaluated.',
-  'admin.deleteExpertEval.success': 'Deleted {count} expert feedback record(s) for {chatId}',
+  'admin.deleteExpertEval.success': 'Deleted {count} expert feedback record(s) for {chatId}.',
   'common.confirmDelete': 'Are you sure you want to delete this data?',
 };
 const mockT = (key) => TRANSLATIONS[key] || key;
@@ -59,8 +59,12 @@ describe('DeleteExpertEval error/success announcements', () => {
   };
 
   // Every "delete proceeds" test needs the existence pre-check to resolve as
-  // found first, or it never reaches window.confirm()/onDelete at all.
-  const chatExists = () => mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
+  // found *and* have expert feedback (validateChat's real precondition for
+  // this consumer — see DeleteExpertEval.js), or it never reaches
+  // window.confirm()/onDelete at all.
+  const chatExists = () => mockGetChat.mockResolvedValue({
+    chat: { chatId: VALID_CHAT_ID, interactions: [{ expertFeedback: { id: 'ef1' } }] },
+  });
 
   it('asks for confirmation via window.confirm before deleting', async () => {
     chatExists();
@@ -99,7 +103,7 @@ describe('DeleteExpertEval error/success announcements', () => {
     // `persistent` prop / this PR's a11y fix), so findByRole('status') would
     // resolve to the still-empty region before the delete result lands —
     // wait for the actual text instead.
-    const status = await screen.findByText(`Deleted 1 expert feedback record(s) for ${VALID_CHAT_ID}`);
+    const status = await screen.findByText(`Deleted 1 expert feedback record(s) for ${VALID_CHAT_ID}.`);
     expect(status.closest('[role="status"]')).not.toBeNull();
     expect(status.closest('.status-message--success-box')).not.toBeNull();
     expect(screen.queryByRole('alert')).toBeNull();
@@ -177,8 +181,40 @@ describe('DeleteExpertEval error/success announcements', () => {
     startDelete();
 
     await waitFor(() => {
-      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
+      expect(screen.getByText('admin.common.chatNotFound')).toBeTruthy();
     });
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockDeleteExpertEval).not.toHaveBeenCalled();
+  });
+
+  it('shows "not evaluated" and skips the confirm dialog when the chat exists but has no expert feedback', async () => {
+    // The real precondition for this consumer isn't "does the chat exist"
+    // (a chat can exist with zero expert feedback) — validateChat checks
+    // the actual thing, from the same getChat() response, no second request.
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID, interactions: [{ question: 'q' }] } });
+
+    render(<DeleteExpertEval lang="en" />);
+    startDelete();
+
+    await waitFor(() => {
+      expect(screen.getByText('Not evaluated.')).toBeTruthy();
+    });
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockDeleteExpertEval).not.toHaveBeenCalled();
+  });
+
+  it('shows a distinct "lookup failed" message, not "not found", when the existence check itself fails', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    mockGetChat.mockRejectedValue(new Error('Failed to fetch'));
+
+    render(<DeleteExpertEval lang="en" />);
+    startDelete();
+
+    await waitFor(() => {
+      expect(screen.getByText('admin.common.fetchFailed')).toBeTruthy();
+    });
+    expect(screen.queryByText('admin.common.chatNotFound')).toBeNull();
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(mockDeleteExpertEval).not.toHaveBeenCalled();
   });

--- a/src/components/__tests__/DeleteExpertEval.test.js
+++ b/src/components/__tests__/DeleteExpertEval.test.js
@@ -3,7 +3,7 @@
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import DeleteExpertEval from '../DeleteExpertEval.js';
 
 const TRANSLATIONS = {
@@ -13,6 +13,7 @@ const TRANSLATIONS = {
   'admin.deleteExpertEval.loading': 'Deleting...',
   'admin.deleteExpertEval.error': 'Failed to delete expert evaluation: {message}',
   'admin.deleteExpertEval.notEvaluated': 'Not evaluated.',
+  'admin.deleteExpertEval.success': 'Deleted {count} expert feedback record(s) for {chatId}',
   'common.confirmDelete': 'Are you sure you want to delete this data?',
 };
 const mockT = (key) => TRANSLATIONS[key] || key;
@@ -20,10 +21,22 @@ vi.mock('../../hooks/useTranslations.js', () => ({
   useTranslations: () => ({ t: mockT }),
 }));
 
-const { mockDeleteExpertEval } = vi.hoisted(() => ({ mockDeleteExpertEval: vi.fn() }));
+const { mockDeleteExpertEval, mockGetChat } = vi.hoisted(() => ({
+  mockDeleteExpertEval: vi.fn(),
+  mockGetChat: vi.fn(),
+}));
 vi.mock('../../services/EvaluationService.js', () => ({
   default: { deleteExpertEval: mockDeleteExpertEval },
 }));
+vi.mock('../../services/DataStoreService.js', () => ({
+  default: { getChat: mockGetChat },
+}));
+
+// A well-formed chat ID (matches isValidChatIdFormat's uuidv4 pattern) -
+// DeleteByChatIdSection.js now confirms the chat exists (DataStoreService
+// .getChat) before the confirm dialog, so every test below needs both a
+// syntactically valid ID and a resolved getChat mock, not just deleteExpertEval.
+const VALID_CHAT_ID = 'abcdef12-3456-4789-8abc-def012345678';
 
 vi.mock('@gcds-core/components-react', () => ({
   GcdsButton: ({ children, onClick, disabled }) => (
@@ -36,49 +49,65 @@ describe('DeleteExpertEval error/success announcements', () => {
   afterEach(() => {
     cleanup();
     mockDeleteExpertEval.mockReset();
+    mockGetChat.mockReset();
     vi.restoreAllMocks();
   });
 
-  const startDelete = () => {
-    fireEvent.change(screen.getByPlaceholderText('Chat ID'), { target: { value: 'abc123' } });
+  const startDelete = (chatId = VALID_CHAT_ID) => {
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: chatId } });
     fireEvent.click(screen.getByText('Delete expert evaluation'));
   };
 
+  // Every "delete proceeds" test needs the existence pre-check to resolve as
+  // found first, or it never reaches window.confirm()/onDelete at all.
+  const chatExists = () => mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
+
   it('asks for confirmation via window.confirm before deleting', async () => {
+    chatExists();
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockDeleteExpertEval.mockResolvedValue({ message: 'Deleted 1 expert feedback(s) for chat abc123', deletedCount: 1 });
 
     render(<DeleteExpertEval lang="en" />);
     startDelete();
 
-    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete this data?');
-    await screen.findByRole('status');
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete this data?'));
   });
 
-  it('does not delete when the confirmation dialog is cancelled', () => {
+  it('does not delete when the confirmation dialog is cancelled', async () => {
+    chatExists();
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
 
     render(<DeleteExpertEval lang="en" />);
     startDelete();
 
-    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
     expect(mockDeleteExpertEval).not.toHaveBeenCalled();
   });
 
-  it('announces a successful delete (deletedCount > 0) as role="status"', async () => {
+  it('announces a successful delete (deletedCount > 0) as role="status", using the translated key not the raw API message', async () => {
+    chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // data.message is server-built, untranslated English text (kept in the
+    // response for logging) — the component must display the translated
+    // admin.deleteExpertEval.success key instead, not this raw string.
     mockDeleteExpertEval.mockResolvedValue({ message: 'Deleted 1 expert feedback(s) for chat abc123', deletedCount: 1 });
 
     render(<DeleteExpertEval lang="en" />);
     startDelete();
 
-    const status = await screen.findByRole('status');
-    expect(status.textContent).toContain('Deleted 1 expert feedback(s) for chat abc123');
-    expect(status.className).toContain('status-message--success-box');
+    // The status region is now persistently mounted (see StatusMessage's
+    // `persistent` prop / this PR's a11y fix), so findByRole('status') would
+    // resolve to the still-empty region before the delete result lands —
+    // wait for the actual text instead.
+    const status = await screen.findByText(`Deleted 1 expert feedback record(s) for ${VALID_CHAT_ID}`);
+    expect(status.closest('[role="status"]')).not.toBeNull();
+    expect(status.closest('.status-message--success-box')).not.toBeNull();
     expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByText('Deleted 1 expert feedback(s) for chat abc123')).toBeNull();
   });
 
   it('treats deletedCount: 0 as an error ("Not evaluated"), not a success', async () => {
+    chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockDeleteExpertEval.mockResolvedValue({ message: 'Deleted 0 expert feedback(s) for chat abc123', deletedCount: 0 });
 
@@ -92,11 +121,15 @@ describe('DeleteExpertEval error/success announcements', () => {
     expect(alert.querySelector('span[lang="en"]')).toBeNull();
   });
 
-  it('announces a chat that doesn\'t exist (API 404 "Chat not found") in a lang="en" span, inside role="alert"', async () => {
+  it('announces a chat deleted between the existence check and the delete call (server-side 404 race) in a lang="en" span, inside role="alert"', async () => {
+    // The existence pre-check found it, but the actual delete call still
+    // fails server-side (e.g. the chat was removed in the gap between the
+    // two requests) — EvaluationService.deleteExpertEval throws for the
+    // API's 404 the same way (services/EvaluationService.js:89, `{ error:
+    // 'Chat not found', status: 404 }`), so DeleteExpertEval.js's own catch
+    // block still needs to handle it, pre-check or not.
+    chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
-    // Mirrors what EvaluationService.deleteExpertEval actually throws when
-    // the API returns 404 — services/EvaluationService.js:89, `{ error:
-    // 'Chat not found', status: 404 }` — not a generic network failure.
     mockDeleteExpertEval.mockRejectedValue(new Error('Chat not found'));
 
     render(<DeleteExpertEval lang="fr" />);
@@ -111,6 +144,7 @@ describe('DeleteExpertEval error/success announcements', () => {
   });
 
   it('wraps a generic network/server error in a lang="en" span too', async () => {
+    chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockDeleteExpertEval.mockRejectedValue(new Error('Failed to fetch'));
 
@@ -123,6 +157,7 @@ describe('DeleteExpertEval error/success announcements', () => {
   });
 
   it('clears a stale result message as soon as the admin edits the chat ID again', async () => {
+    chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockDeleteExpertEval.mockRejectedValue(new Error('Chat not found'));
 
@@ -130,7 +165,33 @@ describe('DeleteExpertEval error/success announcements', () => {
     startDelete();
     await screen.findByRole('alert');
 
-    fireEvent.change(screen.getByPlaceholderText('Chat ID'), { target: { value: 'def456' } });
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID.replace('a', 'b') } });
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('shows "not found" and skips the confirm dialog when the chat does not exist', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    mockGetChat.mockResolvedValue({ chat: null });
+
+    render(<DeleteExpertEval lang="en" />);
+    startDelete();
+
+    await waitFor(() => {
+      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
+    });
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockDeleteExpertEval).not.toHaveBeenCalled();
+  });
+
+  it('flags a malformed chat ID as an inline error instead of looking it up', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+
+    render(<DeleteExpertEval lang="en" />);
+    startDelete('not-a-real-id');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('admin.viewChat.invalidFormat');
+    expect(mockGetChat).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/admin/ChatIdLookupField.js
+++ b/src/components/admin/ChatIdLookupField.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { GcdsButton } from '@gcds-core/components-react';
+import FeedbackInlineError from '../chat/FeedbackInlineError.js';
+
+// Shared label + input + submit button for a "do something with this chat
+// ID" form — the part that's identical across ViewChatByIdSection.js/
+// DeleteChatSection.js/DeleteExpertEval.js. What differs between them
+// (the expand/collapse wrapper, the submit handler, the button's role/
+// text, whether a result gets shown afterward) stays owned by each caller,
+// not bundled in here — purely presentational, no state of its own.
+//
+// className="filter-input" (not "form-control", which isn't real GC DS
+// styling in this project — see admin.css's own comment on .filter-input
+// mirroring GcdsInput's shadow-DOM border/focus tokens).
+const ChatIdLookupField = ({
+  fieldId,
+  label,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  hasError,
+  errorMessage,
+  errorCount,
+  errorRef,
+  buttonRole,
+  buttonLabel,
+  // Every caller's visible label is the same text ("Chat ID") — three
+  // identical accessible names for three different-purpose fields (view a
+  // chat vs. delete a chat vs. delete an expert eval). A sighted user, or
+  // someone reading the page linearly, gets context from the field's own
+  // <summary> right above it; someone using a screen reader's "list all
+  // form fields" navigation mode doesn't. `describedById` points at the
+  // caller's own <summary id>, adding that context to the accessible
+  // *description* (not the name, which stays plain "Chat ID" — see
+  // SC 2.5.3 Label in Name).
+  describedById,
+}) => {
+  const errorId = `${fieldId}-error`;
+  const describedBy = [describedById, hasError && errorId].filter(Boolean).join(' ') || undefined;
+  return (
+    <>
+      <label htmlFor={fieldId} className="filter-label display-block">
+        {label}
+      </label>
+      {hasError && (
+        <FeedbackInlineError
+          id={errorId}
+          message={errorMessage}
+          errorCount={errorCount}
+          inputRef={errorRef}
+        />
+      )}
+      <div className="chat-id-lookup-field">
+        <input
+          type="text"
+          id={fieldId}
+          className="filter-input"
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          aria-required="true"
+          aria-describedby={describedBy}
+        />
+      </div>
+      <GcdsButton type="submit" buttonRole={buttonRole} disabled={disabled} className="mt-200 mb-300">
+        {buttonLabel}
+      </GcdsButton>
+    </>
+  );
+};
+
+export default ChatIdLookupField;

--- a/src/components/admin/ChatLogsDashboard.js
+++ b/src/components/admin/ChatLogsDashboard.js
@@ -157,7 +157,7 @@ const ChatLogsDashboard = ({ lang = 'en' }) => {
           <div className="export-controls bg-white shadow rounded-lg p-4 mb-600">
             <p className="mrgn-bttm-md">{t('admin.chatLogs.exportDescription')}</p>
 
-            <div className="flex items-center gap-4 flex-wrap">
+            <div className="export-controls-row">
               {/* View Dropdown */}
               <div className="export-control-group">
                 <label htmlFor="export-view" className="filter-label">

--- a/src/components/admin/DeleteByChatIdSection.js
+++ b/src/components/admin/DeleteByChatIdSection.js
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { useTranslations } from '../../hooks/useTranslations.js';
+import DataStoreService from '../../services/DataStoreService.js';
+import StatusMessage from './StatusMessage.js';
+import { useInlineFormError } from '../../hooks/useInlineFormError.js';
+import { isValidChatIdFormat } from '../../utils/admin/chatIdFormat.js';
+import ChatIdLookupField from './ChatIdLookupField.js';
+
+// Shared "delete something by chat ID" row: one <details>/summary/form/
+// status shell, reused by DeleteChatSection.js (deletes the whole chat) and
+// DeleteExpertEval.js (deletes just its expert evaluation) - these two only
+// ever differed in which service call runs and what the button/summary
+// text says, never in layout, validation, or status-message handling.
+// Hand-duplicating that shell across two files is exactly what silently
+// drifts over time (one gets tweaked, the other doesn't) - one shared
+// component makes that impossible instead of something to keep checking.
+// Both are rows in AdminPage.js's shared "View and delete chats by ID"
+// section (its own h2) - collapsed by default, summary text is this row's
+// only label, no separate heading here.
+//
+// onDelete(chatId) contract: resolves to { isError: false, text } for a
+// plain success message, or { isError: true, prefix, detail, suffix } for
+// StatusMessage's split-template treatment (see AGENTS.md's
+// admin.common.fetchError pattern) - `detail` is a ReactNode the *caller*
+// has already decided whether to wrap in lang="en": raw exception text
+// needs it, an already-translated reason (e.g. "Not evaluated") doesn't.
+const DeleteByChatIdSection = ({
+  lang = 'en',
+  titleKey,
+  idLabelKey,
+  buttonLabelKey,
+  loadingLabelKey,
+  fieldId,
+  onDelete,
+}) => {
+  const { t } = useTranslations(lang);
+  const [chatId, setChatId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState(null);
+  // Same split as ViewChatByIdSection.js: "empty" and "invalid format" are
+  // pre-submit, client-side field validation (this inline slot, message
+  // varies by which one failed); "not found" is a genuine server-lookup
+  // outcome, so it stays a StatusMessage instead.
+  const [inlineErrorMessage, setInlineErrorMessage] = useState('');
+  const { hasError, errorCount, errorRef, triggerError, clearError } = useInlineFormError();
+
+  const handleInputChange = (event) => {
+    const value = event?.target?.value || '';
+    setChatId(value);
+    clearError();
+    // A stale success/error message from the last delete describes an
+    // action the admin is no longer taking, once they've started typing a
+    // new chat ID — same reasoning as SettingsPage.js's stageChange
+    // clearing a section's stale save-outcome message on edit.
+    setStatus(null);
+  };
+
+  // Closing this row means "I'm done here" — reset it fully (typed ID
+  // included, not just the status message) so reopening it later starts
+  // clean rather than picking up wherever it was left. Native <details>
+  // fires `toggle` for both directions; clearing on open too is a harmless
+  // no-op (already empty from the close that necessarily preceded it).
+  const handleToggle = () => {
+    setChatId('');
+    clearError();
+    setStatus(null);
+  };
+
+  const handleDelete = async (e) => {
+    e.preventDefault();
+    const trimmed = chatId.trim();
+    if (!trimmed) {
+      setInlineErrorMessage(t('admin.common.chatIdRequired'));
+      triggerError();
+      return;
+    }
+    // Format check next, no round trip needed — same reasoning as
+    // ViewChatByIdSection.js: a value that isn't even shaped like a chat ID
+    // is a real input error, distinct from a well-formed ID that just
+    // doesn't match anything (the "not found" StatusMessage below).
+    // Without this, a malformed ID fell through to the existence check and
+    // came back indistinguishable from a real "not found" result.
+    if (!isValidChatIdFormat(trimmed)) {
+      setInlineErrorMessage(t('admin.viewChat.invalidFormat'));
+      triggerError();
+      return;
+    }
+
+    setLoading(true);
+    setStatus(null);
+    // Confirm the chat actually exists before asking the admin to confirm a
+    // delete that's about to fail anyway — same existence check
+    // ViewChatByIdSection.js uses (DataStoreService.getChat, the same
+    // db-chat.js route), same "not found" wording, so a chat ID that
+    // doesn't exist goes straight to that message instead of a confirm
+    // dialog for nothing.
+    try {
+      const data = await DataStoreService.getChat(trimmed);
+      if (!data?.chat) {
+        setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
+        setLoading(false);
+        return;
+      }
+    } catch (err) {
+      // getChat's own catch collapses a genuine 404 and a network/server
+      // failure into the same thrown Error (see DataStoreService.getChat) -
+      // not distinguishable from here, same as ViewChatByIdSection.js: both
+      // read as "not found" rather than misreporting a real outage as this.
+      setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
+      setLoading(false);
+      return;
+    }
+
+    // window.confirm() kept for now (native, blocking) - not part of this
+    // pass's scope, see AdminPage.js redesign discussion.
+    if (!window.confirm(t('common.confirmDelete'))) {
+      setLoading(false);
+      return;
+    }
+
+    const result = await onDelete(trimmed);
+    setStatus(result);
+    if (!result.isError) setChatId('');
+    setLoading(false);
+  };
+
+  return (
+    <details onToggle={handleToggle}>
+      <summary id={`${fieldId}-summary`}>{t(titleKey)}</summary>
+      <div className="mt-200">
+        <form onSubmit={handleDelete}>
+          <ChatIdLookupField
+            fieldId={fieldId}
+            label={t(idLabelKey)}
+            placeholder={t('admin.common.chatIdPlaceholder')}
+            value={chatId}
+            onChange={handleInputChange}
+            disabled={loading}
+            hasError={hasError}
+            errorMessage={inlineErrorMessage}
+            errorCount={errorCount}
+            errorRef={errorRef}
+            buttonRole="danger"
+            buttonLabel={loading ? t(loadingLabelKey) : t(buttonLabelKey)}
+            describedById={`${fieldId}-summary`}
+          />
+        </form>
+        {status?.variant === 'info' ? (
+          // "Not found" — a genuine server-lookup outcome, not an error.
+          <StatusMessage variant="info" message={status.text} persistent />
+        ) : status?.isError ? (
+          // variant="error" + children (not `message`): the <span lang="en">
+          // wrapper a raw exception detail needs (see onDelete's own
+          // comment) can't go inside a plain message string. StatusMessage
+          // adds its own icon automatically either way (see its own
+          // resolveLook comment) — this doesn't need to render one itself.
+          <StatusMessage variant="error" persistent>
+            {status.prefix}{status.detail}{status.suffix}
+          </StatusMessage>
+        ) : (
+          <StatusMessage variant={status?.text ? 'success' : undefined} message={status?.text} persistent />
+        )}
+      </div>
+    </details>
+  );
+};
+
+export default DeleteByChatIdSection;

--- a/src/components/admin/DeleteByChatIdSection.js
+++ b/src/components/admin/DeleteByChatIdSection.js
@@ -1,10 +1,7 @@
-import React, { useState } from 'react';
-import { useTranslations } from '../../hooks/useTranslations.js';
-import DataStoreService from '../../services/DataStoreService.js';
+import React from 'react';
 import StatusMessage from './StatusMessage.js';
-import { useInlineFormError } from '../../hooks/useInlineFormError.js';
-import { isValidChatIdFormat } from '../../utils/admin/chatIdFormat.js';
 import ChatIdLookupField from './ChatIdLookupField.js';
+import { useChatIdLookup } from '../../hooks/admin/useChatIdLookup.js';
 
 // Shared "delete something by chat ID" row: one <details>/summary/form/
 // status shell, reused by DeleteChatSection.js (deletes the whole chat) and
@@ -17,6 +14,12 @@ import ChatIdLookupField from './ChatIdLookupField.js';
 // Both are rows in AdminPage.js's shared "View and delete chats by ID"
 // section (its own h2) - collapsed by default, summary text is this row's
 // only label, no separate heading here.
+//
+// The validate/existence-check logic itself (format check, getChat,
+// validateChat) lives in useChatIdLookup.js, shared with ViewChatByIdSection.js
+// too — that one doesn't go through this component because viewing isn't
+// destructive and shouldn't get a delete-style confirm() dialog; only the
+// pre-confirm checks are actually identical between the two.
 //
 // onDelete(chatId) contract: resolves to { isError: false, text } for a
 // plain success message, or { isError: true, prefix, detail, suffix } for
@@ -32,84 +35,36 @@ const DeleteByChatIdSection = ({
   loadingLabelKey,
   fieldId,
   onDelete,
+  // The chat existing is DeleteChatSection.js's whole precondition, but not
+  // every consumer's — DeleteExpertEval.js's real precondition is "does this
+  // chat have expert feedback", which a plain existence check can't express
+  // (a chat can exist with none). Let a consumer supply a more specific
+  // check against the same already-fetched chat data instead of adding a
+  // second round trip; defaults preserve the old any-chat-is-valid behavior.
+  validateChat,
+  invalidChatMessageKey,
 }) => {
-  const { t } = useTranslations(lang);
-  const [chatId, setChatId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState(null);
-  // Same split as ViewChatByIdSection.js: "empty" and "invalid format" are
-  // pre-submit, client-side field validation (this inline slot, message
-  // varies by which one failed); "not found" is a genuine server-lookup
-  // outcome, so it stays a StatusMessage instead.
-  const [inlineErrorMessage, setInlineErrorMessage] = useState('');
-  const { hasError, errorCount, errorRef, triggerError, clearError } = useInlineFormError();
-
-  const handleInputChange = (event) => {
-    const value = event?.target?.value || '';
-    setChatId(value);
-    clearError();
-    // A stale success/error message from the last delete describes an
-    // action the admin is no longer taking, once they've started typing a
-    // new chat ID — same reasoning as SettingsPage.js's stageChange
-    // clearing a section's stale save-outcome message on edit.
-    setStatus(null);
-  };
-
-  // Closing this row means "I'm done here" — reset it fully (typed ID
-  // included, not just the status message) so reopening it later starts
-  // clean rather than picking up wherever it was left. Native <details>
-  // fires `toggle` for both directions; clearing on open too is a harmless
-  // no-op (already empty from the close that necessarily preceded it).
-  const handleToggle = () => {
-    setChatId('');
-    clearError();
-    setStatus(null);
-  };
+  const {
+    t,
+    chatId,
+    setChatId,
+    handleInputChange,
+    handleToggle,
+    loading,
+    setLoading,
+    status,
+    setStatus,
+    hasError,
+    errorCount,
+    errorRef,
+    inlineErrorMessage,
+    checkChatExists,
+  } = useChatIdLookup({ lang, validateChat, invalidChatMessageKey });
 
   const handleDelete = async (e) => {
     e.preventDefault();
-    const trimmed = chatId.trim();
-    if (!trimmed) {
-      setInlineErrorMessage(t('admin.common.chatIdRequired'));
-      triggerError();
-      return;
-    }
-    // Format check next, no round trip needed — same reasoning as
-    // ViewChatByIdSection.js: a value that isn't even shaped like a chat ID
-    // is a real input error, distinct from a well-formed ID that just
-    // doesn't match anything (the "not found" StatusMessage below).
-    // Without this, a malformed ID fell through to the existence check and
-    // came back indistinguishable from a real "not found" result.
-    if (!isValidChatIdFormat(trimmed)) {
-      setInlineErrorMessage(t('admin.viewChat.invalidFormat'));
-      triggerError();
-      return;
-    }
-
-    setLoading(true);
-    setStatus(null);
-    // Confirm the chat actually exists before asking the admin to confirm a
-    // delete that's about to fail anyway — same existence check
-    // ViewChatByIdSection.js uses (DataStoreService.getChat, the same
-    // db-chat.js route), same "not found" wording, so a chat ID that
-    // doesn't exist goes straight to that message instead of a confirm
-    // dialog for nothing.
-    try {
-      const data = await DataStoreService.getChat(trimmed);
-      if (!data?.chat) {
-        setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
-        setLoading(false);
-        return;
-      }
-    } catch (err) {
-      // getChat's own catch collapses a genuine 404 and a network/server
-      // failure into the same thrown Error (see DataStoreService.getChat) -
-      // not distinguishable from here, same as ViewChatByIdSection.js: both
-      // read as "not found" rather than misreporting a real outage as this.
-      setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
-      setLoading(false);
-      return;
-    }
+    const chat = await checkChatExists(chatId);
+    if (!chat) return;
 
     // window.confirm() kept for now (native, blocking) - not part of this
     // pass's scope, see AdminPage.js redesign discussion.
@@ -118,10 +73,21 @@ const DeleteByChatIdSection = ({
       return;
     }
 
-    const result = await onDelete(trimmed);
-    setStatus(result);
-    if (!result.isError) setChatId('');
-    setLoading(false);
+    // onDelete's two current callers (DeleteChatSection.js/DeleteExpertEval.js)
+    // already catch everything internally and always resolve to a
+    // { isError, text } result rather than reject — but that's a convention,
+    // not something this shared component can enforce on a future caller.
+    // Guard it here too, so a consumer that doesn't follow it fails as a
+    // visible status message instead of leaving the row stuck in loading.
+    try {
+      const result = await onDelete(chatId.trim());
+      setStatus(result);
+      if (!result.isError) setChatId('');
+    } catch (err) {
+      setStatus({ variant: 'error', text: t('admin.common.fetchFailed') });
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -148,6 +114,12 @@ const DeleteByChatIdSection = ({
         {status?.variant === 'info' ? (
           // "Not found" — a genuine server-lookup outcome, not an error.
           <StatusMessage variant="info" message={status.text} persistent />
+        ) : status?.variant === 'error' ? (
+          // A plain, fully-translated failure message (the lookup/onDelete
+          // call itself failed) — no raw exception text to wrap, so this
+          // uses `message` directly rather than the prefix/detail/suffix
+          // children shape the isError branch below needs.
+          <StatusMessage variant="error" message={status.text} persistent />
         ) : status?.isError ? (
           // variant="error" + children (not `message`): the <span lang="en">
           // wrapper a raw exception detail needs (see onDelete's own

--- a/src/components/admin/DeleteChatSection.js
+++ b/src/components/admin/DeleteChatSection.js
@@ -1,43 +1,26 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslations } from '../../hooks/useTranslations.js';
-import { GcdsButton } from '@gcds-core/components-react';
 import DataStoreService from '../../services/DataStoreService.js';
-import StatusMessage from './StatusMessage.js';
+import DeleteByChatIdSection from './DeleteByChatIdSection.js';
 
 const DeleteChatSection = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
-  const [chatId, setChatId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState(null);
 
-  const handleInputChange = (event) => {
-    const value = event?.target?.value || '';
-    setChatId(value);
-    // A stale success/error message from the last delete describes an
-    // action the admin is no longer taking, once they've started typing a
-    // new chat ID — same reasoning as SettingsPage.js's stageChange
-    // clearing a section's stale save-outcome message on edit.
-    setStatus(null);
-  };
-
-  const handleDelete = async (e) => {
-    e.preventDefault();
-    if (!chatId.trim()) return;
-    if (!window.confirm(t('common.confirmDelete'))) return;
-
-    setLoading(true);
-    setStatus(null);
+  const handleDelete = async (chatId) => {
     try {
       await DataStoreService.deleteChat(chatId);
-      setStatus({ text: t('admin.deleteChat.success'), isError: false });
-      setChatId('');
+      // chatId is already validated against the UUID-style format
+      // (isValidChatIdFormat, upstream in DeleteByChatIdSection) before this
+      // runs, so plain replace is safe — it can't contain a `$` sequence the
+      // way raw exception text below can.
+      return { isError: false, text: t('admin.deleteChat.success').replace('{chatId}', chatId) };
     } catch (error) {
       console.error('Error deleting chat:', error);
       // error.message is raw, untranslated exception text — never run it
       // through the {message} template as a plain string substitution (a FR
       // admin would otherwise see it announced as French). Split the
       // translated template around the placeholder instead, so the detail
-      // can be wrapped in its own lang="en" span below.
+      // can be wrapped in its own lang="en" span.
       // TODO (for Official Languages review): the wrapped detail below is
       // still only a pronunciation fix (WCAG 3.1.2), not a translation —
       // error.message comes straight from the network/runtime (e.g. "Failed
@@ -48,53 +31,20 @@ const DeleteChatSection = ({ lang = 'en' }) => {
       // admin.deleteChat.errors.* keys here to map code -> translated text.
       // Flagging for a maintainer decision on whether that's worth doing.
       const [prefix, suffix] = t('admin.deleteChat.error').split('{message}');
-      setStatus({
-        prefix,
-        suffix,
-        detail: error.message || String(error),
-        isError: true,
-      });
-    } finally {
-      setLoading(false);
+      return { isError: true, prefix, detail: <span lang="en">{error.message || String(error)}</span>, suffix };
     }
   };
 
   return (
-    <div className="bg-white shadow rounded-lg p-4">
-      <h2 className="mt-400 mb-400">{t('admin.deleteChat.title')}</h2>
-      <div className="flex gap-400">
-        <label htmlFor="chatId" className="sr-only">
-          {t('admin.deleteChat.idLabel')}
-        </label>
-        <input
-          type="text"
-          id="chatId"
-          className="form-control"
-          value={chatId}
-          onChange={handleInputChange}
-          placeholder={t('admin.deleteChat.idLabel')}
-          disabled={loading}
-          required
-        />
-        <GcdsButton
-          onClick={handleDelete}
-          buttonRole="danger"
-          disabled={loading || !chatId.trim()}
-          className="me-400 hydrated mrgn-tp-1r"
-        >
-          {loading
-            ? t('admin.deleteChat.loading')
-            : t('admin.deleteChat.button')}
-        </GcdsButton>
-      </div>
-      {status?.isError ? (
-        <StatusMessage variant="error">
-          {status.prefix}<span lang="en">{status.detail}</span>{status.suffix}
-        </StatusMessage>
-      ) : (
-        <StatusMessage variant={status?.text ? 'success' : undefined} message={status?.text} />
-      )}
-    </div>
+    <DeleteByChatIdSection
+      lang={lang}
+      titleKey="admin.deleteChat.title"
+      idLabelKey="admin.deleteChat.idLabel"
+      buttonLabelKey="admin.deleteChat.button"
+      loadingLabelKey="admin.deleteChat.loading"
+      fieldId="chatId"
+      onDelete={handleDelete}
+    />
   );
 };
 

--- a/src/components/admin/DeleteChatSection.js
+++ b/src/components/admin/DeleteChatSection.js
@@ -22,14 +22,21 @@ const DeleteChatSection = ({ lang = 'en' }) => {
       // translated template around the placeholder instead, so the detail
       // can be wrapped in its own lang="en" span.
       // TODO (for Official Languages review): the wrapped detail below is
-      // still only a pronunciation fix (WCAG 3.1.2), not a translation —
-      // error.message comes straight from the network/runtime (e.g. "Failed
-      // to fetch", a raw HTTP status line, a driver error) and has no fixed
-      // set of values to put behind a t() key. Genuinely localizing this
-      // needs DataStoreService.deleteChat (and the API route it calls) to
-      // return a stable error CODE instead of a free-text message, plus new
-      // admin.deleteChat.errors.* keys here to map code -> translated text.
-      // Flagging for a maintainer decision on whether that's worth doing.
+      // still only a pronunciation fix (WCAG 3.1.2), not a translation.
+      // Most of what lands here really is unbounded (network drop, an
+      // unexpected 500, "Failed to fetch") with no fixed set of values to
+      // put behind a t() key — but at least one case IS bounded: the 404
+      // race (pre-check passed, then the chat was deleted before this call
+      // completed — api/chat/chat-delete.js throws 'Chat not found.' for
+      // that) is a known, known-value outcome, same reasoning as
+      // DeleteExpertEval.js's admin.deleteExpertEval.notEvaluated case.
+      // Genuinely localizing this needs DataStoreService.deleteChat (and
+      // the API route it calls) to return a stable error CODE instead of
+      // just message text, so this catch block can route the bounded case
+      // to a real t() key and leave lang="en" only for the genuinely
+      // unbounded remainder. Flagging for a maintainer decision on whether
+      // that's worth doing — touches both layers plus a test rewrite, not
+      // just this file.
       const [prefix, suffix] = t('admin.deleteChat.error').split('{message}');
       return { isError: true, prefix, detail: <span lang="en">{error.message || String(error)}</span>, suffix };
     }

--- a/src/components/admin/StatusMessage.js
+++ b/src/components/admin/StatusMessage.js
@@ -32,8 +32,12 @@ import { GcdsIcon } from '@gcds-core/components-react';
 // checkmark span (`fa-solid fa-check-circle`) instead of GcdsIcon, matching
 // the existing precedent in BatchUpload.js — GC DS's icon font has no
 // checkmark glyph. A caller that passes `children` alongside `variant` gets
-// the box/role treatment but is responsible for its own icon (an escape
-// hatch for content richer than "icon + one string").
+// the box/role treatment AND the same icon `message` would have gotten —
+// `children` is only an escape hatch for content richer than one string
+// (e.g. a raw exception detail that needs its own <span lang="en">), not a
+// way to opt out of the icon. (It used to be — see resolveLook's own
+// comment for why that shipped 5 icon-less error boxes before this fixed
+// it at the root.)
 //
 // TODO (design review): none of this component's CSS — the four variant
 // boxes, the loading box, the plain isError/tag styling — has had an actual
@@ -120,10 +124,20 @@ function resolveLook({ variant, loading, message, isError, children }) {
       isError: variantConfig.isError,
       isBlock: true,
       className: variantConfig.className,
-      content: children || (
+      // Icon is unconditional — every real `children` caller in this
+      // codebase only reaches for `children` to wrap part of the text in
+      // e.g. <span lang="en">, never for a genuinely icon-less shape, and
+      // the old `children || (icon + message)` short-circuited the icon
+      // out entirely whenever `children` was passed. That was the actual
+      // cause behind 5 separate call sites shipping error boxes with no
+      // icon (found by inspection, not by design) - fixed at the root
+      // instead of leaving it as a footgun every future caller can still
+      // hit. `children` still exists for richer content than one string;
+      // it just no longer implies "and also drop the icon."
+      content: (
         <>
           <VariantIcon name={variantConfig.icon} />
-          {message}
+          {children || message}
         </>
       ),
     };
@@ -133,10 +147,17 @@ function resolveLook({ variant, loading, message, isError, children }) {
       isError,
       isBlock: true,
       className: 'status-message--loading',
-      content: children || (
+      // Same fix as the variant branch above, same reasoning: the spinner
+      // shouldn't be conditional on whether the caller used `message` or
+      // `children` for the text. No current `loading` caller passes
+      // `children` (all three use `message`), so this was a latent
+      // version of the exact bug fixed above, not yet a live one — fixed
+      // anyway rather than leaving the same footgun for the first future
+      // caller that does.
+      content: (
         <>
           <div className="loading-animation" aria-hidden="true"></div>
-          {message}
+          {children || message}
         </>
       ),
     };

--- a/src/components/admin/ViewChatByIdSection.js
+++ b/src/components/admin/ViewChatByIdSection.js
@@ -1,11 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useTranslations } from '../../hooks/useTranslations.js';
-import DataStoreService from '../../services/DataStoreService.js';
 import StatusMessage from './StatusMessage.js';
-import { useInlineFormError } from '../../hooks/useInlineFormError.js';
-import { isValidChatIdFormat } from '../../utils/admin/chatIdFormat.js';
 import ChatIdLookupField from './ChatIdLookupField.js';
+import { useChatIdLookup } from '../../hooks/admin/useChatIdLookup.js';
 
 // Quick chat-ID lookup, navigating to the chat viewer for the entered ID -
 // requires the full, exact chat ID (a direct navigation, not a search; see
@@ -13,12 +10,16 @@ import ChatIdLookupField from './ChatIdLookupField.js';
 // partial-match search version, which opens a filtered results table
 // instead of navigating anywhere).
 //
-// Checks the chat actually exists (DataStoreService.getChat - the same
-// db-chat.js route, same exact chatId match, that the review page itself
-// fetches from) before navigating. Previously this navigated on any
-// non-empty input, no matter the ID's validity — a wrong or partial ID
-// silently landed on an empty review page with no explanation, instead of
-// telling the admin the lookup failed.
+// Checks the chat actually exists (via useChatIdLookup.js's shared
+// existence check, the same DataStoreService.getChat / db-chat.js route
+// DeleteByChatIdSection.js uses) before navigating. Previously this
+// navigated on any non-empty input, no matter the ID's validity — a wrong
+// or partial ID silently landed on an empty review page with no
+// explanation, instead of telling the admin the lookup failed. Doesn't go
+// through DeleteByChatIdSection.js itself, even though the pre-navigation
+// checks are identical: viewing isn't destructive, so it shouldn't trigger
+// that component's delete-style window.confirm() step — only the shared
+// hook is reused, not the whole component.
 //
 // One row in whichever page renders it (its own h2) - collapsed by
 // default, summary text is this row's only label, no separate heading
@@ -26,84 +27,28 @@ import ChatIdLookupField from './ChatIdLookupField.js';
 // out of AdminPage.js so it can be reused on other pages without
 // duplicating the lookup form itself.
 const ViewChatByIdSection = ({ lang = 'en' }) => {
-  const { t } = useTranslations(lang);
   const navigate = useNavigate();
-  const [lookupChatId, setLookupChatId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState(null);
-  // Both the "empty" and "malformed" cases are pre-submit, client-side
-  // field validation — same inline-error slot as a result, just with a
-  // different message depending on which one failed (see AGENTS.md's
-  // "repeat identical validation failures" note: the message varies, but
-  // errorCount still has to increment on every trigger for
-  // FeedbackInlineError to remount/re-announce on a repeat failure).
-  // "Not found" (below) is a genuine server-lookup outcome, not a form
-  // validation error, so it stays a StatusMessage - matches
-  // EvalDashboardPage.js's own split between searchRequired (inline) and
-  // searchNotFound (StatusMessage).
-  const [inlineErrorMessage, setInlineErrorMessage] = useState('');
-  const { hasError, errorCount, errorRef, triggerError, clearError } = useInlineFormError();
-
-  const handleChange = (e) => {
-    setLookupChatId(e.target.value);
-    clearError();
-    // A stale "not found" message describes a lookup the admin is no
-    // longer making, once they've started typing a new chat ID — same
-    // reasoning as SettingsPage.js's stageChange clearing a section's
-    // stale save-outcome message on edit.
-    setStatus(null);
-  };
-
-  // Closing this row means "I'm done here" — reset it fully (typed ID
-  // included, not just the status message) so reopening it later starts
-  // clean rather than picking up wherever it was left. Native <details>
-  // fires `toggle` for both directions; clearing on open too is a harmless
-  // no-op (already empty from the close that necessarily preceded it).
-  const handleToggle = () => {
-    setLookupChatId('');
-    clearError();
-    setStatus(null);
-  };
+  const {
+    t,
+    chatId,
+    handleInputChange,
+    handleToggle,
+    loading,
+    status,
+    hasError,
+    errorCount,
+    errorRef,
+    inlineErrorMessage,
+    checkChatExists,
+  } = useChatIdLookup({ lang });
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const trimmed = lookupChatId.trim();
-    if (!trimmed) {
-      setInlineErrorMessage(t('admin.common.chatIdRequired'));
-      triggerError();
-      return;
-    }
-    // Format check next, no round trip needed: chat IDs are uuidv4() (see
-    // chatIdFormat.js) - a value that isn't even shaped like one is a real
-    // input error, same inline slot as the empty case above but with its
-    // own message. Distinct from a well-formed ID that just doesn't match
-    // anything (the "not found" StatusMessage below) - not the same
-    // outcome, shouldn't read as the same message.
-    if (!isValidChatIdFormat(trimmed)) {
-      setInlineErrorMessage(t('admin.viewChat.invalidFormat'));
-      triggerError();
-      return;
-    }
-    setLoading(true);
-    setStatus(null);
-    try {
-      const data = await DataStoreService.getChat(trimmed);
-      if (!data?.chat) {
-        setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
-        setLoading(false);
-        return;
-      }
-      navigate(`/${lang}?chat=${encodeURIComponent(trimmed)}&review=1`);
-      // No setLoading(false) here on success — this component is about to
-      // unmount as the page navigates away.
-    } catch (err) {
-      // getChat's own catch collapses a genuine 404 and a network/server
-      // failure into the same thrown Error (see DataStoreService.getChat) -
-      // not distinguishable from here, so both read as "not found" (info)
-      // rather than misreporting a real outage as an input error.
-      setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
-      setLoading(false);
-    }
+    const chat = await checkChatExists(chatId);
+    if (!chat) return;
+    navigate(`/${lang}?chat=${encodeURIComponent(chat.chatId)}&review=1`);
+    // No setLoading(false) here on success — this component is about to
+    // unmount as the page navigates away.
   };
 
   return (
@@ -115,8 +60,8 @@ const ViewChatByIdSection = ({ lang = 'en' }) => {
             fieldId="view-chat-id"
             label={t('admin.viewChat.label')}
             placeholder={t('admin.common.chatIdPlaceholder')}
-            value={lookupChatId}
-            onChange={handleChange}
+            value={chatId}
+            onChange={handleInputChange}
             disabled={loading}
             hasError={hasError}
             errorMessage={inlineErrorMessage}

--- a/src/components/admin/ViewChatByIdSection.js
+++ b/src/components/admin/ViewChatByIdSection.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslations } from '../../hooks/useTranslations.js';
+import DataStoreService from '../../services/DataStoreService.js';
+import StatusMessage from './StatusMessage.js';
+import { useInlineFormError } from '../../hooks/useInlineFormError.js';
+import { isValidChatIdFormat } from '../../utils/admin/chatIdFormat.js';
+import ChatIdLookupField from './ChatIdLookupField.js';
+
+// Quick chat-ID lookup, navigating to the chat viewer for the entered ID -
+// requires the full, exact chat ID (a direct navigation, not a search; see
+// EvalDashboardPage.js's own "View chat by ID" for the genuinely different
+// partial-match search version, which opens a filtered results table
+// instead of navigating anywhere).
+//
+// Checks the chat actually exists (DataStoreService.getChat - the same
+// db-chat.js route, same exact chatId match, that the review page itself
+// fetches from) before navigating. Previously this navigated on any
+// non-empty input, no matter the ID's validity — a wrong or partial ID
+// silently landed on an empty review page with no explanation, instead of
+// telling the admin the lookup failed.
+//
+// One row in whichever page renders it (its own h2) - collapsed by
+// default, summary text is this row's only label, no separate heading
+// here - same shape as DeleteChatSection.js/DeleteExpertEval.js. Pulled
+// out of AdminPage.js so it can be reused on other pages without
+// duplicating the lookup form itself.
+const ViewChatByIdSection = ({ lang = 'en' }) => {
+  const { t } = useTranslations(lang);
+  const navigate = useNavigate();
+  const [lookupChatId, setLookupChatId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState(null);
+  // Both the "empty" and "malformed" cases are pre-submit, client-side
+  // field validation — same inline-error slot as a result, just with a
+  // different message depending on which one failed (see AGENTS.md's
+  // "repeat identical validation failures" note: the message varies, but
+  // errorCount still has to increment on every trigger for
+  // FeedbackInlineError to remount/re-announce on a repeat failure).
+  // "Not found" (below) is a genuine server-lookup outcome, not a form
+  // validation error, so it stays a StatusMessage - matches
+  // EvalDashboardPage.js's own split between searchRequired (inline) and
+  // searchNotFound (StatusMessage).
+  const [inlineErrorMessage, setInlineErrorMessage] = useState('');
+  const { hasError, errorCount, errorRef, triggerError, clearError } = useInlineFormError();
+
+  const handleChange = (e) => {
+    setLookupChatId(e.target.value);
+    clearError();
+    // A stale "not found" message describes a lookup the admin is no
+    // longer making, once they've started typing a new chat ID — same
+    // reasoning as SettingsPage.js's stageChange clearing a section's
+    // stale save-outcome message on edit.
+    setStatus(null);
+  };
+
+  // Closing this row means "I'm done here" — reset it fully (typed ID
+  // included, not just the status message) so reopening it later starts
+  // clean rather than picking up wherever it was left. Native <details>
+  // fires `toggle` for both directions; clearing on open too is a harmless
+  // no-op (already empty from the close that necessarily preceded it).
+  const handleToggle = () => {
+    setLookupChatId('');
+    clearError();
+    setStatus(null);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = lookupChatId.trim();
+    if (!trimmed) {
+      setInlineErrorMessage(t('admin.common.chatIdRequired'));
+      triggerError();
+      return;
+    }
+    // Format check next, no round trip needed: chat IDs are uuidv4() (see
+    // chatIdFormat.js) - a value that isn't even shaped like one is a real
+    // input error, same inline slot as the empty case above but with its
+    // own message. Distinct from a well-formed ID that just doesn't match
+    // anything (the "not found" StatusMessage below) - not the same
+    // outcome, shouldn't read as the same message.
+    if (!isValidChatIdFormat(trimmed)) {
+      setInlineErrorMessage(t('admin.viewChat.invalidFormat'));
+      triggerError();
+      return;
+    }
+    setLoading(true);
+    setStatus(null);
+    try {
+      const data = await DataStoreService.getChat(trimmed);
+      if (!data?.chat) {
+        setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
+        setLoading(false);
+        return;
+      }
+      navigate(`/${lang}?chat=${encodeURIComponent(trimmed)}&review=1`);
+      // No setLoading(false) here on success — this component is about to
+      // unmount as the page navigates away.
+    } catch (err) {
+      // getChat's own catch collapses a genuine 404 and a network/server
+      // failure into the same thrown Error (see DataStoreService.getChat) -
+      // not distinguishable from here, so both read as "not found" (info)
+      // rather than misreporting a real outage as an input error.
+      setStatus({ variant: 'info', text: t('admin.viewChat.notFound') });
+      setLoading(false);
+    }
+  };
+
+  return (
+    <details onToggle={handleToggle}>
+      <summary id="view-chat-id-summary">{t('admin.common.viewChatById')}</summary>
+      <div className="mt-200">
+        <form onSubmit={handleSubmit}>
+          <ChatIdLookupField
+            fieldId="view-chat-id"
+            label={t('admin.viewChat.label')}
+            placeholder={t('admin.common.chatIdPlaceholder')}
+            value={lookupChatId}
+            onChange={handleChange}
+            disabled={loading}
+            hasError={hasError}
+            errorMessage={inlineErrorMessage}
+            errorCount={errorCount}
+            errorRef={errorRef}
+            buttonLabel={loading ? t('admin.viewChat.loading') : t('admin.viewChat.button')}
+            describedById="view-chat-id-summary"
+          />
+        </form>
+        <StatusMessage variant={status?.variant} message={status?.text} persistent />
+      </div>
+    </details>
+  );
+};
+
+export default ViewChatByIdSection;

--- a/src/components/admin/__tests__/DeleteChatSection.test.js
+++ b/src/components/admin/__tests__/DeleteChatSection.test.js
@@ -7,7 +7,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import DeleteChatSection from '../DeleteChatSection.js';
 
 const TRANSLATIONS = {
-  'admin.deleteChat.success': '{chatId} deleted successfully',
+  'admin.deleteChat.success': '{chatId} deleted successfully.',
   'admin.deleteChat.error': 'Failed to delete chat: {message}',
   'admin.deleteChat.idLabel': 'Chat ID',
   'admin.deleteChat.title': 'Delete a chat from the logs',
@@ -77,7 +77,7 @@ describe('DeleteChatSection error/success announcements', () => {
     fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
     fireEvent.click(screen.getByText('Delete chat'));
 
-    const expectedText = `${VALID_CHAT_ID} deleted successfully`;
+    const expectedText = `${VALID_CHAT_ID} deleted successfully.`;
     await waitFor(() => {
       expect(screen.getByText(expectedText)).toBeTruthy();
     });
@@ -96,7 +96,7 @@ describe('DeleteChatSection error/success announcements', () => {
     fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
     fireEvent.click(screen.getByText('Delete chat'));
     await waitFor(() => {
-      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
+      expect(screen.getByText('admin.common.chatNotFound')).toBeTruthy();
     });
     expect(screen.getByLabelText('Chat ID').value).toBe(VALID_CHAT_ID);
 
@@ -104,7 +104,7 @@ describe('DeleteChatSection error/success announcements', () => {
     // the toggle event has to be dispatched directly.
     fireEvent(container.querySelector('details'), new Event('toggle'));
 
-    expect(screen.queryByText('admin.viewChat.notFound')).toBeNull();
+    expect(screen.queryByText('admin.common.chatNotFound')).toBeNull();
     expect(screen.getByLabelText('Chat ID').value).toBe('');
   });
 
@@ -118,8 +118,28 @@ describe('DeleteChatSection error/success announcements', () => {
     fireEvent.click(screen.getByText('Delete chat'));
 
     await waitFor(() => {
-      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
+      expect(screen.getByText('admin.common.chatNotFound')).toBeTruthy();
     });
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockDeleteChat).not.toHaveBeenCalled();
+  });
+
+  it('shows a distinct "lookup failed" message, not "not found", when the existence check itself fails', async () => {
+    // getChat() throwing (real outage, distinct from its own { chat: null }
+    // 404 handling) must not read as "this chat doesn't exist" — that was
+    // the actual bug: both cases collapsed into the same not-found text.
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    mockGetChat.mockRejectedValue(new Error('Failed to fetch'));
+
+    render(<DeleteChatSection lang="en" />);
+
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
+    fireEvent.click(screen.getByText('Delete chat'));
+
+    await waitFor(() => {
+      expect(screen.getByText('admin.common.fetchFailed')).toBeTruthy();
+    });
+    expect(screen.queryByText('admin.common.chatNotFound')).toBeNull();
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(mockDeleteChat).not.toHaveBeenCalled();
   });

--- a/src/components/admin/__tests__/DeleteChatSection.test.js
+++ b/src/components/admin/__tests__/DeleteChatSection.test.js
@@ -7,7 +7,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import DeleteChatSection from '../DeleteChatSection.js';
 
 const TRANSLATIONS = {
-  'admin.deleteChat.success': 'Chat deleted successfully',
+  'admin.deleteChat.success': '{chatId} deleted successfully',
   'admin.deleteChat.error': 'Failed to delete chat: {message}',
   'admin.deleteChat.idLabel': 'Chat ID',
   'admin.deleteChat.title': 'Delete a chat from the logs',
@@ -20,10 +20,19 @@ vi.mock('../../../hooks/useTranslations.js', () => ({
   useTranslations: () => ({ t: mockT }),
 }));
 
-const { mockDeleteChat } = vi.hoisted(() => ({ mockDeleteChat: vi.fn() }));
-vi.mock('../../../services/DataStoreService.js', () => ({
-  default: { deleteChat: mockDeleteChat },
+const { mockDeleteChat, mockGetChat } = vi.hoisted(() => ({
+  mockDeleteChat: vi.fn(),
+  mockGetChat: vi.fn(),
 }));
+vi.mock('../../../services/DataStoreService.js', () => ({
+  default: { deleteChat: mockDeleteChat, getChat: mockGetChat },
+}));
+
+// A well-formed chat ID (matches isValidChatIdFormat's uuidv4 pattern) -
+// DeleteByChatIdSection.js now confirms the chat exists (DataStoreService
+// .getChat) before the confirm dialog, so every test below needs both a
+// syntactically valid ID and a resolved getChat mock, not just deleteChat.
+const VALID_CHAT_ID = 'abcdef12-3456-4789-8abc-def012345678';
 
 vi.mock('@gcds-core/components-react', () => ({
   GcdsButton: ({ children, onClick, disabled }) => (
@@ -36,16 +45,18 @@ describe('DeleteChatSection error/success announcements', () => {
   afterEach(() => {
     cleanup();
     mockDeleteChat.mockReset();
+    mockGetChat.mockReset();
     vi.restoreAllMocks();
   });
 
   it('wraps the untranslated error detail in a lang="en" span, inside role="alert"', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
     mockDeleteChat.mockRejectedValue(new Error('Failed to fetch'));
 
     render(<DeleteChatSection lang="fr" />);
 
-    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: 'abc123' } });
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
     fireEvent.click(screen.getByText('Delete chat'));
 
     const alert = await screen.findByRole('alert');
@@ -58,17 +69,72 @@ describe('DeleteChatSection error/success announcements', () => {
 
   it('announces a successful delete as role="status", not role="alert"', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
     mockDeleteChat.mockResolvedValue({});
 
     render(<DeleteChatSection lang="en" />);
 
-    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: 'abc123' } });
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
+    fireEvent.click(screen.getByText('Delete chat'));
+
+    const expectedText = `${VALID_CHAT_ID} deleted successfully`;
+    await waitFor(() => {
+      expect(screen.getByText(expectedText)).toBeTruthy();
+    });
+    expect(screen.getByText(expectedText).closest('[role="status"]')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('clears the stale message and the typed chat ID when the row is collapsed', async () => {
+    // "Not found" (unlike a successful delete) deliberately leaves the typed
+    // ID in place — the field only clearing via the toggle, not as a
+    // byproduct of the result itself, is what this test needs to isolate.
+    mockGetChat.mockResolvedValue({ chat: null });
+
+    const { container } = render(<DeleteChatSection lang="en" />);
+
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
+    fireEvent.click(screen.getByText('Delete chat'));
+    await waitFor(() => {
+      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
+    });
+    expect(screen.getByLabelText('Chat ID').value).toBe(VALID_CHAT_ID);
+
+    // jsdom doesn't simulate native <details> open/close from a click, so
+    // the toggle event has to be dispatched directly.
+    fireEvent(container.querySelector('details'), new Event('toggle'));
+
+    expect(screen.queryByText('admin.viewChat.notFound')).toBeNull();
+    expect(screen.getByLabelText('Chat ID').value).toBe('');
+  });
+
+  it('shows "not found" and skips the confirm dialog when the chat does not exist', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    mockGetChat.mockResolvedValue({ chat: null });
+
+    render(<DeleteChatSection lang="en" />);
+
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: VALID_CHAT_ID } });
     fireEvent.click(screen.getByText('Delete chat'));
 
     await waitFor(() => {
-      expect(screen.getByText('Chat deleted successfully')).toBeTruthy();
+      expect(screen.getByText('admin.viewChat.notFound')).toBeTruthy();
     });
-    expect(screen.getByText('Chat deleted successfully').closest('[role="status"]')).toBeTruthy();
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockDeleteChat).not.toHaveBeenCalled();
+  });
+
+  it('flags a malformed chat ID as an inline error instead of looking it up', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+
+    render(<DeleteChatSection lang="en" />);
+
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: 'not-a-real-id' } });
+    fireEvent.click(screen.getByText('Delete chat'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('admin.viewChat.invalidFormat');
+    expect(mockGetChat).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/admin/__tests__/ViewChatByIdSection.test.js
+++ b/src/components/admin/__tests__/ViewChatByIdSection.test.js
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ViewChatByIdSection from '../ViewChatByIdSection.js';
+
+const TRANSLATIONS = {
+  'admin.common.viewChatById': 'View chat by ID',
+  'admin.common.chatIdRequired': 'Please enter a chat ID.',
+  'admin.common.chatIdPlaceholder': 'Enter full chat ID',
+  'admin.common.chatNotFound': 'No chat found with that ID.',
+  'admin.common.fetchFailed': 'Failed to load data. Please try again.',
+  'admin.viewChat.label': 'Chat ID',
+  'admin.viewChat.button': 'View chat',
+  'admin.viewChat.loading': 'Looking up...',
+  'admin.viewChat.invalidFormat': 'Invalid chat ID format',
+};
+const mockT = (key) => TRANSLATIONS[key] || key;
+vi.mock('../../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({ t: mockT }),
+}));
+
+const { mockGetChat, mockNavigate } = vi.hoisted(() => ({
+  mockGetChat: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+vi.mock('../../../services/DataStoreService.js', () => ({
+  default: { getChat: mockGetChat },
+}));
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@gcds-core/components-react', () => ({
+  GcdsButton: ({ children, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  GcdsIcon: ({ name }) => <span data-icon={name} />,
+}));
+
+// A well-formed chat ID (matches isValidChatIdFormat's uuidv4 pattern).
+const VALID_CHAT_ID = 'abcdef12-3456-4789-8abc-def012345678';
+
+describe('ViewChatByIdSection', () => {
+  afterEach(() => {
+    cleanup();
+    mockGetChat.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  const startLookup = (chatId = VALID_CHAT_ID) => {
+    fireEvent.change(screen.getByLabelText('Chat ID'), { target: { value: chatId } });
+    fireEvent.click(screen.getByText('View chat'));
+  };
+
+  it('navigates to the review page for a chat that exists', async () => {
+    mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
+
+    render(<ViewChatByIdSection lang="en" />);
+    startLookup();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(`/en?chat=${encodeURIComponent(VALID_CHAT_ID)}&review=1`);
+    });
+  });
+
+  it('shows "not found" and does not navigate when the chat does not exist', async () => {
+    mockGetChat.mockResolvedValue({ chat: null });
+
+    render(<ViewChatByIdSection lang="en" />);
+    startLookup();
+
+    await waitFor(() => {
+      expect(screen.getByText('No chat found with that ID.')).toBeTruthy();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a distinct "lookup failed" message, not "not found", when the existence check itself fails', async () => {
+    mockGetChat.mockRejectedValue(new Error('Failed to fetch'));
+
+    render(<ViewChatByIdSection lang="en" />);
+    startLookup();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load data. Please try again.')).toBeTruthy();
+    });
+    expect(screen.queryByText('No chat found with that ID.')).toBeNull();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('flags an empty submit as an inline error instead of looking it up', async () => {
+    render(<ViewChatByIdSection lang="en" />);
+    fireEvent.click(screen.getByText('View chat'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Please enter a chat ID.');
+    expect(mockGetChat).not.toHaveBeenCalled();
+  });
+
+  it('flags a malformed chat ID as an inline error instead of looking it up', async () => {
+    render(<ViewChatByIdSection lang="en" />);
+    startLookup('not-a-real-id');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Invalid chat ID format');
+    expect(mockGetChat).not.toHaveBeenCalled();
+  });
+
+  it('clears the stale message and the typed chat ID when the row is collapsed', async () => {
+    mockGetChat.mockResolvedValue({ chat: null });
+
+    const { container } = render(<ViewChatByIdSection lang="en" />);
+    startLookup();
+
+    await waitFor(() => {
+      expect(screen.getByText('No chat found with that ID.')).toBeTruthy();
+    });
+    expect(screen.getByLabelText('Chat ID').value).toBe(VALID_CHAT_ID);
+
+    // jsdom doesn't simulate native <details> open/close from a click, so
+    // the toggle event has to be dispatched directly.
+    fireEvent(container.querySelector('details'), new Event('toggle'));
+
+    expect(screen.queryByText('No chat found with that ID.')).toBeNull();
+    expect(screen.getByLabelText('Chat ID').value).toBe('');
+  });
+});

--- a/src/hooks/admin/useChatIdLookup.js
+++ b/src/hooks/admin/useChatIdLookup.js
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { useTranslations } from '../useTranslations.js';
+import DataStoreService from '../../services/DataStoreService.js';
+import { useInlineFormError } from '../useInlineFormError.js';
+import { isValidChatIdFormat } from '../../utils/admin/chatIdFormat.js';
+
+// Shared "validate + confirm this chat ID exists" logic behind
+// DeleteByChatIdSection.js (delete flows) and ViewChatByIdSection.js (a
+// non-destructive navigation) — everything up to and including the
+// existence check is identical between them; what happens *after* isn't
+// (one shows a native confirm() before an async delete, the other just
+// navigates), so that part stays in each caller rather than being forced
+// through one component's delete-shaped contract.
+//
+// validateChat/invalidChatMessageKey: the chat existing isn't always the
+// real precondition (e.g. DeleteExpertEval.js's is "has expert feedback",
+// which a plain existence check can't express) — see DeleteByChatIdSection.js's
+// own comment for the full reasoning. Checked against the same already-fetched
+// chat data, no second request.
+export function useChatIdLookup({
+  lang = 'en',
+  validateChat = () => true,
+  invalidChatMessageKey = 'admin.common.chatNotFound',
+} = {}) {
+  const { t } = useTranslations(lang);
+  const [chatId, setChatId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState(null);
+  // "Empty" and "invalid format" are pre-submit, client-side field
+  // validation (this inline slot); "not found"/"invalid target"/"lookup
+  // failed" are genuine server-lookup outcomes, so those stay StatusMessages.
+  const [inlineErrorMessage, setInlineErrorMessage] = useState('');
+  const { hasError, errorCount, errorRef, triggerError, clearError } = useInlineFormError();
+
+  const handleInputChange = (event) => {
+    const value = event?.target?.value || '';
+    setChatId(value);
+    clearError();
+    // A stale result message describes an action the admin is no longer
+    // taking, once they've started typing a new chat ID — same reasoning as
+    // SettingsPage.js's stageChange clearing a section's stale save-outcome
+    // message on edit.
+    setStatus(null);
+  };
+
+  // Closing the row means "I'm done here" — reset it fully (typed ID
+  // included, not just the status message) so reopening it later starts
+  // clean rather than picking up wherever it was left. Native <details>
+  // fires `toggle` for both directions; clearing on open too is a harmless
+  // no-op (already empty from the close that necessarily preceded it).
+  const handleToggle = () => {
+    setChatId('');
+    clearError();
+    setStatus(null);
+  };
+
+  // Validates and existence-checks rawValue. Returns the fetched chat object
+  // on success — caller proceeds with its own next step, and still owns
+  // setLoading(false) for that step. Returns null on any failure, having
+  // already set inline/status state and setLoading(false) itself — caller
+  // should just `return` when this returns null.
+  // TODO: this always fetches db-chat.js's fully-populated chat just to test
+  // truthiness; DeleteChatSection.js/ViewChatByIdSection.js discard it and
+  // ViewChatByIdSection.js's caller (HomePage.js) re-fetches the same chat
+  // right after. Only DeleteExpertEval.js's validateChat actually needs the
+  // populated data. Low priority — admin/partner-only, low-volume — but a
+  // lightweight existence check (unpopulated findOne) would cut the waste
+  // for the other two callers.
+  const checkChatExists = async (rawValue) => {
+    const trimmed = (rawValue || '').trim();
+    if (!trimmed) {
+      setInlineErrorMessage(t('admin.common.chatIdRequired'));
+      triggerError();
+      return null;
+    }
+    // Format check next, no round trip needed: a value that isn't even
+    // shaped like a chat ID is a real input error, distinct from a
+    // well-formed ID that just doesn't match anything (the "not found"
+    // StatusMessage below) — without this, a malformed ID fell through to
+    // the existence check and came back indistinguishable from a real
+    // "not found" result.
+    if (!isValidChatIdFormat(trimmed)) {
+      setInlineErrorMessage(t('admin.viewChat.invalidFormat'));
+      triggerError();
+      return null;
+    }
+
+    setLoading(true);
+    setStatus(null);
+    try {
+      const data = await DataStoreService.getChat(trimmed);
+      // getChat() distinguishes a real 404 (returns { chat: null }) from
+      // any other failure (still throws, caught below) — see its own
+      // comment — so a genuinely nonexistent chat ID reads as "not found"
+      // and an outage gets its own distinct message instead of both
+      // reading as "this data doesn't exist."
+      if (!data?.chat) {
+        setStatus({ variant: 'info', text: t('admin.common.chatNotFound') });
+        setLoading(false);
+        return null;
+      }
+      if (!validateChat(data.chat)) {
+        setStatus({ variant: 'info', text: t(invalidChatMessageKey) });
+        setLoading(false);
+        return null;
+      }
+      return data.chat;
+    } catch (err) {
+      setStatus({ variant: 'error', text: t('admin.common.fetchFailed') });
+      setLoading(false);
+      return null;
+    }
+  };
+
+  return {
+    t,
+    chatId,
+    setChatId,
+    handleInputChange,
+    handleToggle,
+    loading,
+    setLoading,
+    status,
+    setStatus,
+    hasError,
+    errorCount,
+    errorRef,
+    inlineErrorMessage,
+    checkChatExists,
+  };
+}
+
+export default useChatIdLookup;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -579,7 +579,6 @@
       "label": "Chat ID",
       "button": "View chat",
       "loading": "Looking up...",
-      "notFound": "No chat found with that ID",
       "invalidFormat": "Invalid chat ID format"
     },
     "evalPage": {
@@ -789,6 +788,8 @@
       "viewChatById": "View chat by ID",
       "chatIdRequired": "Please enter a chat ID.",
       "chatIdPlaceholder": "Enter full chat ID",
+      "chatNotFound": "No chat found with that ID.",
+      "fetchFailed": "Failed to load data. Please try again.",
       "sortActivateAscending": "{column}: activate for ascending sort",
       "sortActivateDescending": "{column}: activate for descending sort",
       "sortRemove": "{column}: activate to remove sort",
@@ -839,7 +840,6 @@
       "searchChatIdInputLabel": "Chat ID",
       "searchChatIdPlaceholder": "Enter chat ID (partial or full)",
       "searchButton": "Search for chat ID",
-      "searchNotFound": "No chat found with that ID.",
       "resultsHeading": "Evaluation results",
       "columns": {
         "chatId": "Chat ID",
@@ -910,7 +910,7 @@
       "idLabel": "Chat ID",
       "button": "Delete chat",
       "loading": "Deleting...",
-      "success": "{chatId} deleted successfully",
+      "success": "{chatId} deleted successfully.",
       "error": "Failed to delete chat: {message}"
     },
     "deleteExpertEval": {
@@ -918,7 +918,7 @@
       "idLabel": "Chat ID",
       "button": "Delete expert evaluation",
       "loading": "Deleting...",
-      "success": "Deleted {count} expert feedback record(s) for {chatId}",
+      "success": "Deleted {count} expert feedback record(s) for {chatId}.",
       "error": "Failed to delete expert evaluation: {message}",
       "notEvaluated": "Not evaluated."
     }
@@ -1392,7 +1392,7 @@
     }
   },
   "publicDashboard": {
-    "title": "AI Answers public dashboard",
+    "title": "Public dashboard",
     "usersOnlyPill": "Public users only",
     "footnote": "Data includes questions from public users only. Questions from partner and admin accounts signed in to test and evaluate are excluded.",
     "overviewTitle": "Overview",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -378,9 +378,8 @@
     }
   },
   "admin": {
-    "title": "AI Answers Admin",
-    "partnerTitle": "AI Answers Partner dashboard",
-    "backToAdmin": "Back to admin",
+    "title": "AI Answers admin home",
+    "partnerTitle": "AI Answers partner home",
     "navigation": {
       "ariaLabel": "Admin navigation",
       "title": "Admin menu",
@@ -398,7 +397,6 @@
       "publicDashboard": "Public dashboard",
       "partnerDashboard": "Partner dashboard",
       "technicalMetrics": "View technical metrics",
-      "publicEval": "Evaluate a public chat",
       "sessions": "Active sessions",
       "chatDashboard": "View chats",
       "logout": "Sign out",
@@ -564,7 +562,8 @@
       "viewUsers": "View and manage users"
     },
     "howTo": {
-      "title": "How to",
+      "title": "How to guides",
+      "trigger": "See all partner how tos",
       "evalInformedAnswers": "Evaluation-informed answers",
       "evaluateAnswers": "Evaluate answers",
       "partnerOnboarding": "Partner onboarding",
@@ -573,10 +572,15 @@
       "notFoundTitle": "Guide not found",
       "notFound": "That how-to guide does not exist."
     },
+    "chatTools": {
+      "title": "View and delete chats by ID"
+    },
     "viewChat": {
       "label": "Chat ID",
-      "placeholder": "Enter chat id",
-      "button": "View chat"
+      "button": "View chat",
+      "loading": "Looking up...",
+      "notFound": "No chat found with that ID",
+      "invalidFormat": "Invalid chat ID format"
     },
     "evalPage": {
       "similarityTitle": "Similarity-based expert feedback transfer",
@@ -783,6 +787,8 @@
       "noSearchResults": "No search results found.",
       "filtersClearedAnnouncement": "Filters cleared.",
       "viewChatById": "View chat by ID",
+      "chatIdRequired": "Please enter a chat ID.",
+      "chatIdPlaceholder": "Enter full chat ID",
       "sortActivateAscending": "{column}: activate for ascending sort",
       "sortActivateDescending": "{column}: activate for descending sort",
       "sortRemove": "{column}: activate to remove sort",
@@ -834,7 +840,6 @@
       "searchChatIdPlaceholder": "Enter chat ID (partial or full)",
       "searchButton": "Search for chat ID",
       "searchNotFound": "No chat found with that ID.",
-      "searchRequired": "Please enter a chat ID.",
       "resultsHeading": "Evaluation results",
       "columns": {
         "chatId": "Chat ID",
@@ -905,7 +910,7 @@
       "idLabel": "Chat ID",
       "button": "Delete chat",
       "loading": "Deleting...",
-      "success": "Chat deleted successfully",
+      "success": "{chatId} deleted successfully",
       "error": "Failed to delete chat: {message}"
     },
     "deleteExpertEval": {
@@ -913,7 +918,7 @@
       "idLabel": "Chat ID",
       "button": "Delete expert evaluation",
       "loading": "Deleting...",
-      "success": "Expert evaluation deleted successfully",
+      "success": "Deleted {count} expert feedback record(s) for {chatId}",
       "error": "Failed to delete expert evaluation: {message}",
       "notEvaluated": "Not evaluated."
     }
@@ -1387,7 +1392,7 @@
     }
   },
   "publicDashboard": {
-    "title": "AI Answers Public dashboard",
+    "title": "AI Answers public dashboard",
     "usersOnlyPill": "Public users only",
     "footnote": "Data includes questions from public users only. Questions from partner and admin accounts signed in to test and evaluate are excluded.",
     "overviewTitle": "Overview",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -579,7 +579,6 @@
       "label": "ID de chat",
       "button": "Afficher le chat",
       "loading": "Recherche en cours...",
-      "notFound": "Aucun chat trouvé avec cet ID",
       "invalidFormat": "Format d'ID de chat invalide"
     },
     "evalPage": {
@@ -789,6 +788,8 @@
       "viewChatById": "Voir le chat par ID",
       "chatIdRequired": "Veuillez entrer un identifiant de clavardage.",
       "chatIdPlaceholder": "Entrez l'ID complet du chat",
+      "chatNotFound": "Aucun chat trouvé avec cet ID.",
+      "fetchFailed": "Échec du chargement des données. Veuillez réessayer.",
       "sortActivateAscending": "{column} : activer le tri croissant",
       "sortActivateDescending": "{column} : activer le tri décroissant",
       "sortRemove": "{column} : activer pour annuler le tri",
@@ -839,7 +840,6 @@
       "searchChatIdInputLabel": "ID de chat",
       "searchChatIdPlaceholder": "Entrez l'ID de chat (partiel ou complet)",
       "searchButton": "Rechercher l'ID de chat",
-      "searchNotFound": "Aucun chat trouvé avec cet ID.",
       "resultsHeading": "Résultats de l'évaluation",
       "columns": {
         "chatId": "ID de chat",
@@ -889,7 +889,7 @@
       "idLabel": "ID de chat",
       "button": "Supprimer le chat",
       "loading": "Suppression en cours...",
-      "success": "{chatId} supprimé avec succès",
+      "success": "{chatId} supprimé avec succès.",
       "error": "Échec de la suppression du chat : {message}"
     },
     "deleteExpertEval": {
@@ -897,7 +897,7 @@
       "idLabel": "ID de chat",
       "button": "Supprimer l'évaluation d'expert",
       "loading": "Suppression en cours...",
-      "success": "Supprimé {count} évaluation(s) d'expert pour {chatId}",
+      "success": "Supprimé {count} évaluation(s) d'expert pour {chatId}.",
       "error": "Échec de la suppression de l'évaluation d'expert : {message}",
       "notEvaluated": "Non évalué."
     },
@@ -1392,7 +1392,7 @@
     }
   },
   "publicDashboard": {
-    "title": "Tableau de bord public Réponses IA",
+    "title": "Tableau de bord public",
     "usersOnlyPill": "Utilisateurs du public seulement",
     "footnote": "Les données comprennent uniquement les questions des utilisateurs du public. Les questions des comptes partenaires et administrateurs connectés pour tester et évaluer sont exclues.",
     "overviewTitle": "Aperçu",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -378,9 +378,8 @@
     }
   },
   "admin": {
-    "title": "Administration de Réponses IA",
-    "partnerTitle": "Tableau de bord partenaire Réponses IA",
-    "backToAdmin": "Retour à l'administration",
+    "title": "Accueil administrateur de Réponses IA",
+    "partnerTitle": "Accueil partenaire de Réponses IA",
     "navigation": {
       "ariaLabel": "Navigation administrateur",
       "title": "Menu administrateur",
@@ -398,7 +397,6 @@
       "publicDashboard": "Tableau de bord public",
       "partnerDashboard": "Tableau de bord partenaire",
       "technicalMetrics": "Voir les métriques techniques",
-      "publicEval": "Évaluer un chat public",
       "sessions": "Sessions actives",
       "chatDashboard": "Voir les chats",
       "logout": "Se déconnecter",
@@ -564,7 +562,8 @@
       "viewUsers": "Voir et gérer les utilisateurs"
     },
     "howTo": {
-      "title": "Comment faire",
+      "title": "Guides pratiques",
+      "trigger": "Voir tous les guides pratiques pour les partenaires",
       "evalInformedAnswers": "Réponses informées par les évaluations",
       "evaluateAnswers": "Évaluer les réponses",
       "partnerOnboarding": "Intégration des partenaires",
@@ -573,10 +572,15 @@
       "notFoundTitle": "Guide introuvable",
       "notFound": "Ce guide n'existe pas."
     },
+    "chatTools": {
+      "title": "Afficher et supprimer des chats par ID"
+    },
     "viewChat": {
       "label": "ID de chat",
-      "placeholder": "Entrez l'ID du chat",
-      "button": "Afficher le chat"
+      "button": "Afficher le chat",
+      "loading": "Recherche en cours...",
+      "notFound": "Aucun chat trouvé avec cet ID",
+      "invalidFormat": "Format d'ID de chat invalide"
     },
     "evalPage": {
       "similarityTitle": "Transfert de rétroaction d'experts basé sur la similarité",
@@ -783,6 +787,8 @@
       "noSearchResults": "Aucun résultat de recherche trouvé.",
       "filtersClearedAnnouncement": "Filtres réinitialisés.",
       "viewChatById": "Voir le chat par ID",
+      "chatIdRequired": "Veuillez entrer un identifiant de clavardage.",
+      "chatIdPlaceholder": "Entrez l'ID complet du chat",
       "sortActivateAscending": "{column} : activer le tri croissant",
       "sortActivateDescending": "{column} : activer le tri décroissant",
       "sortRemove": "{column} : activer pour annuler le tri",
@@ -834,7 +840,6 @@
       "searchChatIdPlaceholder": "Entrez l'ID de chat (partiel ou complet)",
       "searchButton": "Rechercher l'ID de chat",
       "searchNotFound": "Aucun chat trouvé avec cet ID.",
-      "searchRequired": "Veuillez entrer un identifiant de clavardage.",
       "resultsHeading": "Résultats de l'évaluation",
       "columns": {
         "chatId": "ID de chat",
@@ -884,7 +889,7 @@
       "idLabel": "ID de chat",
       "button": "Supprimer le chat",
       "loading": "Suppression en cours...",
-      "success": "Chat supprimé avec succès",
+      "success": "{chatId} supprimé avec succès",
       "error": "Échec de la suppression du chat : {message}"
     },
     "deleteExpertEval": {
@@ -892,7 +897,7 @@
       "idLabel": "ID de chat",
       "button": "Supprimer l'évaluation d'expert",
       "loading": "Suppression en cours...",
-      "success": "Évaluation d'expert supprimée avec succès",
+      "success": "Supprimé {count} évaluation(s) d'expert pour {chatId}",
       "error": "Échec de la suppression de l'évaluation d'expert : {message}",
       "notEvaluated": "Non évalué."
     },

--- a/src/pages/AdminPage.js
+++ b/src/pages/AdminPage.js
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
-import { GcdsContainer, GcdsLink, GcdsButton } from '@gcds-core/components-react';
+import { GcdsContainer, GcdsLink } from '@gcds-core/components-react';
 import { useAuth } from '../contexts/AuthContext.js';
 import ChatLogsDashboard from '../components/admin/ChatLogsDashboard.js';
+import ViewChatByIdSection from '../components/admin/ViewChatByIdSection.js';
 import DeleteChatSection from '../components/admin/DeleteChatSection.js';
 import DeleteExpertEval from '../components/DeleteExpertEval.js';
 import { RoleBasedContent } from '../components/RoleBasedUI.js';
@@ -14,8 +14,6 @@ import { HOW_TOS } from '../config/howTos.js';
 const AdminPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const { logout, currentUser } = useAuth();
-  const navigate = useNavigate();
-  const [lookupChatId, setLookupChatId] = useState('');
 
   const handleLogout = () => {
     logout();
@@ -35,9 +33,7 @@ const AdminPage = ({ lang = 'en' }) => {
   return (
     <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">
-        {isPartner
-          ? t('admin.partnerTitle', 'AI Answers Partner Dashboard')
-          : t('admin.title', 'Admin Dashboard')}
+        {isPartner ? t('admin.partnerTitle') : t('admin.title')}
       </h1>
 
       {/* Admin notifications panel - only visible to admins */}
@@ -50,27 +46,27 @@ const AdminPage = ({ lang = 'en' }) => {
         {/* Partner Menu - Visible to everyone (Partner & Admin) */}
         <section className="mb-400">
           <h2 className="mt-400 mb-400">
-            {t('admin.navigation.partnerMenu', 'Partner Menu')}
+            {t('admin.navigation.partnerMenu')}
           </h2>
           <ul className="list-none p-0">
             <li>
               <GcdsLink href={`/${lang}`} target="_blank" rel="noopener noreferrer">
-                {t('admin.navigation.aiAnswers', 'AI Answers')}
+                {t('admin.navigation.aiAnswers')}
               </GcdsLink>
             </li>
             <li>
               <GcdsLink href={getPath('eval-dashboard', lang)}>
-                {t('admin.navigation.evalDashboard', 'Evaluation dashboard')}
+                {t('admin.navigation.evalDashboard')}
               </GcdsLink>
             </li>
             <li>
               <GcdsLink href={getPath('chat-dashboard', lang)}>
-                {t('admin.navigation.chatDashboard', 'Chat dashboard')}
+                {t('admin.navigation.chatDashboard')}
               </GcdsLink>
             </li>
             <li>
               <GcdsLink href={getPath('metrics', lang)}>
-                {t('admin.navigation.metrics', 'View performance metrics')}
+                {t('admin.navigation.metrics')}
               </GcdsLink>
             </li>
             <li>
@@ -80,7 +76,7 @@ const AdminPage = ({ lang = 'en' }) => {
             </li>
             <li>
               <GcdsLink href={getPath('scenario-overrides', lang)}>
-                {t('admin.navigation.scenarioOverrides', 'Scenario overrides')}
+                {t('admin.navigation.scenarioOverrides')}
               </GcdsLink>
             </li>
             <li>
@@ -90,7 +86,7 @@ const AdminPage = ({ lang = 'en' }) => {
             </li>
             <li>
               <GcdsLink href={getPath('batch', lang)}>
-                {t('admin.navigation.batches', 'View and manage batches')}
+                {t('admin.navigation.batches')}
               </GcdsLink>
             </li>
             <li>
@@ -105,22 +101,22 @@ const AdminPage = ({ lang = 'en' }) => {
         <RoleBasedContent roles={["admin"]}>
           <section className="mb-400">
             <h2 className="mt-400 mb-400">
-              {t('admin.navigation.title', 'Admin Menu')}
+              {t('admin.navigation.title')}
             </h2>
             <ul className="list-none p-0">
               <li>
                 <GcdsLink href={getPath('users', lang)}>
-                  {t('admin.navigation.users', 'Manage User Accounts')}
+                  {t('admin.navigation.users')}
                 </GcdsLink>
               </li>
               <li>
                 <GcdsLink href={getPath('database', lang)}>
-                  {t('admin.navigation.database', 'Manage the database')}
+                  {t('admin.navigation.database')}
                 </GcdsLink>
               </li>
               <li>
                 <GcdsLink href={getPath('eval', lang)}>
-                  {t('admin.navigation.eval', 'Evaluation Administration')}
+                  {t('admin.navigation.eval')}
                 </GcdsLink>
               </li>
               <li>
@@ -135,31 +131,31 @@ const AdminPage = ({ lang = 'en' }) => {
               </li>
               <li>
                 <GcdsLink href={getPath('vector', lang)}>
-                  {t('admin.navigation.vector', 'Vector Administration')}
+                  {t('admin.navigation.vector')}
                 </GcdsLink>
               </li>
               <li>
                 <GcdsLink href={getPath('settings', lang)}>
-                  {t('settings.title', 'Settings')}
+                  {t('settings.title')}
                 </GcdsLink>
               </li>
               <li>
                 <GcdsLink href={getPath('sessions', lang)}>
-                  {t('admin.navigation.sessions', 'Active Sessions')}
+                  {t('admin.navigation.sessions')}
                 </GcdsLink>
               </li>
               <li>
                 <GcdsLink href={getPath('connectivity', lang)}>
-                  {t('admin.navigation.connectivity', 'Service Connectivity')}
+                  {t('admin.navigation.connectivity')}
                 </GcdsLink>
               </li>
               {/* Experimental Features */}
               <li className="mt-400">
-                <strong>{t('admin.navigation.experimental', 'Experimental')}</strong>
+                <strong>{t('admin.navigation.experimental')}</strong>
                 <ul className="list-none pl-400">
                   <li>
                     <GcdsLink href={getPath('experimental-datasets', lang)}>
-                      {t('admin.navigation.dataAnalysis', 'Data Analysis')}
+                      {t('admin.navigation.dataAnalysis')}
                     </GcdsLink>
                   </li>
                 </ul>
@@ -178,7 +174,7 @@ const AdminPage = ({ lang = 'en' }) => {
                 className="filter-button-secondary filter-button-secondary--inline"
                 onClick={handleLogout}
               >
-                {t('admin.navigation.logout', 'Logout')}
+                {t('admin.navigation.logout')}
               </button>
             </li>
           </ul>
@@ -188,9 +184,10 @@ const AdminPage = ({ lang = 'en' }) => {
       {/* How-to guides, rendered in-app from public/content/admin/ */}
       <RoleBasedContent roles={["admin", "partner"]}>
         <section className="mb-400">
+          <h2 className="mt-400 mb-200">{t('admin.howTo.title')}</h2>
           <details>
-            <summary>{t('admin.howTo.title')}</summary>
-            <ul className="list-none p-0">
+            <summary>{t('admin.howTo.trigger')}</summary>
+            <ul className="list-disc canada-ca-list-spcd-1 mt-200">
               {HOW_TOS.map((howTo) => (
                 <li key={howTo.id}>
                   {/* New tab so the guide stays open alongside the page it describes */}
@@ -204,44 +201,24 @@ const AdminPage = ({ lang = 'en' }) => {
         </section>
       </RoleBasedContent>
 
-      {/* Quick chat lookup for admins and partners */}
+      {/* Chat ID utilities for admins and partners: one real heading (not
+          repeated per row - see SettingsPage.js's own accordion for the
+          "one visible label per row, no separate heading" look this
+          matches), three collapsed-by-default <details> rows underneath it,
+          each row's own <summary> text the row's only label. ViewChatByIdSection.js/
+          DeleteChatSection.js/DeleteExpertEval.js each render their own
+          <details> row the same way, as standalone reusable components. */}
       <RoleBasedContent roles={["admin", "partner"]}>
         <section className="mb-400">
-          <h2 className="mt-400 mb-200">{t('admin.common.viewChatById')}</h2>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (!lookupChatId) return;
-              navigate(`/${lang}?chat=${encodeURIComponent(lookupChatId)}&review=1`);
-            }}
-          >
-            <label htmlFor="view-chat-id" className="sr-only">
-              {t('admin.viewChat.label', 'Chat ID')}
-            </label>
-            <div className="flex gap-400">
-              <input
-                id="view-chat-id"
-                name="view-chat-id"
-                type="text"
-                className="form-control"
-                value={lookupChatId}
-                onChange={(e) => setLookupChatId(e.target.value)}
-                placeholder={t('admin.viewChat.placeholder', 'Enter chat id')}
-              />
-              <GcdsButton type="submit" disabled={!lookupChatId.trim()}>
-                {t('admin.viewChat.button', 'View chat')}
-              </GcdsButton>
-            </div>
-          </form>
+          <h2 className="mt-400 mb-200">{t('admin.chatTools.title')}</h2>
+          <ViewChatByIdSection lang={lang} />
+          <DeleteChatSection lang={lang} />
+          <DeleteExpertEval lang={lang} />
         </section>
       </RoleBasedContent>
 
-      <DeleteChatSection lang={lang} />
-
-      <DeleteExpertEval lang={lang} />
-
       <section id="chat-logs" className="mb-600">
-        <h2 className="mt-400 mb-400">{t('admin.chatLogs.title', 'Recent Chat Interactions')}</h2>
+        <h2 className="mt-400 mb-400">{t('admin.chatLogs.title')}</h2>
         <ChatLogsDashboard lang={lang} />
       </section>
     </GcdsContainer >

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -533,7 +533,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
               </button>
             </form>
             {searchChatIdNotFound && (
-              <StatusMessage variant="info" message={t('admin.evalDashboard.searchNotFound')} />
+              <StatusMessage variant="info" message={t('admin.common.chatNotFound')} />
             )}
           </div>
         </details>

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -506,7 +506,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
               {hasSearchChatIdError && (
                 <FeedbackInlineError
                   id="eval-search-chat-id-error"
-                  message={t('admin.evalDashboard.searchRequired')}
+                  message={t('admin.common.chatIdRequired')}
                   errorCount={searchChatIdErrorCount}
                   inputRef={searchChatIdErrorRef}
                 />

--- a/src/pages/PublicDashboardPage.js
+++ b/src/pages/PublicDashboardPage.js
@@ -9,7 +9,16 @@ const PublicDashboardPage = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('publicDashboard.title')}</h1>
+      {/* Split/"stacked" title — see admin.css's .canada-ca-h1-stacked__eyebrow
+          comment for the full explanation of this Canada.ca Specifications/
+          GCWeb pattern. Reuses homepage.title (the site's own brand name)
+          rather than a new key — publicDashboard.title used to repeat "AI
+          Answers" itself, redundant once it's the eyebrow above it, so that
+          key was trimmed down to just the page's own name. */}
+      <h1 className="mb-400">
+        <span className="canada-ca-h1-stacked__eyebrow">{t('homepage.title')}</span>
+        <span className="canada-ca-h1-stacked__title">{t('publicDashboard.title')}</span>
+      </h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>

--- a/src/pages/__tests__/EvalDashboardPage.searchBeforeApply.test.js
+++ b/src/pages/__tests__/EvalDashboardPage.searchBeforeApply.test.js
@@ -118,7 +118,7 @@ describe('EvalDashboardPage - search-by-ID surfaced before Apply', () => {
     await submitChatIdSearch(container, 'no-such-id');
 
     expect(container.querySelector('[data-testid="mock-data-table"]')).toBeNull();
-    expect(getByText('admin.evalDashboard.searchNotFound')).toBeTruthy();
+    expect(getByText('admin.common.chatNotFound')).toBeTruthy();
     // The box stays up so the user can try again immediately.
     expect(container.querySelector('#eval-search-chat-id-input')).not.toBeNull();
   });
@@ -128,11 +128,11 @@ describe('EvalDashboardPage - search-by-ID surfaced before Apply', () => {
 
     const { container, queryByText } = render(<EvalDashboardPage lang="en" />);
     await submitChatIdSearch(container, 'no-such-id');
-    expect(queryByText('admin.evalDashboard.searchNotFound')).toBeTruthy();
+    expect(queryByText('admin.common.chatNotFound')).toBeTruthy();
 
     fireEvent.change(container.querySelector('#eval-search-chat-id-input'), { target: { value: 'no-such-id2' } });
 
-    expect(queryByText('admin.evalDashboard.searchNotFound')).toBeNull();
+    expect(queryByText('admin.common.chatNotFound')).toBeNull();
   });
 
   it('shows a validation error on an empty submit instead of querying, and clears it once the user types', async () => {

--- a/src/pages/__tests__/EvalDashboardPage.searchBeforeApply.test.js
+++ b/src/pages/__tests__/EvalDashboardPage.searchBeforeApply.test.js
@@ -143,11 +143,11 @@ describe('EvalDashboardPage - search-by-ID surfaced before Apply', () => {
     });
 
     expect(EvaluationService.getEvalDashboard).not.toHaveBeenCalled();
-    expect(getByText('admin.evalDashboard.searchRequired')).toBeTruthy();
+    expect(getByText('admin.common.chatIdRequired')).toBeTruthy();
     expect(container.querySelector('#eval-search-chat-id-input').getAttribute('aria-describedby')).toBe('eval-search-chat-id-error');
 
     fireEvent.change(container.querySelector('#eval-search-chat-id-input'), { target: { value: 'abc' } });
 
-    expect(queryByText('admin.evalDashboard.searchRequired')).toBeNull();
+    expect(queryByText('admin.common.chatIdRequired')).toBeNull();
   });
 });

--- a/src/services/DataStoreService.js
+++ b/src/services/DataStoreService.js
@@ -318,6 +318,14 @@ class DataStoreService {
   static async getChat(chatId) {
     try {
       const response = await AuthService.fetch(getApiUrl(`db-chat?chatId=${chatId}`));
+      // 404 (db-chat.js's own "Chat not found") is a real, expected outcome
+      // for this call's two admin-tool callers (existence pre-check before
+      // delete, direct lookup-by-ID) — return the same { chat: null } shape
+      // they already check for on success, rather than throwing. Any other
+      // non-ok status (500, auth failure, etc.) still throws below, so
+      // callers can tell "doesn't exist" apart from "the lookup itself
+      // failed" instead of both collapsing into one generic error.
+      if (response.status === 404) return { chat: null };
       if (!response.ok) throw new Error('Failed to fetch chat');
       return await response.json();
     } catch (error) {

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -766,6 +766,37 @@
   max-width: 40rem;
 }
 
+/* Same shape as .eval-search-chat-id__field above (matching max-width, on
+   a wrapping <div> rather than the input itself) - ChatIdLookupField.js's
+   own input. Block-level wrapper, not just a width cap: without it, once
+   the input stops being width:100% (which forced the button below it by
+   consuming the whole line), the input and its inline-level GcdsButton
+   sibling had room to sit side by side again in normal flow. Wrapping the
+   input in its own block guarantees the button starts on a new line
+   regardless of either element's own display type. */
+.chat-id-lookup-field {
+  max-width: 40rem;
+}
+
+/* ChatLogsDashboard.js's export View/Format dropdowns. Previously
+   `className="flex items-center gap-4 flex-wrap"` on the row and
+   `className="export-control-group"` on each field - none of those
+   classes were ever defined anywhere in this project's CSS (Tailwind-style
+   names with nothing behind them), so the row had no flex/gap/wrap at all
+   and each .filter-select (which *is* real, width:100%) just stretched
+   full-width and stacked with plain block-level spacing between them -
+   read as "too much space", not a deliberate gap. */
+.export-controls-row {
+  display: flex;
+  align-items: center;
+  gap: var(--gcds-spacing-400);
+  flex-wrap: wrap;
+}
+
+.export-control-group {
+  max-width: 16rem;
+}
+
 /* Search box + entries-per-page/pagination focus styling, split out from
    .dashboard-table-container below for tables that shouldn't take its 90vw
    full-viewport breakout width (e.g. MetricsDashboard.js's Institution
@@ -2939,4 +2970,49 @@ table.dataTable.dashboard-table thead th[data-tooltip]::after {
 
 .admin-notifications-action::after {
   content: "→";
+}
+
+/* Split/"stacked" h1 — small eyebrow (aka kicker/overline) label above a
+   large role title. A Canada.ca Specifications/GCWeb pattern (design.canada.ca
+   renders it as `h1 span.stacked`, using flex-direction: column-reverse to
+   visually flip a DOM order that writes the big title first); GC DS doesn't
+   have an equivalent heading variant yet, so this is hand-built rather than
+   token-driven for the eyebrow's own size/weight — everything else (the h1's
+   own bold title size and its red underline) already comes from GC DS as-is,
+   this only adds the small label above it.
+   TOKEN SUGGESTION: GC DS could add a "kicker"/eyebrow slot or size token to
+   GcdsHeading for exactly this — a small secondary label above the heading
+   text, sized off something like --gcds-heading-h4-desktop/-mobile the way
+   this class approximates by hand. */
+.canada-ca-h1-stacked__eyebrow,
+.canada-ca-h1-stacked__title {
+  display: block;
+}
+
+.canada-ca-h1-stacked__eyebrow {
+  font-family: "Lato", sans-serif;
+  font-size: 1.6875rem; /* matches --gcds-heading-h4-desktop's size */
+  line-height: 133%;
+  font-weight: 500;
+  color: var(--gcds-heading-role-secondary);
+  margin-bottom: var(--gcds-heading-spacing-25);
+}
+
+@media (max-width: 47.9375em) {
+  .canada-ca-h1-stacked__eyebrow {
+    font-size: 1.5rem; /* matches --gcds-heading-h4-mobile's size */
+  }
+}
+
+/* GcdsButton's own shadow CSS sets `transition: all .15s ease-in-out` on its
+   button part. Inside a native <details> (chat-ID lookup/delete rows, how-to
+   guides), the button is hidden until the panel opens — its first paint then
+   also gets caught by that `all` transition, producing a visible "pop" as
+   the button's final styles appear to animate in rather than just render.
+   Scoping the transition down to only the properties that should actually
+   animate (hover/focus feedback) via ::part(button) keeps that feedback
+   without the pop. */
+details gcds-button::part(button) {
+  transition: background-color .15s ease-in-out, color .15s ease-in-out,
+    border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 }

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -762,18 +762,15 @@
 .eval-search-chat-id.filter-panel:not([open]) > .filter-panel-summary:hover {
   background: #f3f4f6;
 }
-.eval-search-chat-id__field {
-  max-width: 40rem;
-}
-
-/* Same shape as .eval-search-chat-id__field above (matching max-width, on
-   a wrapping <div> rather than the input itself) - ChatIdLookupField.js's
-   own input. Block-level wrapper, not just a width cap: without it, once
-   the input stops being width:100% (which forced the button below it by
-   consuming the whole line), the input and its inline-level GcdsButton
-   sibling had room to sit side by side again in normal flow. Wrapping the
-   input in its own block guarantees the button starts on a new line
-   regardless of either element's own display type. */
+/* Shared by EvalDashboardPage.js's search field and ChatIdLookupField.js's
+   own input - both are block-level wrappers around a chat-ID input, not
+   just a width cap: without it, once the input stops being width:100%
+   (which forced the button below it by consuming the whole line), the
+   input and its inline-level GcdsButton sibling had room to sit side by
+   side again in normal flow. Wrapping the input in its own block
+   guarantees the button starts on a new line regardless of either
+   element's own display type. */
+.eval-search-chat-id__field,
 .chat-id-lookup-field {
   max-width: 40rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -228,6 +228,11 @@ gcds-details {
   margin-bottom: 1.25em;
 }
 
+/* -2 above: long/bulleted-paragraph items. -1 here: short-sentence items. */
+.canada-ca-list-spcd-1 li {
+  margin-bottom: 0.625em;
+}
+
 .flex-center {
   display: flex;
   align-items: center;

--- a/src/utils/admin/chatIdFormat.js
+++ b/src/utils/admin/chatIdFormat.js
@@ -1,0 +1,8 @@
+// Chat IDs are generated as uuidv4() (middleware/chat-session.js) - this
+// lets a lookup/delete-by-chat-ID field reject an obviously malformed
+// value client-side, before spending a round trip on it. A syntactically
+// valid-but-nonexistent ID still has to go to the server to find out -
+// this only catches the "that's not even shaped like a chat ID" case.
+const CHAT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const isValidChatIdFormat = (value) => CHAT_ID_PATTERN.test((value || '').trim());


### PR DESCRIPTION
fix: admin page accessibility rebuild — chat-ID tools, H1 wording, bilingual messages

  Chat-ID tool consolidation & accessibility
  - Extract shared ChatIdLookupField/DeleteByChatIdSection components used by
    ViewChatByIdSection, DeleteChatSection, and DeleteExpertEval, replacing
    three near-duplicate implementations with one `<details>` row pattern per
    tool (its own <summary> as the row's only label, not a repeated heading)
    (WCAG 3.2.4 Consistent Identification — same function, same structure and
    labeling across all three tools instead of three implementations free to
    drift apart)
  - Add an existence pre-check (DataStoreService.getChat) before the delete
    confirm dialog, so a not-found chat ID is identified in text instead of
    proceeding into a native confirm() over a record that doesn't exist
    (WCAG 3.3.1 Error Identification)
  - Fix StatusMessage's icon-drop bug: content: children || (icon + message)
    silently dropped the icon whenever a caller passed children instead of
    message, leaving 5 error/success boxes distinguishable by background
    color alone. Icon now renders unconditionally
    (WCAG 1.4.1 Use of Color — state can't be conveyed by color alone)
  - Consolidate a duplicated chat-ID-required validation message
    (admin.evalDashboard.searchRequired -> admin.common.chatIdRequired) so
    the same input error is identified the same way on every page
    (WCAG 3.2.4 Consistent Identification)

  H1 wording
  - Settle on "AI Answers admin home" / "AI Answers partner home" (EN) and
    "Accueil administrateur/partenaire de Réponses IA" (FR). The prior H1
    ("Admin Dashboard" / "AI Answers Partner dashboard") didn't distinguish
    this page — the entry point — from the many dashboards it links to
    (Eval dashboard, Chat dashboard, Metrics, Partner dashboard); "admin/
    partner home" names what this page actually is
    (WCAG 2.4.6 Headings and Labels — headings must describe topic or purpose)
  - Strip old-style t(key, 'fallback') args across AdminPage.js's nav (24
    call sites) now that every key is confirmed present in both locales
    (Official Languages requirement, not a numbered WCAG criterion — a
    fallback silently serves English if a French entry ever goes missing,
    rather than failing loudly)

  Dead locale key cleanup (not an accessibility change — locale hygiene)
  - Remove admin.backToAdmin (superseded by common.backToAdmin) and
    admin.navigation.publicEval (confirmed intentional retirement,
    superseded by the Users filter in Chat Dashboard) — both verified to
    have zero live references, including dynamic/config-driven usage

  Bilingual delete-message fixes
  - DeleteExpertEval's and DeleteChatSection's success messages displayed
    raw, server-built English text with no translation and no lang="en"
    wrapper — a French admin/partner would have a screen reader attempt to
    pronounce English text as French
    (WCAG 3.1.2 Language of Parts — resolved outright via real translation
    rather than patched with a lang attribute)
    Now use the translated key with {count}/{chatId} interpolation; tests
    updated to match