### PR TITLE
Fix/heading-structure-a11y-revision

### DIFF
--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -240,7 +240,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
   const SectionWrapper = ({ children, isLoading, title, error }) => (
     <div className="mb-600">
       <div>
-        {title && <h3 className="mb-0">{title}</h3>}
+        {title && <h2 className="mb-0">{title}</h2>}
         {isLoading && (
           <SectionLoadingIndicator message={t('common.loading')} />
         )}
@@ -549,7 +549,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
 
             <SectionWrapper isLoading={loadingState.dept} title={null} error={errorState.dept}>
               <div className="mb-600">
-                <h3 className="mb-0">{t('metrics.dashboard.byDepartment.title')}</h3>
+                <h2 className="mb-0">{t('metrics.dashboard.byDepartment.title')}</h2>
                 {/* metrics-table-container (admin.css): same styled search
                     box as ChatDashboardPage.js/EvalDashboardPage.js's
                     .dashboard-table-container, minus its 90vw breakout width

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -281,6 +281,14 @@ const PartnerDashboard = ({ lang = 'en' }) => {
 
   return (
     <div>
+      {/* Visually hidden - same pattern as Chat/Eval/Metrics/AutoEval
+          dashboards' matching heading: the filter panel's own summary/
+          controls already make its purpose clear on screen. Kept as a real
+          heading (not removed) so screen-reader users navigating by
+          heading/landmark still get this section announced. Previously
+          missing here entirely - every sibling dashboard using FilterPanel
+          had this, this one didn't. */}
+      <h2 className="sr-only">{t('admin.filters.title')}</h2>
       <div className="mb-100">
         <FilterPanel
           lang={lang}

--- a/src/components/admin/PartnerDashboard.js
+++ b/src/components/admin/PartnerDashboard.js
@@ -282,13 +282,13 @@ const PartnerDashboard = ({ lang = 'en' }) => {
   return (
     <div>
       {/* Visually hidden - same pattern as Chat/Eval/Metrics/AutoEval
-          dashboards' matching heading: the filter panel's own summary/
-          controls already make its purpose clear on screen. Kept as a real
-          heading (not removed) so screen-reader users navigating by
-          heading/landmark still get this section announced. Previously
+          dashboards' matching heading: FilterPanel's own <summary> isn't
+          heading-navigable, so this gives screen-reader users a
+          heading/landmark entry point into the filter section. Distinct
+          text from FilterPanel's "Filters" summary label. Previously
           missing here entirely - every sibling dashboard using FilterPanel
           had this, this one didn't. */}
-      <h2 className="sr-only">{t('admin.filters.title')}</h2>
+      <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
       <div className="mb-100">
         <FilterPanel
           lang={lang}

--- a/src/components/admin/PublicDashboard.js
+++ b/src/components/admin/PublicDashboard.js
@@ -145,9 +145,31 @@ const PublicDashboard = ({ lang = 'en' }) => {
 
       <DashboardFilterBar lang={lang} loading={loading} onInitialLoad={handleInitialLoad} onApply={handleApply} minDate={minDate} />
 
-      <h2 className="dashboard-section-title">
-        {formatDateRange(appliedStartDate, appliedEndDate)}
-      </h2>
+      {/* "Overview" above owns the filter bar (this page has just the two
+          sections - Overview, Safety metrics - so it doubles as that
+          section's own intro rather than needing a separate Filters
+          heading). This h2 is the real sibling heading for the results
+          that follow - visually hidden since the visible date-range text
+          right below it already makes the section's purpose clear on
+          screen (same reasoning as the Filters/Results headings elsewhere
+          in this app), kept as a real heading so screen-reader users
+          navigating by heading/landmark still get it announced. Was
+          previously a second *visible* <h2> whose text was the computed
+          date range itself - not descriptive heading text (SC 2.4.6), and
+          genuinely empty before the first fetch resolves. A heading also
+          needs to stay the same across interactions to work as a reliable
+          landmark (a user re-navigating by heading expects "Results" to
+          mean the same thing every time) - a heading whose text is a
+          computed value that changes with every filter apply defeats that,
+          independent of the emptiness bug. The date range is a data value,
+          not a heading - shown as a prominent styled <p> instead, only
+          once there's something to show. */}
+      <h2 className="sr-only">{t('admin.common.resultsHeading')}</h2>
+      {appliedStartDate && appliedEndDate && (
+        <p className="dashboard-section-title">
+          {formatDateRange(appliedStartDate, appliedEndDate)}
+        </p>
+      )}
 
       {loading ? (
         <LoadingOverlay message={t('common.loading')} />

--- a/src/components/admin/TechnicalMetricsDashboard.js
+++ b/src/components/admin/TechnicalMetricsDashboard.js
@@ -66,7 +66,7 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
   const SectionWrapper = ({ children, isLoading, title, error, note }) => (
     <div className="mb-600">
       <div>
-        {title && <h3 className="mb-0">{title}</h3>}
+        {title && <h2 className="mb-0">{title}</h2>}
         {note && <p className="font-size-text-small mb-300">{note}</p>}
         {isLoading && (
           <SectionLoadingIndicator message={t('common.loading')} />

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -115,7 +115,7 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
 
   return (
     <div className="mb-600">
-      <h3 className="mb-0">{t('metrics.dashboard.userScored.title')}</h3>
+      <h2 className="mb-0">{t('metrics.dashboard.userScored.title')}</h2>
       <GcdsText className="font-size-text-xsm-nr mb-300">{t('metrics.dashboard.userScored.description')}</GcdsText>
       <div>
         {/* Totals Table */}
@@ -160,7 +160,7 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
             applies zebra/hover regardless, so this table currently looks
             slightly different from the plain Totals table above it. */}
         <div style={{ marginTop: '2rem' }}>
-          <h4>{t('metrics.dashboard.userScored.reasonTableTitle')}</h4>
+          <h3>{t('metrics.dashboard.userScored.reasonTableTitle')}</h3>
           <div className="metrics-table-container">
           <DataTable
             className="display dashboard-table"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -696,6 +696,7 @@
     },
     "filters": {
       "title": "Filters",
+      "sectionHeading": "Choose filter options",
       "clearAll": "Clear all",
       "apply": "Apply",
       "loading": "Loading...",
@@ -834,7 +835,6 @@
       "searchButton": "Search for chat ID",
       "searchNotFound": "No chat found with that ID.",
       "searchRequired": "Please enter a chat ID.",
-      "resultsHeading": "Evaluation results",
       "columns": {
         "chatId": "Chat ID",
         "questionNumber": "#",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -789,11 +789,11 @@
       "fetchError": "Failed to load data: {message}",
       "searchResultsAnnouncement": "{count} results found.",
       "searchResultsUpdatedAnnouncement": "Search results updated.",
-      "metricsLoading": "Loading metrics..."
+      "metricsLoading": "Loading metrics...",
+      "resultsHeading": "Results"
     },
     "chatDashboard": {
       "title": "Chat dashboard",
-      "timeRangeTitle": "Get chat interactions for the selected period",
       "loading": "Loading chats...",
       "error": "Unable to load chat data.",
       "columns": {
@@ -827,7 +827,6 @@
     },
     "evalDashboard": {
       "title": "Evaluation dashboard",
-      "timeRangeTitle": "Get evaluations for the selected period",
       "loading": "Loading evaluations...",
       "error": "Unable to load evaluation data.",
       "searchChatIdInputLabel": "Chat ID",
@@ -857,7 +856,6 @@
     "autoEvalDashboard": {
       "title": "Auto-evaluation dashboard",
       "description": "Filter auto-evaluations and explore details in the table below.",
-      "timeRangeTitle": "Get auto-evaluations for the selected period",
       "loading": "Loading evaluations...",
       "error": "Unable to load evaluation data.",
       "resultsSummary": "Total matching evaluations: {count}",
@@ -1602,7 +1600,6 @@
   },
   "metrics": {
     "title": "Metrics dashboard",
-    "timeRangeTitle": "Get usage and evaluation metrics",
     "dashboard": {
       "loadedAnnouncement": "Metrics loaded.",
       "totalSessions": "Total sessions",
@@ -1707,7 +1704,6 @@
   },
   "technicalMetrics": {
     "title": "Technical metrics",
-    "timeRangeTitle": "Get technical metrics for the selected period",
     "dashboard": {
       "loading": "Loading technical metrics...",
       "loadedAnnouncement": "Technical metrics loaded.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -696,6 +696,7 @@
     },
     "filters": {
       "title": "Filtres",
+      "sectionHeading": "Choisir des options de filtrage",
       "clearAll": "Tout effacer",
       "apply": "Appliquer",
       "loading": "Chargement...",
@@ -834,7 +835,6 @@
       "searchButton": "Rechercher l'ID de chat",
       "searchNotFound": "Aucun chat trouvé avec cet ID.",
       "searchRequired": "Veuillez entrer un identifiant de clavardage.",
-      "resultsHeading": "Résultats de l'évaluation",
       "columns": {
         "chatId": "ID de chat",
         "questionNumber": "#",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -789,11 +789,11 @@
       "fetchError": "Échec du chargement des données : {message}",
       "searchResultsAnnouncement": "{count} résultats trouvés.",
       "searchResultsUpdatedAnnouncement": "Résultats de recherche mis à jour.",
-      "metricsLoading": "Chargement des métriques..."
+      "metricsLoading": "Chargement des métriques...",
+      "resultsHeading": "Résultats"
     },
     "chatDashboard": {
       "title": "Tableau de bord de chat",
-      "timeRangeTitle": "Obtenir les interactions de clavardage pour la période sélectionnée",
       "loading": "Chargement des chats...",
       "error": "Impossible de charger les données de chat.",
       "columns": {
@@ -827,7 +827,6 @@
     },
     "evalDashboard": {
       "title": "Tableau de bord des évaluations",
-      "timeRangeTitle": "Obtenir les évaluations pour la période sélectionnée",
       "loading": "Chargement des évaluations...",
       "error": "Impossible de charger les données d'évaluation.",
       "searchChatIdInputLabel": "ID de chat",
@@ -857,7 +856,6 @@
     "autoEvalDashboard": {
       "title": "Tableau de bord des évaluations automatiques",
       "description": "Filtrez les évaluations automatiques et explorez les détails dans le tableau ci-dessous.",
-      "timeRangeTitle": "Obtenir les auto-évaluations pour la période sélectionnée",
       "loading": "Chargement des évaluations...",
       "error": "Impossible de charger les données d'évaluation.",
       "resultsSummary": "Total des évaluations correspondantes : {count}",
@@ -1602,7 +1600,6 @@
   },
   "metrics": {
     "title": "Tableau de bord des métriques",
-    "timeRangeTitle": "Obtenir les métriques d'utilisation et d'évaluation",
     "dashboard": {
       "loadedAnnouncement": "Métriques chargées.",
       "totalSessions": "Total des sessions",
@@ -1707,7 +1704,6 @@
   },
   "technicalMetrics": {
     "title": "Métriques techniques",
-    "timeRangeTitle": "Obtenir les métriques techniques pour la période sélectionnée",
     "dashboard": {
       "loading": "Chargement des métriques techniques...",
       "loadedAnnouncement": "Métriques techniques chargées.",

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -9,6 +9,7 @@ import EvaluationService from '../services/EvaluationService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import LoadingOverlay from '../components/admin/LoadingOverlay.js';
 import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
+import { wireTableAccessibility } from '../utils/admin/dataTableAccessibility.js';
 
 DataTable.use(DT);
 
@@ -134,7 +135,12 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
         </GcdsText>
       </nav>
 
-      <h2 className="mt-400 mb-400">{t('admin.autoEvalDashboard.timeRangeTitle')}</h2>
+      {/* Visually hidden - same as Chat/Eval/Metrics dashboards' matching
+          heading: the filter panel's own summary/controls already make its
+          purpose clear on screen. Kept as a real heading (not removed) so
+          screen-reader users navigating by heading/landmark still get this
+          section announced. */}
+      <h2 className="sr-only">{t('admin.filters.title')}</h2>
       <div className="mb-600">
         <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} filterLoading={loading} filterError={error} filterResultCount={pageResultCount} hasAppliedFilters={hasAppliedFilters} />
       </div>
@@ -193,15 +199,18 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
                   try {
                     const api = this.api();
                     tableApiRef.current = api;
-                    // TODO: no scope="col" headers, no search-term pill, no
-                    // sr-only search-results announcement here (unlike
-                    // ChatDashboardPage.js/EvalDashboardPage.js/
-                    // MetricsDashboard.js, which all share
-                    // utils/admin/dataTableAccessibility.js +
-                    // hooks/admin/useSearchAnnouncement.js). Needs
-                    // assessment: this table has per-column filter inputs
+                    // scope="col" headers only - wireTableAccessibility's
+                    // search-term pill/announcement half is a no-op here (it
+                    // bails out once it finds no .dt-search container), which
+                    // is correct: this table has per-column filter inputs
                     // instead of one global search box, so it's not yet
-                    // decided whether/how the shared pattern should apply.
+                    // decided whether/how that half of the shared pattern
+                    // (utils/admin/dataTableAccessibility.js +
+                    // hooks/admin/useSearchAnnouncement.js, used by
+                    // ChatDashboardPage.js/EvalDashboardPage.js/
+                    // MetricsDashboard.js) should apply to a per-column-filter
+                    // table like this one.
+                    wireTableAccessibility(api, { t });
                     const debounce = (fn, wait = 300) => {
                       let t = null;
                       return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), wait); };

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -136,11 +136,11 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
       </nav>
 
       {/* Visually hidden - same as Chat/Eval/Metrics dashboards' matching
-          heading: the filter panel's own summary/controls already make its
-          purpose clear on screen. Kept as a real heading (not removed) so
-          screen-reader users navigating by heading/landmark still get this
-          section announced. */}
-      <h2 className="sr-only">{t('admin.filters.title')}</h2>
+          heading: FilterPanel's own <summary> isn't heading-navigable, so
+          this gives screen-reader users a heading/landmark entry point into
+          the filter section. Distinct text from FilterPanel's "Filters"
+          summary label. */}
+      <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
       <div className="mb-600">
         <FilterPanel lang={lang} onApplyFilters={(filters) => { handleApplyFilters(filters); }} onClearFilters={handleClearFilters} isVisible={true} filterLoading={loading} filterError={error} filterResultCount={pageResultCount} hasAppliedFilters={hasAppliedFilters} />
       </div>

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -231,12 +231,12 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         </GcdsText>
       </nav>
 
-      {/* Visually hidden: the filter panel's own summary/controls already make
-          its purpose clear on screen, and this heading's copy just repeated
-          that at the cost of vertical space. Kept as a real heading (not
-          removed) so screen-reader users navigating by heading/landmark
-          still get this section announced. */}
-      <h2 className="sr-only">{t('admin.filters.title')}</h2>
+      {/* Visually hidden: FilterPanel's own <summary> isn't heading-navigable
+          (it's a disclosure toggle, not a heading), so this gives
+          screen-reader users a heading/landmark entry point into the filter
+          section. Distinct text from FilterPanel's "Filters" summary label
+          so the two don't read as an identical back-to-back announcement. */}
+      <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
       <div className="mb-100">
         <FilterPanel
           lang={lang}

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -236,7 +236,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
           that at the cost of vertical space. Kept as a real heading (not
           removed) so screen-reader users navigating by heading/landmark
           still get this section announced. */}
-      <h2 className="sr-only">{t('admin.chatDashboard.timeRangeTitle')}</h2>
+      <h2 className="sr-only">{t('admin.filters.title')}</h2>
       <div className="mb-100">
         <FilterPanel
           lang={lang}
@@ -280,6 +280,11 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         <div>
           {dataTableReady && (
             <div className="dashboard-table-container dashboard-table-container--grouped">
+              {/* Sibling of the Filters h2 above, not nested under it - matches
+                  EvalDashboardPage.js's resultsHeading. Previously nothing
+                  filled this role, so the table had no heading-navigation stop
+                  of its own at all. */}
+              <h2 className="sr-only">{t('admin.common.resultsHeading')}</h2>
               <DataTable
                 key={tableKey}
                 columns={columns}

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -433,7 +433,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
           clear on screen. Kept as a real heading (not removed) so
           screen-reader users navigating by heading/landmark still get this
           section announced. */}
-      <h2 className="sr-only">{t('admin.evalDashboard.timeRangeTitle')}</h2>
+      <h2 className="sr-only">{t('admin.filters.title')}</h2>
       <StatusMessage persistent message={searchAnnouncement} nonce={searchAnnounceNonce} className="sr-only" />
       <div className="mb-100">
         <FilterPanel

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -429,11 +429,10 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       </nav>
 
       {/* Visually hidden - same as ChatDashboardPage.js's matching heading:
-          the filter panel's own summary/controls already make its purpose
-          clear on screen. Kept as a real heading (not removed) so
-          screen-reader users navigating by heading/landmark still get this
-          section announced. */}
-      <h2 className="sr-only">{t('admin.filters.title')}</h2>
+          FilterPanel's own <summary> isn't heading-navigable, so this gives
+          screen-reader users a heading/landmark entry point into the filter
+          section. Distinct text from FilterPanel's "Filters" summary label. */}
+      <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
       <StatusMessage persistent message={searchAnnouncement} nonce={searchAnnounceNonce} className="sr-only" />
       <div className="mb-100">
         <FilterPanel
@@ -545,7 +544,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
                 to tab TO here) - only a programmatic .focus() target, via
                 resultsHeadingRef/useFocusOnChange above. */}
             <h2 ref={resultsHeadingRef} tabIndex={-1} className="sr-only">
-              {t('admin.evalDashboard.resultsHeading')}
+              {t('admin.common.resultsHeading')}
             </h2>
             <DataTable
               key={tableKey}

--- a/src/pages/MetricsPage.js
+++ b/src/pages/MetricsPage.js
@@ -20,7 +20,7 @@ const MetricsPage = ({ lang = 'en' }) => {
       </nav>
 
       <section id="metrics-dashboard" className="mb-600">
-        <h2 className="sr-only">{t('metrics.timeRangeTitle')}</h2>
+        <h2 className="sr-only">{t('admin.filters.title')}</h2>
         <MetricsDashboard lang={lang} />
       </section>
     </GcdsContainer>

--- a/src/pages/MetricsPage.js
+++ b/src/pages/MetricsPage.js
@@ -20,7 +20,7 @@ const MetricsPage = ({ lang = 'en' }) => {
       </nav>
 
       <section id="metrics-dashboard" className="mb-600">
-        <h2 className="sr-only">{t('admin.filters.title')}</h2>
+        <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
         <MetricsDashboard lang={lang} />
       </section>
     </GcdsContainer>

--- a/src/pages/TechnicalMetricsPage.js
+++ b/src/pages/TechnicalMetricsPage.js
@@ -18,7 +18,7 @@ const TechnicalMetricsPage = ({ lang = 'en' }) => {
       </nav>
 
       <section id="technical-metrics-dashboard" className="mb-600">
-        <h2 className="sr-only">{t('technicalMetrics.timeRangeTitle')}</h2>
+        <h2 className="sr-only">{t('admin.filters.title')}</h2>
         <TechnicalMetricsDashboard lang={lang} />
       </section>
     </GcdsContainer>

--- a/src/pages/TechnicalMetricsPage.js
+++ b/src/pages/TechnicalMetricsPage.js
@@ -18,7 +18,7 @@ const TechnicalMetricsPage = ({ lang = 'en' }) => {
       </nav>
 
       <section id="technical-metrics-dashboard" className="mb-600">
-        <h2 className="sr-only">{t('admin.filters.title')}</h2>
+        <h2 className="sr-only">{t('admin.filters.sectionHeading')}</h2>
         <TechnicalMetricsDashboard lang={lang} />
       </section>
     </GcdsContainer>


### PR DESCRIPTION
fix: correct heading structure across admin dashboards

  No skipped heading levels
  - Promote MetricsDashboard.js/TechnicalMetricsDashboard.js's section
    headings h3 -> h2, and EndUserFeedbackSection.js's nested table
    heading h4 -> h3 to match, so the hierarchy is sequential instead of
    skipping a level (WCAG 1.3.1 Info and Relationships — heading levels must reflect
    actual document structure)

  Add missing Filters headings
  - PartnerDashboard.js and AutoEvalDashboardPage.js were the only two
    FilterPanel-driven dashboards with no heading marking the filter
    section at all — every sibling dashboard had one, these two didn't,
    so screen-reader users navigating by heading had no way to locate
    or identify the filter controls on these two pages (WCAG 1.3.1 Info and Relationships / 2.4.6 Headings and Labels)

  Fix a heading whose text was a computed, unstable data value
  - PublicDashboard.js's results section heading was a *visible* h2
    whose text was the computed date range itself — not descriptive of
    the section's topic/purpose, empty before the first fetch resolved,
    and different on every filter apply (a heading has to stay stable to
    work as a landmark a user can rely on when re-navigating). Replaced
    with a stable sr-only "Results" h2; the date range now renders as a
    ` <p> `(a data value, not a heading - but styled to keep the same look)  (WCAG 2.4.6 Headings and Labels)

  Add a missing Results heading
  - ChatDashboardPage.js's results table had no heading-navigation stop
    of its own; added an sr-only "Results" h2 as sibling to the Filters
    heading, matching EvalDashboardPage.js's existing pattern
    (WCAG 1.3.1 Info and Relationships)

  Wire up table header accessibility
  - AutoEvalDashboardPage.js's DataTable now calls the shared
    wireTableAccessibility() (scope="col" on header cells); the
    search-pill/announcement half of that helper stays a no-op here
    since this table uses per-column filters, not a global search box —
    correctly left undecided rather than forced to match
    (WCAG 1.3.1 Info and Relationships — header cells must be
    programmatically associated with their columns)

  Locale consolidation
  - Replace 5 near-duplicate page-specific "time range" strings
    (chatDashboard/evalDashboard/autoEvalDashboard/metrics/technicalMetrics
    .timeRangeTitle, e.g. "Get chat interactions for the selected period")
    with one shared admin.filters.title ("Filters"/"Filtres") — the old
    text described an instruction, not the section's actual purpose; the
    section is the filter controls, so "Filters" is the accurate label
    across all five dashboards instead of five different phrasings
    (WCAG 2.4.6 Headings and Labels, 3.2.4 Consistent Identification)
  - Add shared admin.common.resultsHeading ("Results"/"Résultats") for
    the two new Results headings above