### PR TITLE
fix: language-aware display for non-EN/FR questions and answers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,27 +114,28 @@ node scripts/check-chat-logs.js <file.json> --filter similarQuestions # injected
 What lives in which event: see [docs/architecture/using-evals-for-answers.md](docs/architecture/using-evals-for-answers.md#inspecting-what-was-injected-manual-testing). Key ones: `node:context output` (matched department/topic), `node:similarQuestions output` (injected eval text in `metadata.similarQuestionsText`), `node:answer input/output` (what reached the LLM, what came back), `node:shortCircuit output` (whether the instant-answer path fired).
 
 ## Official languages
-**English users and admins and partners must be served in English. French users and admins and partners must be served in French.** This applies to all pages and tools — public-facing, admin, and partner.
 
-**Never hardcode user-facing text in components or pages.** All text visible to users must use translation keys via `t()` and have entries in both `src/locales/en.json` and `src/locales/fr.json`. When adding any new text (column headers, labels, buttons, messages, placeholders, error messages, status messages, option labels, etc.), always add the corresponding key to both locale files in the same PR.
-
-**A `t()` call whose fallback argument you're writing or editing must not have one — write `t('some.key')`, never `t('some.key', 'Fallback text')` or `t('some.key') || 'Fallback text'`.** A fallback is not a harmless safety net just because the real key exists in both locale files today — it's exactly what fires if that key is ever mistyped, renamed, or its FR entry goes missing in a later edit, and the app degrades to silently showing English instead of failing loudly. That's the one outcome an Official Languages review can't catch by grepping for missing keys. Add the real key to both `en.json` and `fr.json` in the same PR instead.
-
-This covers brand-new call sites *and* any existing call's fallback argument you're actively editing (e.g. syncing its wording to a locale-key rename) — editing the argument makes it your line, not a pre-existing one you're leaving alone. It does not mean retroactively stripping a fallback from some other pre-existing call in a file you're touching for an unrelated reason — leave those and flag them as a drive-by instead of silently rewriting them.
-
-### Exceptions
-- **Backend/console/database output**: `console.log`, `console.error`, server-side log strings, developer-facing CLI output, and dynamic content retrieved from the database are exempt.
-- **Internal technical identifiers used as option values**: e.g. workflow names like `GenericGraph` where the value and label are the same internal enum — these are not user-facing text.
-
-### Sentence case
-All text visible to users uses sentence case (only the first word and proper nouns capitalised). This applies to button labels, column headers, section titles, navigation links, and option labels. Examples: `"Upload file"` not `"Upload File"`, `"Processed batches"` not `"Processed Batches"`, `"Clarifying question"` not `"Clarifying Question"`.
+See [docs/coding-agent-docs/official-languages.md](docs/coding-agent-docs/official-languages.md)
+for the full ruleset: the core EN/FR requirement, `t()`/locale-key rules, the
+`lang`-attribute rules (including the two-part Rule 1/Rule 2 split for
+admin/eval tooling vs. the live conversation transcript), locale key parity,
+number/percentage formatting, French punctuation spacing, and the PR review
+checklist. Read it before creating or reviewing any user-facing text —
+nearly every UI change touches at least one of these. Two related things
+stay in this file instead: locale key *hygiene* below (the fuller practice
+around adding/reusing/namespacing keys — general maintenance practice, not
+itself an OL rule, even though the parity it protects is), and the content
+style guide (writing quality, not a bilingual/legal requirement at all).
 
 ### Content style guide
+
+**Sentence case.** All text visible to users uses sentence case (only the first word and proper nouns capitalised). This applies to button labels, column headers, section titles, navigation links, and option labels. Examples: `"Upload file"` not `"Upload File"`, `"Processed batches"` not `"Processed Batches"`, `"Clarifying question"` not `"Clarifying Question"`.
+
 When writing a non-trivial amount of new user-facing copy — a paragraph of explanatory text, an alert/warning/status message, a confirm-dialog body, anything longer than a short label — check it against the [Canada.ca content style guide](https://design.canada.ca/style-guide/index.html) (this is also where the sentence-case rule above comes from). Core rules that matter most for this codebase:
 - **Plain language**: familiar words, active voice, positive phrasing over negative where possible (negative phrasing is fine for genuinely safety/data-loss-critical warnings, e.g. destructive-action confirms).
 - **Short sentences**: aim under ~15–20 words each; split up anything longer rather than stacking clauses.
 - **Second person, direct address**: "you"/"your" for the reader, "we" for the Government of Canada as a whole, where the copy is speaking to a person at all (not always applicable to terse admin/system copy).
-- **No end punctuation on titles/headings/table captions** in English (French keeps its own punctuation rules — see below).
+- **No end punctuation on titles/headings/table captions** in English (French keeps its own punctuation rules — see [docs/coding-agent-docs/official-languages.md](docs/coding-agent-docs/official-languages.md)'s French punctuation spacing section).
 - **Numbers**: digits for 10 and up, ages, dates, percentages; spell out zero to nine in narrative text.
 It's a useful sanity check for any user-facing copy, not just long-form text — just not necessary for single words, short labels, or an existing locale string you're not otherwise changing.
 
@@ -153,51 +154,9 @@ node scripts/find-dead-locale-keys.cjs
 This reports:
 1. **Dead keys** — keys in `en.json`/`fr.json` with no detected usage in `src/`
 2. **Duplicate keys** — different keys with identical values (consolidation candidates)
-3. **Parity gaps** — keys present in EN but missing from FR, or vice versa
+3. **Parity gaps** — keys present in EN but missing from FR, or vice versa — this is the OL requirement itself (see [docs/coding-agent-docs/official-languages.md](docs/coding-agent-docs/official-languages.md)); the other two are general hygiene.
 
 Parity gaps must be fixed before merging. Dead keys and duplicates are cleaned up incrementally — fix a few per PR rather than all at once.
-
-### Number and percentage formatting
-
-**This is an Official Languages requirement.** French and English have different conventions for numbers and percentages (`1 000` vs `1,000`; `45 %` vs `45%`). Any component or page that displays numeric data to users must format numbers and percentages using the shared helpers in `src/utils/numberFormat.js`:
-
-```js
-import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
-
-const fmtN = (n) => formatNumber(n, lang);   // 1 000 (fr) / 1,000 (en)
-const fmtPct = (n) => formatPercent(n, lang); // 45 % (fr) / 45% (en)
-```
-
-- **`formatNumber(n, lang)`** — formats integers and large numbers with the correct thousands separator (`fr-CA` uses non-breaking space, `en-CA` uses comma). Handles `null`/`undefined` → `0`.
-- **`formatPercent(n, lang)`** — appends `%` with a non-breaking space before it in French (`45 %`), no space in English (`45%`). Takes an already-computed integer (0–100), not a fraction.
-- **`formatDecimal(n, lang, fractionDigits = 3)`** — formats a decimal number with locale-aware separators (`,` vs `.`) and a fixed number of decimal places. Pass-through for `null`/`undefined`/empty/non-numeric values.
-
-Rules:
-- Never use `+ '%'`, `'0%'`, or `'100%'` as literal strings in data displayed to users — always go through `fmtPct`.
-- Never use `n.toFixed(d)` or inline `Intl.NumberFormat` for decimal values displayed to users — always go through `formatDecimal`.
-- For DataTables columns with sorting enabled, pass raw numbers in the data object and use the `render: (d, type) => type === 'display' ? fmtN(d) : d` pattern so sorting operates on the raw value.
-- These helpers apply to dashboards, tables, batch lists, and any other UI that surfaces counts, totals, or percentages.
-
-### French punctuation spacing
-Per the official Government of Canada style guide (*The Canadian Style*, TERMIUM Plus §17.07), Canadian French requires a space only before the colon `:` (e.g. `"Assigné à :"`) — English does not. Unlike France French, Canadian French does **not** put a space before `;`, `!`, or `?` (e.g. `"Continuer?"`, not `"Continuer ?"`). This has slipped through review before in two forms:
-- A static `fr.json` string typed without the space before `:` (e.g. `"Assigné à:"` instead of `"Assigné à :"`).
-- JS that hardcodes punctuation while building a label at runtime (e.g. `` `${label}: ${value}` ``) instead of putting the full punctuated phrase in the locale string. If code needs one literal separator shared across both languages, prefer a mark that doesn't have a French spacing rule (e.g. `" - "`) rather than `":"`.
-
-### PR review checklist — official languages
-Every PR that touches UI components, pages, or locale files must be verified against these before merging.
-
-**Must fix before merging:**
-- [ ] No hardcoded user-facing strings in components or pages (no `'English text'` literals, no `t('key', 'fallback')` or `t('key') || 'fallback'` patterns on any call site you wrote or edited, no `lang === 'en' ? '...' : '...'` inline conditionals)
-- [ ] All translation calls use `t()` or `safeT()` — not raw string literals (`safeT` is a wrapper around `t()` used in chat components that unwraps object results to a plain string; same locale key rules apply)
-- [ ] Every new `t('key')` call has a matching entry in **both** `en.json` and `fr.json`
-- [ ] `node scripts/find-dead-locale-keys.cjs` reports **0 parity gaps**
-- [ ] French translations are real translations — not copied English text or placeholders
-- [ ] All numbers displayed to users go through `formatNumber(n, lang)` — no raw `.toLocaleString()`, `toString()`, or unformatted numeric values
-- [ ] All percentages displayed to users go through `formatPercent(n, lang)` — no `+ '%'`, `'0%'`, or `'100%'` string literals
-- [ ] French text has a space before `:` only (not before `;`, `!`, `?`) — check both static `fr.json` values and any JS that concatenates punctuation onto a label at runtime
-
-**Flag but don't block:**
-- Sentence case is generally preferred for all text visible to users — note inconsistencies (e.g. mid-sentence capitals, ALL-CAPS emphasis) in review and fix opportunistically
 
 ### Markdown-driven pages
 
@@ -227,6 +186,7 @@ Before starting work, read the relevant reference doc:
 - **Dashboards & filters (exec/partner cards, `FilterPanel`, cross-dashboard filter logic, Chat/Eval/Metrics gotchas):** [docs/coding-agent-docs/dashboards.md](docs/coding-agent-docs/dashboards.md)
 - **Any server-side paginated/searchable table, dashboard or not (which wrapper to use, migrating a hand-rolled table):** [docs/coding-agent-docs/tables.md](docs/coding-agent-docs/tables.md)
 - **CSS, styling, visual look and feel, GC Design System tokens:** [docs/coding-agent-docs/design-system.md](docs/coding-agent-docs/design-system.md)
+- **Creating or reviewing user-facing text (copy, labels, error messages, locale keys, `lang` attributes):** [docs/coding-agent-docs/official-languages.md](docs/coding-agent-docs/official-languages.md)
 
 ## Database query safety
 

--- a/__tests__/api.chat-dashboard.filters.test.js
+++ b/__tests__/api.chat-dashboard.filters.test.js
@@ -228,4 +228,41 @@ describe('api/chat/chat-dashboard filter handling', () => {
     const groupStage = Array.isArray(capturedPipeline) && capturedPipeline.find(stage => stage && stage.$group);
     expect(groupStage).toBeUndefined();
   });
+
+  it('does not add the questionLanguage match for an unrelated search term', async () => {
+    let capturedPipeline;
+    ChatModel.Chat.aggregate.mockImplementationOnce((pipeline) => {
+      capturedPipeline = pipeline;
+      return { allowDiskUse: () => Promise.resolve([]) };
+    });
+    ChatModel.Chat.aggregate.mockImplementationOnce(() => ({ allowDiskUse: () => Promise.resolve([]) }));
+
+    const req = {
+      method: 'GET',
+      query: {
+        search: 'passport',
+        startDate: new Date().toISOString(),
+        endDate: new Date().toISOString()
+      }
+    };
+
+    const res = {
+      status: vi.fn(() => res),
+      json: vi.fn(() => res)
+    };
+
+    try {
+      await handler(req, res);
+    } catch (e) {
+      // ignore errors as long as aggregate was invoked
+    }
+
+    const searchMatch = Array.isArray(capturedPipeline) && capturedPipeline.find(stage =>
+      stage && stage.$match && Array.isArray(stage.$match.$or) &&
+      stage.$match.$or.some(cond => cond.redactedQuestion)
+    );
+
+    expect(searchMatch).toBeDefined();
+    expect(searchMatch.$match.$or.some(cond => cond.questionLanguage)).toBe(false);
+  });
 });

--- a/api/chat/chat-dashboard.js
+++ b/api/chat/chat-dashboard.js
@@ -194,7 +194,13 @@ async function chatDashboardHandler(req, res) {
     });
     pipeline.push({
       $addFields: {
-        'interactions.redactedQuestion': { $ifNull: [{ $arrayElemAt: ['$interactionQuestion.redactedQuestion', 0] }, ''] }
+        'interactions.redactedQuestion': { $ifNull: [{ $arrayElemAt: ['$interactionQuestion.redactedQuestion', 0] }, ''] },
+        // Both needed for the admin display rule (see src/utils/answerLanguage.js's
+        // resolveDisplayContent): EN/FR show redactedQuestion as-is, anything
+        // else falls back to englishQuestion - questionLanguage is what
+        // decides which.
+        'interactions.questionLanguage': { $ifNull: [{ $arrayElemAt: ['$interactionQuestion.language', 0] }, ''] },
+        'interactions.englishQuestion': { $ifNull: [{ $arrayElemAt: ['$interactionQuestion.englishQuestion', 0] }, ''] }
       }
     });
 
@@ -213,10 +219,18 @@ async function chatDashboardHandler(req, res) {
     pipeline.push({
       $addFields: {
         'interactions.answerType': { $ifNull: [{ $arrayElemAt: ['$interactionAnswer.answerType', 0] }, ''] },
+        // Computed once here, referenced by answerContent's own fallback
+        // below - a field added earlier in an $addFields stage is visible
+        // to a later field's expression in the same stage. Kept as its own
+        // field (not folded into answerContent) so the frontend can apply
+        // the questionLanguage-driven display rule the same way it does for
+        // the question (resolveDisplayContent), independent of
+        // answerContent's separate null-safety fallback below.
+        'interactions.englishAnswer': { $ifNull: [{ $arrayElemAt: ['$interactionAnswer.englishAnswer', 0] }, ''] },
         'interactions.answerContent': {
           $ifNull: [
             { $arrayElemAt: ['$interactionAnswer.content', 0] },
-            { $ifNull: [{ $arrayElemAt: ['$interactionAnswer.englishAnswer', 0] }, ''] }
+            '$interactions.englishAnswer'
           ]
         },
         'interactions.citationRef': { $arrayElemAt: ['$interactionAnswer.citation', 0] }
@@ -375,7 +389,10 @@ async function chatDashboardHandler(req, res) {
         department: '$interactions.department',
         program: '$interactions.program',
         redactedQuestion: '$interactions.redactedQuestion',
+        questionLanguage: '$interactions.questionLanguage',
+        englishQuestion: '$interactions.englishQuestion',
         answerContent: '$interactions.answerContent',
+        englishAnswer: '$interactions.englishAnswer',
         citationUrl: '$interactions.citationUrl',
         partnerEval: '$interactions.partnerEval',
         aiEval: '$interactions.aiEval',
@@ -403,18 +420,17 @@ async function chatDashboardHandler(req, res) {
     // data grows.
     if (searchParam) {
       const esc = escapeRegex(searchParam);
+      const searchOr = [
+        { chatId: { $regex: esc, $options: 'i' } },
+        { interactionId: { $regex: esc, $options: 'i' } },
+        { department: { $regex: esc, $options: 'i' } },
+        { program: { $regex: esc, $options: 'i' } },
+        { redactedQuestion: { $regex: esc, $options: 'i' } },
+        { answerContent: { $regex: esc, $options: 'i' } },
+        { citationUrl: { $regex: esc, $options: 'i' } }
+      ];
       pipeline.push({
-        $match: {
-          $or: [
-            { chatId: { $regex: esc, $options: 'i' } },
-            { interactionId: { $regex: esc, $options: 'i' } },
-            { department: { $regex: esc, $options: 'i' } },
-            { program: { $regex: esc, $options: 'i' } },
-            { redactedQuestion: { $regex: esc, $options: 'i' } },
-            { answerContent: { $regex: esc, $options: 'i' } },
-            { citationUrl: { $regex: esc, $options: 'i' } }
-          ]
-        }
+        $match: { $or: searchOr }
       });
     }
 
@@ -546,7 +562,10 @@ async function chatDashboardHandler(req, res) {
       program: row.program || '',
       programFr: frForProgram(row.program),
       redactedQuestion: row.redactedQuestion || '',
+      questionLanguage: row.questionLanguage || '',
+      englishQuestion: row.englishQuestion || '',
       answerContent: row.answerContent || '',
+      englishAnswer: row.englishAnswer || '',
       citationUrl: row.citationUrl || '',
       date: row.createdAt ? row.createdAt.toISOString() : null,
       questionNumber: row.questionNumber || 0,

--- a/docs/coding-agent-docs/official-languages.md
+++ b/docs/coding-agent-docs/official-languages.md
@@ -1,0 +1,201 @@
+# Official languages
+
+Everything here is something an agent needs to be aware of when **creating or
+reviewing** user-facing content in this app — the Official Languages Act +
+WCAG lang-tag legal requirement. Read this before writing or reviewing any
+new copy, label, error message, or locale key — nearly every UI change
+touches at least one of these. (For general writing quality — sentence case,
+plain language — and the fuller locale-key maintenance practice, see
+AGENTS.md's "Content style guide" and "Locale key hygiene" instead; both are
+separate, non-OL concerns kept there.)
+
+**English users and admins and partners must be served in English. French
+users and admins and partners must be served in French.** This applies to
+all pages and tools — public-facing, admin, and partner.
+
+**Never hardcode user-facing text in components or pages.** All text visible
+to users must use translation keys via `t()` and have entries in both
+`src/locales/en.json` and `src/locales/fr.json`. When adding any new text
+(column headers, labels, buttons, messages, placeholders, error messages,
+status messages, option labels, etc.), always add the corresponding key to
+both locale files in the same PR.
+
+**A `t()` call whose fallback argument you're writing or editing must not
+have one — write `t('some.key')`, never `t('some.key', 'Fallback text')` or
+`t('some.key') || 'Fallback text'`.** A fallback is not a harmless safety net
+just because the real key exists in both locale files today — it's exactly
+what fires if that key is ever mistyped, renamed, or its FR entry goes
+missing in a later edit, and the app degrades to silently showing English
+instead of failing loudly. That's the one outcome an Official Languages
+review can't catch by grepping for missing keys. Add the real key to both
+`en.json` and `fr.json` in the same PR instead.
+
+This covers brand-new call sites *and* any existing call's fallback argument
+you're actively editing (e.g. syncing its wording to a locale-key rename) —
+editing the argument makes it your line, not a pre-existing one you're
+leaving alone. It does not mean retroactively stripping a fallback from some
+other pre-existing call in a file you're touching for an unrelated reason —
+leave those and flag them as a drive-by instead of silently rewriting them.
+
+Verify parity with `node scripts/find-dead-locale-keys.cjs` (0 parity gaps
+required before merging) — see AGENTS.md's "Locale key hygiene" for the
+fuller practice around adding/reusing/namespacing keys.
+
+## Exceptions
+- **Backend/console/database output**: `console.log`, `console.error`, server-side log strings, developer-facing CLI output, and dynamic content retrieved from the database are exempt.
+- **`<option>` `value` attributes**: e.g. workflow names like `GenericGraph` (`src/config/workflows.js`'s `WORKFLOWS`) — the `value` attribute itself is never rendered as visible text, only the paired `labelKey` is (translated via `t()`), so it isn't in scope for this rule to begin with.
+- **Formal/proper names for a specific product or service**: e.g. `VectorPage.js`'s embedding-provider dropdown (`<option value="openai">OpenAI</option>`, `<option value="azure">Azure OpenAI</option>`) — "OpenAI" and "Azure OpenAI" are brand names, not translated, the same way you wouldn't translate "GitHub" or "MailChimp." This one *is* visible text that stays untranslated on purpose — don't confuse it with the `value`-attribute case above.
+
+## An API response's `message`/`error` field is not exempt once it reaches the screen
+
+The "server-side log strings" exception above covers `console.log`/`console.error`
+— it does not cover an API route building a `message`/`error` string that the
+frontend then renders directly (`{result.message}`, `text: data.message`,
+`message={row.error}`). That's user-facing text like any other, and it always
+renders in English regardless of the admin's chosen language.
+
+`lang="en"` is a pronunciation patch (WCAG 3.1.2), not a translation — it's
+the fallback of last resort for cases where translation isn't the solution,
+not the default fix. Before reaching for it, check whether the source is
+actually bounded:
+- A **fixed, small set of strings** (a status enum, a handful of known
+  outcomes), or an exception with a **stable code** (MongoDB/Mongoose errors
+  have one, often sitting unused next to the free-text `message`) — translate
+  properly, switching on that state/code through `t()`.
+- Only a **genuinely unbounded** value (raw network/driver text, no stable
+  code) gets `<span lang="en">`, and even then it's a TODO for a real fix, not
+  a closed issue. See `DeleteChatSection.js`/`DeleteExpertEval.js` for the
+  wrapper pattern and why raw text should never hit a `{message}` template via
+  plain `String.replace` ("Interpolating dynamic text" — see
+  `docs/coding-agent-docs/common-tasks.md`).
+
+Example of the bounded case going unfixed: `DatabasePage.js`'s index tools
+render `f.error`/`col.error` (MongoDB exception text) with no wrapper — but
+the UI already displays that error's numeric `code` right next to it, so the
+mappable piece exists and just isn't used. Check what's actually on the error
+object before assuming a message is free text.
+
+## Content in a *known* language still needs its own `lang` attribute — and two different rules apply depending on what the content is
+
+The section above is about text with no fixed language of its own (an
+exception message defaults to English because that's what the runtime
+produces). This is the opposite case: content whose actual language is
+already known and stored, but doesn't match the page's own `lang`. Two
+different UI contexts need two different rules here — conflating them
+produces the wrong result in both directions.
+
+**Rule 1 — admin/eval tooling (dashboards, review panels, rating forms):
+EN/FR show their own original text; anything else shows the English
+translation.** This isn't a display preference — it's two separate, unrelated
+constraints that happen to produce one rule:
+
+1. **EN/FR side — the OL requirement.** EN and FR are Canada's two official
+   languages, so a question/answer that arrived in either one is displayed as
+   itself, full stop. This holds regardless of what translation data happens
+   to exist for it — see point 2 below, an English translation is in fact
+   generated for French questions too, and display still ignores it. This
+   isn't an absence-of-data coincidence; it's the same OL requirement that
+   governs every other page in this app, applied here via real data
+   (`Question.language`, `models/question.js`) instead of a hardcoded
+   "always English," and tagged accordingly (`lang="en"`/`lang="fr"`, same
+   WCAG 3.1.2 Language of Parts criterion as the `lang="en"` wrapper above).
+2. **Non-EN/FR side — the tool can't output what was never produced.** The
+   question-understanding translation step (`GraphWorkflowHelper.translateQuestion`,
+   called from every graph workflow — `GenericGraph.js`, `DefaultWithVectorGraph.js`,
+   `GenericWithQAGraph.js`, `DefaultWithLocalModel.js`, `InstantAndQAGraph.js`)
+   always targets English — `translateQuestion(state.redactedText, 'en', ...)`,
+   hardcoded, never the page's own language, and runs unconditionally for
+   every question regardless of detected language (so even an EN or FR
+   question gets an `englishQuestion` populated — translating French to
+   English, or English to itself — see point 1, display ignores it either
+   way). There is no translate-to-French step anywhere in this pipeline,
+   though, so for a genuinely non-EN/FR question, no French version of it
+   ever exists to show. English is the only translated form that data
+   constraint can ever produce — not a fallback of convenience, a ceiling on
+   what the tool has to work with.
+
+`resolveDisplayContent`/`getOriginallyAskedInLabel`
+(`src/utils/answerLanguage.js`) implement this rule and are applied in
+`ExpertFeedbackPanel.js`, `ChatDashboardPage.js`'s Question/Answer columns
+(`api/chat/chat-dashboard.js`'s pipeline carries `questionLanguage`/
+`englishQuestion`/`englishAnswer` for this), `ExpertFeedbackComponent.js`, and
+`FeedbackComponent.js`/`SourceViewComponent.js` (the expert "How was
+this answer?" prompt gates its rating choice behind a "Review the English
+source text" step whenever the answer isn't already EN/FR, since a reviewer
+can't meaningfully rate what they can't read). The download logs
+(`chat-export-logs.js`) are untouched by this rule and keep full
+original-language fidelity regardless of what these tools show.
+
+**This is AI Answers' own English draft/working text, never call it a
+"translation" in admin-facing copy or identifiers.** The English shown by
+`resolveDisplayContent`'s `isSource`/non-EN/FR fallback (and everywhere it
+feeds — `SourceViewComponent.js`, `OriginalLanguagePill.js`,
+`ExpertFeedbackPanel.js`'s "Source text" column) is the same English draft
+the model produced before generating the non-EN/FR answer, not a
+machine-translation output being offered as a convenience. Framing it as a
+"translation" risks reading as though the admin app runs its own
+translation service - it doesn't, and shouldn't be described as one, in
+visible strings, identifiers, or comments alike.
+
+**Rule 2 — the actual conversation transcript: show the real language, never
+collapse it.** A chat genuinely conducted in Arabic answers in Arabic, not
+English — `agenticBase.js` translates the English draft answer into whatever
+language the question was detected in, for any language the translation step
+can identify (Canadian Indigenous languages excepted — see
+`UNSUPPORTED_INDIGENOUS_ISO3`, `translationGuardrail.js` — those are blocked
+before an answer is generated at all). Showing an English proxy here would
+misrepresent what the end user actually experienced. Both bubbles get this
+right: the answer bubble via `ChatAppContainer.js`, the question bubble via
+`ChatInterface.js`'s `<p>{message.text}</p>`, each tagged with
+`getAnswerLanguage`/`toLangAttr` (`answerLanguage.js`) and the real detected
+language — not Rule 1's collapse-to-English.
+
+Checked the other similar admin tables (`EvalDashboardPage.js`,
+`AutoEvalDashboardPage.js`) — they only show `questionNumber` in their grids,
+not the actual text, so this specific gap doesn't extend to those, but don't
+assume that stays true as those pages evolve. Wherever raw question/answer
+text does get rendered, a screen reader currently announces it in whatever
+language the admin's own UI happens to be in, regardless of what language the
+content is actually in. Flagging as a known gap, not fixed here.
+
+## Number and percentage formatting
+
+**This is an Official Languages requirement.** French and English have different conventions for numbers and percentages (`1 000` vs `1,000`; `45 %` vs `45%`). Any component or page that displays numeric data to users must format numbers and percentages using the shared helpers in `src/utils/numberFormat.js`:
+
+```js
+import { formatNumber, formatPercent } from '../../utils/numberFormat.js';
+
+const fmtN = (n) => formatNumber(n, lang);   // 1 000 (fr) / 1,000 (en)
+const fmtPct = (n) => formatPercent(n, lang); // 45 % (fr) / 45% (en)
+```
+
+- **`formatNumber(n, lang)`** — formats integers and large numbers with the correct thousands separator (`fr-CA` uses non-breaking space, `en-CA` uses comma). Handles `null`/`undefined` → `0`.
+- **`formatPercent(n, lang)`** — appends `%` with a non-breaking space before it in French (`45 %`), no space in English (`45%`). Takes an already-computed integer (0–100), not a fraction.
+- **`formatDecimal(n, lang, fractionDigits = 3)`** — formats a decimal number with locale-aware separators (`,` vs `.`) and a fixed number of decimal places. Pass-through for `null`/`undefined`/empty/non-numeric values.
+
+Rules:
+- Never use `+ '%'`, `'0%'`, or `'100%'` as literal strings in data displayed to users — always go through `fmtPct`.
+- Never use `n.toFixed(d)` or inline `Intl.NumberFormat` for decimal values displayed to users — always go through `formatDecimal`.
+- For DataTables columns with sorting enabled, pass raw numbers in the data object and use the `render: (d, type) => type === 'display' ? fmtN(d) : d` pattern so sorting operates on the raw value.
+- These helpers apply to dashboards, tables, batch lists, and any other UI that surfaces counts, totals, or percentages.
+
+## French punctuation spacing
+Per the official Government of Canada style guide (*The Canadian Style*, TERMIUM Plus §17.07), Canadian French requires a space only before the colon `:` (e.g. `"Assigné à :"`) — English does not. Unlike France French, Canadian French does **not** put a space before `;`, `!`, or `?` (e.g. `"Continuer?"`, not `"Continuer ?"`). This has slipped through review before in two forms:
+- A static `fr.json` string typed without the space before `:` (e.g. `"Assigné à:"` instead of `"Assigné à :"`).
+- JS that hardcodes punctuation while building a label at runtime (e.g. `` `${label}: ${value}` ``) instead of putting the full punctuated phrase in the locale string. If code needs one literal separator shared across both languages, prefer a mark that doesn't have a French spacing rule (e.g. `" - "`) rather than `":"`.
+
+## PR review checklist — official languages
+Every PR that touches UI components, pages, or locale files must be verified against these before merging.
+
+**Must fix before merging:**
+- [ ] No hardcoded user-facing strings in components or pages (no `'English text'` literals, no `t('key', 'fallback')` or `t('key') || 'fallback'` patterns on any call site you wrote or edited, no `lang === 'en' ? '...' : '...'` inline conditionals)
+- [ ] All translation calls use `t()` or `safeT()` — not raw string literals (`safeT` is a wrapper around `t()` used in chat components that unwraps object results to a plain string; same locale key rules apply)
+- [ ] Every new `t('key')` call has a matching entry in **both** `en.json` and `fr.json`
+- [ ] `node scripts/find-dead-locale-keys.cjs` reports **0 parity gaps**
+- [ ] French translations are real translations — not copied English text or placeholders
+- [ ] All numbers displayed to users go through `formatNumber(n, lang)` — no raw `.toLocaleString()`, `toString()`, or unformatted numeric values
+- [ ] All percentages displayed to users go through `formatPercent(n, lang)` — no `+ '%'`, `'0%'`, or `'100%'` string literals
+- [ ] French text has a space before `:` only (not before `;`, `!`, `?`) — check both static `fr.json` values and any JS that concatenates punctuation onto a label at runtime
+
+**Flag but don't block:**
+- Sentence case is generally preferred for all text visible to users — note inconsistencies (e.g. mid-sentence capitals, ALL-CAPS emphasis) in review and fix opportunistically

--- a/services/AnswerGenerationService.js
+++ b/services/AnswerGenerationService.js
@@ -14,7 +14,21 @@ const convertInteractionsToMessages = (interactions) => {
     const reversed = [...interactions].reverse();
     for (let i = reversed.length - 1; i >= 0; i--) {
         const item = reversed[i];
-        if (item && item.interaction && item.interaction.question && item.interaction.answer) {
+        // TODO(ai-turn-check-sync): this "is this an AI turn" guard is
+        // hand-duplicated in 2 other files - ContextAgentService.js and
+        // ConversationIntegrityService.js's serializeHistory (search for
+        // "isUser" there). All three independently implement the same
+        // invariant (originally by the same author, Ryan Hyma, in commits
+        // a2c70182 and b585a348 - a2c70182 wrote this file's own copy;
+        // b585a348, five weeks later, added the other two after a real
+        // conversation-integrity hash-mismatch bug from them being out of
+        // sync). Keep this in sync with the other two if you touch it -
+        // consider a shared helper only if that becomes a recurring cost.
+        // item.sender === 'user' is defense-in-depth, not the primary guard -
+        // a user-sender entry should never carry `.interaction` at all
+        // (src/components/chat/ChatAppContainer.js), but the one time that
+        // contract broke, every historical turn got pushed here twice.
+        if (item && item.sender !== 'user' && item.interaction && item.interaction.question && item.interaction.answer) {
             messages.push({ role: 'user', content: item.interaction.question });
             messages.push({ role: 'assistant', content: item.interaction.answer.content });
         }

--- a/services/ContextAgentService.js
+++ b/services/ContextAgentService.js
@@ -21,11 +21,32 @@ const invokeContextAgent = async (agentType, request) => {
       }
     ];
 
-    // Add conversation history messages before the current message
+    // Add conversation history messages before the current message.
+    // TODO(ai-turn-check-sync): this "is this an AI turn" guard is
+    // hand-duplicated in 2 other files - AnswerGenerationService.js and
+    // ConversationIntegrityService.js's serializeHistory (search for
+    // "isUser" there). All three independently implement the same
+    // invariant (originally by the same author, Ryan Hyma, both written in
+    // commit b585a348 - a real bug-fix after a conversation-integrity hash
+    // mismatch caused by this file and ConversationIntegrityService.js
+    // drifting apart). Keep this in sync with the other two if you touch
+    // it - consider a shared helper only if that becomes a recurring cost.
+    //
+    // Only process AI-turn entries (the ones carrying the full Q&A pair in
+    // `interaction`) to avoid duplicates - a client message array pushes
+    // one entry per bubble (user + AI) per turn, and a user-sender entry
+    // must never contribute its own pair here too. The explicit
+    // `sender === 'user'` check is defense-in-depth on top of the
+    // `!entry.interaction` check below: a user-sender entry should never
+    // carry `.interaction` in the first place (src/components/chat/
+    // ChatAppContainer.js gives it a plain `questionLanguage` string
+    // instead), but this file has no way to enforce that from the client
+    // side, and the one time that contract was silently broken (a user
+    // bubble briefly carried the same `.interaction` object as its paired
+    // AI bubble), every historical turn got pushed here twice with no
+    // error or warning.
     conversationHistory.forEach(entry => {
-      // Only process entries with interactions (AI messages) to avoid duplicates
-      // and ensure we rely on the full Q&A pair stored in the interaction.
-      if (!entry.interaction) return;
+      if (entry.sender === 'user' || !entry.interaction) return;
 
       messages.push({
         role: "user",

--- a/services/ConversationIntegrityService.js
+++ b/services/ConversationIntegrityService.js
@@ -74,8 +74,29 @@ class ConversationIntegrityService {
         const lines = [];
         for (let i = 0; i < filteredHistory.length; i++) {
             const m = filteredHistory[i];
+            const isUser = (m.sender === 'user' || m.role === 'user');
 
-            if (m.interaction) {
+            // TODO(ai-turn-check-sync): this "is this an AI turn" guard is
+            // hand-duplicated in 2 other files - AnswerGenerationService.js
+            // and ContextAgentService.js (search for "ai-turn-check-sync" there). All
+            // three independently implement the same invariant (originally
+            // by the same author, Ryan Hyma, in commits a2c70182 and
+            // b585a348 - a2c70182 wrote AnswerGenerationService.js's own
+            // copy; b585a348, five weeks later, wrote this one and
+            // ContextAgentService.js's together, as a real bug fix after a
+            // conversation-integrity hash mismatch from them being out of
+            // sync). Keep this in sync with the other two if you touch it -
+            // consider a shared helper only if that becomes a recurring cost.
+            //
+            // Only an AI-sender message carrying `interaction` represents a full
+            // Q+A turn on its own. Client state also retroactively attaches the
+            // same `interaction` object onto the *user* bubble (ChatAppContainer.js,
+            // so the question bubble can read its own detected language) - without
+            // this sender check, that user message would hit this branch too and
+            // double up the user:/ai: lines below, changing the signature from
+            // what AnswerGenerationService originally computed over the plain
+            // [user, ai] pair.
+            if (m.interaction && !isUser) {
                 const qRaw = m.interaction.question?.redactedQuestion || m.interaction.question?.text || m.interaction.question;
                 const aRaw = m.interaction.answer?.content || m.interaction.answer?.text || m.interaction.answer;
                 const q = this.normalizeText(qRaw);
@@ -85,8 +106,9 @@ class ConversationIntegrityService {
             } else {
                 // Check redundancy: If this is a user message and the NEXT message has an interaction,
                 // assume the interaction covers this turn (User Q + AI A) and skip this standalone user message.
-                // This handles the [User, AI(with interaction)] pattern common in client state.
-                const isUser = (m.sender === 'user' || m.role === 'user');
+                // This handles the [User, AI(with interaction)] pattern common in client state - including a
+                // user message that now carries its own `interaction` (see comment above), since the check
+                // above only looks at the *next* message here, not this one's own `interaction`.
                 if (isUser && i + 1 < filteredHistory.length) {
                     const next = filteredHistory[i + 1];
                     if (next.interaction) {

--- a/services/__tests__/AnswerGenerationService.test.js
+++ b/services/__tests__/AnswerGenerationService.test.js
@@ -139,4 +139,38 @@ describe('AnswerGenerationService', () => {
         expect(userContent).toContain('Current');
         expect(userContent).not.toContain('Ignored raw message');
     });
+
+    // Regression: a user-sender entry should never carry `.interaction` at
+    // all (src/components/chat/ChatAppContainer.js gives it a plain
+    // questionLanguage string instead) - but the one time that contract was
+    // silently broken, the user bubble and its paired AI bubble both carried
+    // the same `.interaction` object, and this function had no sender check
+    // to fall back on, so every historical turn was pushed twice.
+    it('does not double-count a turn when a user-sender entry also carries the same interaction as its paired AI entry', async () => {
+        const fakeMessage = {
+            content: 'Response',
+            response_metadata: { tokenUsage: {}, model_name: 'gpt-4' },
+        };
+        mockAgent.invoke.mockResolvedValue({ messages: [fakeMessage] });
+
+        const sharedInteraction = {
+            question: 'Valid Question',
+            answer: { content: 'Valid Answer' },
+        };
+        const historyWithSharedInteraction = [
+            { sender: 'user', text: 'Valid Question', interaction: sharedInteraction },
+            { sender: 'ai', interaction: sharedInteraction },
+        ];
+
+        await AnswerGenerationService.generateAnswer(
+            { message: 'Current', conversationHistory: historyWithSharedInteraction },
+            'test-chat'
+        );
+
+        const messages = mockAgent.invoke.mock.calls[0][0].messages;
+        const questionOccurrences = messages.filter(m => m.content === 'Valid Question').length;
+        const answerOccurrences = messages.filter(m => m.content === 'Valid Answer').length;
+        expect(questionOccurrences).toBe(1);
+        expect(answerOccurrences).toBe(1);
+    });
 });

--- a/services/__tests__/ContextAgentService.test.js
+++ b/services/__tests__/ContextAgentService.test.js
@@ -100,6 +100,52 @@ describe('ContextAgentService', () => {
     });
   });
 
+  // Regression: a user-sender entry should never carry `.interaction` at all
+  // (src/components/chat/ChatAppContainer.js gives it a plain
+  // questionLanguage string instead) - but the one time that contract was
+  // silently broken, the user bubble and its paired AI bubble both carried
+  // the same `.interaction` object, and this file's only guard was
+  // `!entry.interaction`, which both entries satisfied - so every historical
+  // turn was pushed here twice.
+  it('does not double-count a turn when a user-sender entry also carries the same interaction as its paired AI entry', async () => {
+    const sharedInteraction = {
+      question: 'Earlier question',
+      answer: { content: 'Earlier answer' },
+    };
+
+    await invokeWith({
+      conversationHistory: [
+        { sender: 'user', text: 'Earlier question', interaction: sharedInteraction },
+        { sender: 'ai', interaction: sharedInteraction },
+      ],
+    });
+
+    const historyMessages = capturedMessages.filter((m) => m !== currentUserMessage() && m.role !== 'system');
+    expect(historyMessages).toEqual([
+      { role: 'user', content: 'Earlier question' },
+      { role: 'assistant', content: 'Earlier answer' },
+    ]);
+  });
+
+  it('still processes an unlabelled (no sender field) history entry that carries an interaction, for backward compatibility', async () => {
+    await invokeWith({
+      conversationHistory: [
+        {
+          interaction: {
+            question: 'Earlier question',
+            answer: { content: 'Earlier answer' },
+          },
+        },
+      ],
+    });
+
+    const historyMessages = capturedMessages.filter((m) => m !== currentUserMessage() && m.role !== 'system');
+    expect(historyMessages).toEqual([
+      { role: 'user', content: 'Earlier question' },
+      { role: 'assistant', content: 'Earlier answer' },
+    ]);
+  });
+
   it('passes search results to the system message', async () => {
     await invokeWith({ referringUrl: 'https://www.canada.ca/en/services.html' });
 

--- a/services/__tests__/ConversationIntegrityService.test.js
+++ b/services/__tests__/ConversationIntegrityService.test.js
@@ -39,6 +39,26 @@ describe('ConversationIntegrityService', () => {
             const serialized = ConversationIntegrityService.serializeHistory(historyWithTags);
             expect(serialized).toBe('user:Where is this?|ai:Here.');
         });
+
+        // Regression: ChatAppContainer.js retroactively attaches the same
+        // `interaction` object onto the *user* bubble too, not just the AI
+        // bubble (so the question bubble can read its own detected language).
+        // Before the sender check, a user message carrying `interaction` hit
+        // the same expand-to-Q+A branch as the AI message, doubling the
+        // user:/ai: lines and producing a different signature than the plain
+        // [user, ai] pair AnswerGenerationService originally signed.
+        it('should not double-count a user message that also carries interaction', () => {
+            const interaction = {
+                question: 'What is it?',
+                answer: { content: 'Interaction Answer' },
+            };
+            const historyBothBubblesTagged = [
+                { sender: 'user', text: 'What is it?', interaction },
+                { sender: 'ai', interaction },
+            ];
+            const serialized = ConversationIntegrityService.serializeHistory(historyBothBubblesTagged);
+            expect(serialized).toBe('user:What is it?|ai:Interaction Answer');
+        });
     });
 
     describe('calculateSignature', () => {
@@ -76,6 +96,32 @@ describe('ConversationIntegrityService', () => {
             ];
             const isValid = ConversationIntegrityService.verifyHistory(tamperedHistory, signature);
             expect(isValid).toBe(false);
+        });
+
+        // End-to-end regression for the same bug as above, at the signature
+        // level: a signature computed the way AnswerGenerationService.js does
+        // it after a turn completes - a plain [{sender, text}] pair, no
+        // `interaction` involved - must still verify against the client's
+        // resubmitted history on the *next* turn, which by then carries the
+        // same `interaction` object on both the user and ai bubble.
+        it('should verify a signature computed over a plain pair against the client\'s both-bubbles-tagged resubmission', () => {
+            const plainTurn = [
+                { sender: 'user', text: 'What is it?' },
+                { sender: 'ai', text: 'Interaction Answer' },
+            ];
+            const signature = ConversationIntegrityService.calculateSignature(plainTurn);
+
+            const interaction = {
+                question: 'What is it?',
+                answer: { content: 'Interaction Answer' },
+                historySignature: signature,
+            };
+            const resubmittedHistory = [
+                { sender: 'user', text: 'What is it?', interaction },
+                { sender: 'ai', interaction },
+            ];
+
+            expect(ConversationIntegrityService.verifyHistory(resubmittedHistory, signature)).toBe(true);
         });
     });
 });

--- a/src/App.computeAlternateLangHref.test.js
+++ b/src/App.computeAlternateLangHref.test.js
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { computeAlternateLangHref } from './App.js';
+
+// Regression coverage for the site-wide EN/FR header toggle. Review-mode
+// pages (?chat=...&review=1&adminLang=...) need the toggle to swap only
+// `adminLang` in the query string - the route's own `lang` path segment is
+// pinned to the reviewed chat's own pageLanguage (WCAG 3.1.2 /
+// official-languages.md Rule 2) and must never change on toggle, since the
+// chat transcript itself (ChatAppContainer -> ChatInterface, keyed off
+// `lang`) reads that route segment. Everything else in review mode -
+// ChatReviewPage.js's H1/nav, this App shell's own header/footer/status
+// banner, ChatInterface.js's inline eval tooling - keys off `adminLang`
+// instead, so it should follow the toggle normally.
+describe('computeAlternateLangHref', () => {
+  it('swaps the path lang segment and preserves search/hash outside review mode (unchanged existing behaviour)', () => {
+    const location = { pathname: '/en/about', search: '?foo=bar', hash: '#section' };
+    const { alternateLangHref, currentLang } = computeAlternateLangHref(location);
+
+    expect(currentLang).toBe('en');
+    expect(alternateLangHref).toContain('/fr/');
+    expect(alternateLangHref).toContain('?foo=bar');
+    expect(alternateLangHref).toContain('#section');
+  });
+
+  it('in review mode, swaps adminLang in the query string and leaves the path lang segment untouched', () => {
+    const location = {
+      pathname: '/en',
+      search: '?chat=abc123&review=1&adminLang=fr',
+      hash: '',
+    };
+    const { alternateLangHref, currentLang } = computeAlternateLangHref(location);
+
+    // currentLang drives the App shell's own chrome (header/footer/status
+    // banner) and document.documentElement.lang - it should follow adminLang
+    // in review mode, not the route's own /en path segment.
+    expect(currentLang).toBe('fr');
+    // The path itself (the reviewed chat's own pageLanguage) must not change.
+    expect(alternateLangHref.startsWith('/en?')).toBe(true);
+    expect(alternateLangHref).not.toContain('/fr');
+    // adminLang flips to the other language; chat/review params are preserved.
+    const params = new URLSearchParams(alternateLangHref.split('?')[1]);
+    expect(params.get('adminLang')).toBe('en');
+    expect(params.get('chat')).toBe('abc123');
+    expect(params.get('review')).toBe('1');
+  });
+
+  it('in review mode with no adminLang in the URL, defaults to the route\'s own lang before flipping', () => {
+    const location = { pathname: '/fr', search: '?chat=abc123&review=1', hash: '' };
+    const { alternateLangHref, currentLang } = computeAlternateLangHref(location);
+
+    // No adminLang present - HomePage.js's own fallback is `lang` (the route),
+    // so the toggle's starting point should be 'fr' (from the /fr path), and
+    // the computed currentLang for chrome purposes reflects that same fallback.
+    expect(currentLang).toBe('fr');
+    expect(alternateLangHref.startsWith('/fr?')).toBe(true);
+    const params = new URLSearchParams(alternateLangHref.split('?')[1]);
+    expect(params.get('adminLang')).toBe('en');
+  });
+
+  it('a ?chat=X URL without review=1 is not treated as review mode (uses normal path-swap behaviour)', () => {
+    const location = { pathname: '/en', search: '?chat=abc123', hash: '' };
+    const { alternateLangHref, currentLang } = computeAlternateLangHref(location);
+
+    expect(currentLang).toBe('en');
+    expect(alternateLangHref.startsWith('/fr')).toBe(true);
+  });
+});

--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,11 @@ const getAlternatePath = (currentPath, currentLang) => {
 
 // Compute both the current language and the alternate lang href (preserving search/hash).
 // Returns an object: { alternateLangHref, currentLang }
-const computeAlternateLangHref = (location) => {
+// Exported for direct unit testing (App.computeAlternateLangHref.test.js) - this is
+// shared logic that drives the site-wide EN/FR header toggle for every route,
+// document.documentElement.lang, and OG/SEO metadata, so it's covered directly
+// rather than only indirectly through a full App render.
+export const computeAlternateLangHref = (location) => {
   // location is the object from react-router; pathname does not include protocol/host
   try {
     console.debug('[computeAlternateLangHref] location:', location);
@@ -145,6 +149,28 @@ const computeAlternateLangHref = (location) => {
     console.debug('[computeAlternateLangHref] hostname:', runtimeHostname, 'hostPrefix:', hostPrefix, 'hadHostPrefix:', hadHostPrefix, 'currentLang:', currentLang);
   } catch (e) {
     // ignore
+  }
+
+  const search = (location && location.search) || (typeof window !== 'undefined' ? window.location.search : '');
+  const hash = (location && location.hash) || (typeof window !== 'undefined' ? window.location.hash : '');
+
+  // Review mode (?chat=...&review=1&adminLang=...): the route's own `lang`
+  // (this path segment) is pinned to the reviewed chat's own pageLanguage -
+  // WCAG 3.1.2 / official-languages.md Rule 2, never collapsed to a
+  // different language than what the end user actually saw - so it must
+  // never change on toggle. Only `adminLang` (the reviewing admin's own UI
+  // language - ChatReviewPage.js's H1/nav, this App shell's own
+  // header/footer/status banner, and ChatInterface.js's inline eval tooling
+  // all key off it, per HomePage.js's `adminLang` derivation) should follow
+  // the toggle here. The chat transcript itself (bubbles, citation heading)
+  // is keyed off `lang`, untouched by this branch, so it stays put too.
+  const searchParams = new URLSearchParams(search);
+  if (searchParams.get('review') === '1') {
+    const effectiveAdminLang = searchParams.get('adminLang') || currentLang;
+    const newAdminLang = effectiveAdminLang === 'en' ? 'fr' : 'en';
+    searchParams.set('adminLang', newAdminLang);
+    const alternateLangHref = `${path}?${searchParams.toString()}${hash || ''}`;
+    return { alternateLangHref, currentLang: effectiveAdminLang };
   }
 
   const alternatePath = getAlternatePath(path, currentLang);

--- a/src/components/admin/SimilarChatsDashboard.js
+++ b/src/components/admin/SimilarChatsDashboard.js
@@ -5,7 +5,7 @@ import DT from 'datatables.net-dt';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
 import VectorService from '../../services/VectorService.js';
-import { buildChatReviewLinkHtml } from '../../utils/reviewLink.js';
+import { buildChatReviewLinkHtml, chatLangFromPageLanguage } from '../../utils/reviewLink.js';
 import StatusMessage from './StatusMessage.js';
 import FeedbackInlineError from '../chat/FeedbackInlineError.js';
 import { useInlineFormError } from '../../hooks/useInlineFormError.js';
@@ -117,7 +117,12 @@ const SimilarChatsDashboard = ({ lang = 'en' }) => {
               {
                 title: t('vector.columns.chatId'),
                 data: 'chatId',
-                render: (data) => buildChatReviewLinkHtml(data, lang)
+                // Route to the chat's own pageLanguage (already shown in the
+                // adjacent Page language column below), not this dashboard's
+                // own current UI language - see the same note in
+                // ChatDashboardPage.js. The admin's own language rides along
+                // separately as the adminLang query param (4th arg).
+                render: (data, type, row) => buildChatReviewLinkHtml(data, chatLangFromPageLanguage(row.pageLanguage), null, lang)
               },
               { title: t('vector.columns.similarity'), data: 'similarity' },
               { title: t('vector.columns.aiProvider'), data: 'aiProvider' },

--- a/src/components/admin/__tests__/EvalAnalysisSection.test.js
+++ b/src/components/admin/__tests__/EvalAnalysisSection.test.js
@@ -109,9 +109,12 @@ describe('EvalAnalysisReport', () => {
     // "vs others" column removed deliberately (sensitivity); flag stays.
     expect(screen.queryByText('vs others')).toBeNull();
     // Example chatId links to review mode in a new tab, deep-linked to the
-    // evaluated interaction; groups without a stored example render a dash.
+    // evaluated interaction, routed to the example's own (EN/FR breakdown
+    // row) language - here 'en', same as the admin's own `lang`, which
+    // still rides along separately as the adminLang query param; groups
+    // without a stored example render a dash.
     const link = screen.getByRole('link', { name: 'chat-abc' });
-    expect(link.getAttribute('href')).toBe('/en?chat=chat-abc&review=1#interaction=interactionId' + encodeURIComponent('int-1'));
+    expect(link.getAttribute('href')).toBe('/en?chat=chat-abc&review=1&adminLang=en#interaction=interactionId' + encodeURIComponent('int-1'));
     expect(link.getAttribute('target')).toBe('_blank');
     expect(screen.getByText('—')).toBeTruthy();
   });

--- a/src/components/admin/dashboard/ContentIssueChatsCard.js
+++ b/src/components/admin/dashboard/ContentIssueChatsCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GcdsLink } from '@gcds-core/components-react';
 import CollapsibleCard from './CollapsibleCard.js';
-import { buildChatReviewHref } from '../../../utils/reviewLink.js';
+import { buildChatReviewHref, chatLangFromPageLanguage } from '../../../utils/reviewLink.js';
 
 // Collapsible list of chats matching some expert-feedback flag (content
 // issue, harmful, ...), server-scoped to the dashboard's current filters.
@@ -56,8 +56,13 @@ const ContentIssueChatsCard = ({
             </thead>
             <tbody>
               {chats.map((c) => {
-                const chatLang = c.pageLanguage === 'fr' ? 'fr' : 'en';
-                const href = buildChatReviewHref(c.chatId, chatLang, c.interactionId);
+                // Route to the chat's OWN pageLanguage, not the admin's
+                // current UI language - see the note in ChatDashboardPage.js.
+                // The admin's own language rides along separately as the
+                // `adminLang` query param (4th arg) for the review page's
+                // own chrome to use.
+                const chatLang = chatLangFromPageLanguage(c.pageLanguage);
+                const href = buildChatReviewHref(c.chatId, chatLang, c.interactionId, lang);
                 return (
                   <tr key={`${c.chatId}-${c.interactionId}`}>
                     <td style={{ ...cell, wordBreak: 'break-all' }}>
@@ -67,7 +72,7 @@ const ContentIssueChatsCard = ({
                           full note. Same upstream GC DS issue, not fixable
                           from our CSS (real shadow DOM, no exposed `part`
                           on that span). */}
-                      <GcdsLink href={href} target="_blank" lang={chatLang}>{c.chatId}</GcdsLink>
+                      <GcdsLink href={href} target="_blank" lang={lang}>{c.chatId}</GcdsLink>
                     </td>
                     <td style={cell}>
                       <span className={`label ${c.status}`}>{statusLabels[c.status] || c.status}</span>

--- a/src/components/admin/dashboard/CountTable.js
+++ b/src/components/admin/dashboard/CountTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GcdsLink } from '@gcds-core/components-react';
 import { formatNumber } from '../../../utils/numberFormat.js';
+import { detectUrlLanguage } from '../../../utils/dashboard/urlLanguage.js';
 
 // Plain two-column "label / count" table shared by the dashboard's collapsible
 // list cards (top referral pages, top citation pages, answer-type breakdown).
@@ -34,7 +35,26 @@ const CountTable = ({ labelColLabel, countColLabel, rows = [], lang = 'en', capt
                 // after the link text. Real shadow DOM, no exposed `part`
                 // on that span, so nothing in our own CSS can reach it. Not
                 // fixable here — let GC DS know upstream.
-                <GcdsLink href={row.href} target="_blank" lang={lang}>{row.label}</GcdsLink>
+                //
+                // GcdsLink's own `lang` prop does two unrelated jobs at once:
+                // native HTML lang inheritance (how a screen reader
+                // pronounces slotted text) AND a plain JS property read
+                // (gcds-link.js's assignLanguage/i18n[lang]) that picks which
+                // language string labels the icon it renders - here, the
+                // "(Opens destination in a new tab.)" accessible text. Those
+                // need different values: the host keeps the admin's own
+                // `lang` so that hint announces in the admin's language, and
+                // an inner span carries the row's own URL language
+                // (detectUrlLanguage) so the citation/referral title text
+                // itself is still pronounced correctly (WCAG 3.1.2) - a
+                // fixed-language Canada.ca URL, unrelated to whatever
+                // language the admin dashboard is set to. Putting
+                // detectUrlLanguage's result directly on GcdsLink instead
+                // would fix the text's pronunciation but wrongly flip the
+                // icon hint into the citation's language too.
+                <GcdsLink href={row.href} target="_blank" lang={lang}>
+                  <span lang={detectUrlLanguage(row.href, lang)}>{row.label}</span>
+                </GcdsLink>
               ) : (
                 row.label
               )}

--- a/src/components/admin/dashboard/EvalAnalysisReport.js
+++ b/src/components/admin/dashboard/EvalAnalysisReport.js
@@ -73,9 +73,17 @@ const EvalAnalysisReport = ({ analysis, lang = 'en' }) => {
   // Older stored reports have no example.
   const exampleLink = (example) => {
     if (!example?.chatId) return '—';
+    // Route to the example's own (EN/FR breakdown row) language, not the
+    // admin's current UI language - see the note in ChatDashboardPage.js.
+    // The admin's own language rides along separately as the `adminLang`
+    // query param (4th arg) for the review page's own chrome to use. The
+    // visible text is just the opaque chatId though, not real content -
+    // its `lang` attribute (driving GcdsLink's own "opens in a new tab"
+    // hint) is admin-facing chrome, so it follows the admin's own `lang`
+    // instead of `chatLang`, same reasoning as ContentIssueChatsCard.js.
     const chatLang = example.lang === 'fr' ? 'fr' : 'en';
     return (
-      <GcdsLink href={buildChatReviewHref(example.chatId, chatLang, example.interactionId)} target="_blank" lang={chatLang}>
+      <GcdsLink href={buildChatReviewHref(example.chatId, chatLang, example.interactionId, lang)} target="_blank" lang={lang}>
         {example.chatId}
       </GcdsLink>
     );

--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -53,9 +53,22 @@ const extractSentences = (paragraph) => {
   return sentences.length > 0 ? sentences : [paragraph];
 };
 
-const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessages = [], initialReferringUrl = null, clientReferrer = null, chatCreatedAt = null, targetInteractionId = null, onSessionError = null, onChatIdUpdate = null }) => {
+const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessages = [], initialReferringUrl = null, clientReferrer = null, chatCreatedAt = null, adminLang = null, targetInteractionId = null, onSessionError = null, onChatIdUpdate = null }) => {
   const MAX_CONVERSATION_TURNS = 3;
   const MAX_CHAR_LIMIT = 400;
+  // `lang` is always the language the transcript itself was actually in -
+  // for a live chat it's the current user's own page; in review mode
+  // HomePage.js/ChatDashboardPage.js route review links using the reviewed
+  // chat's own pageLanguage, not the admin's. So `t`/`safeT` below - used for
+  // the transcript's own fixed labels, e.g. the citation heading
+  // (agents/prompts/citationInstructions.js's history - it used to be
+  // LLM-generated per-response, deliberately made a fixed programmatic label
+  // instead for consistent wording/punctuation) - can key off `lang` directly
+  // without a separate override (official-languages.md Rule 2: never
+  // collapsed to a different language than what the end user actually saw).
+  // `adminLang` (the reviewing admin's own current UI language, only set in
+  // review mode) is for the admin-only chrome around that transcript instead
+  // - see the components that receive it below.
   const { t } = useTranslations(lang);
 
   // Add safeT helper function
@@ -63,6 +76,18 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
     const result = t(key);
     return typeof result === 'object' && result !== null ? result.text : result;
   }, [t]);
+
+  // Mirrors ChatInterface.js's effectiveAdminLang/safeAdminT split (see that
+  // file's comment for the full rationale). Only needed here for the
+  // expert-feedback-deleted live-region announcement below, which - like the
+  // rest of the review-mode admin chrome - should read in the reviewing
+  // admin's own UI language, not the transcript's `lang`.
+  const effectiveAdminLang = adminLang || lang;
+  const { t: adminT } = useTranslations(effectiveAdminLang);
+  const safeAdminT = useCallback((key) => {
+    const result = adminT(key);
+    return typeof result === 'object' && result !== null ? result.text : result;
+  }, [adminT]);
 
   const { url: pageUrl, department: urlDepartment } = usePageContext();
   const [messages, setMessages] = useState([]);
@@ -584,13 +609,37 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
 
         clearInput();
 
-        // Add the AI response to messages
-        setMessages(prevMessages => [...prevMessages, {
-          id: aiMessageId,
-          interaction: interaction,
-          sender: 'ai',
-          aiService: selectedAI,
-        }]);
+        // Add the AI response to messages, and retroactively give this
+        // turn's user message the detected question language too - it was
+        // pushed before the response came back, with nothing to tag itself
+        // with (ChatInterface.js's lang={toLangAttr(message.questionLanguage)}
+        // was silently reading undefined).
+        //
+        // Deliberately NOT `{ ...m, interaction }` (attaching the whole AI
+        // interaction object to the user bubble) - `.interaction` presence
+        // is a signal several *other*, unrelated pieces of server-side code
+        // (ContextAgentService.js, AnswerGenerationService.js) already use
+        // to mean "this is the AI's real turn, safe to read a full Q&A pair
+        // from" when building conversationHistory for the next request. This
+        // client `messages` array *is* that conversationHistory (sent
+        // verbatim in GraphClient.js's payload) - a user message also
+        // carrying `.interaction` broke that assumption for both files
+        // without their knowledge (each historical turn's Q&A got pushed
+        // twice, since both the user and AI message of that turn satisfied
+        // their `if (entry.interaction)` check). Passing only the resolved
+        // language string keeps `.interaction` truthiness reliably meaning
+        // "the AI's turn" everywhere, current and future - see the same
+        // reasoning applied to HomePage.js's review-mode message-building
+        // loop.
+        setMessages(prevMessages => [
+          ...prevMessages.map(m => (m.id === userMessageId ? { ...m, questionLanguage: getAnswerLanguage(interaction) } : m)),
+          {
+            id: aiMessageId,
+            interaction: interaction,
+            sender: 'ai',
+            aiService: selectedAI,
+          }
+        ]);
 
         setTurnCount(prev => prev + 1);
 
@@ -820,7 +869,7 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
           <>
             <hr className="citation-divider" aria-hidden="true" />
             <div className="citation-container">
-              <p key={`${messageId}-head`} className="citation-head">{safeT('homepage.chat.citation.heading')}</p>
+              <p key={`${messageId}-head`} className="citation-head" lang={answerLang}>{safeT('homepage.chat.citation.heading')}</p>
               <ul key={`${messageId}-link`} className="citation-link list-disc">
                   <li>
                     {/* Intentionally a raw <a>, not <GcdsLink>: the Adobe
@@ -1001,13 +1050,49 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
           </>
         )}
         <div className="disclaimer">
-          <p className="font-size-text-xsm-nr">
+          <p className="font-size-text-xsm-nr" lang={answerLang}>
             {safeT('homepage.chat.input.disclaimer')}
           </p>
         </div>
       </div>
     );
   }, [safeT, chatId, isMobile]);
+
+  // Keeps `messages` (the actual source ChatInterface/FeedbackComponent/
+  // ExpertFeedbackPanel all render from) in sync after an expert eval is
+  // submitted or deleted, without a page refresh. Both
+  // FeedbackComponent.js's handleExpertFeedback and
+  // ExpertFeedbackPanel.js's handleDelete used to only update the shared
+  // `message` object in place (a direct mutation, not a state update) -
+  // React never learns that mutation happened, so ChatInterface.js's own
+  // `!message.interaction.expertFeedback` check (deciding whether to show
+  // the eval form or the read-only summary panel) kept evaluating against
+  // its last render and never flipped until something else (e.g. a full
+  // page reload) forced ChatInterface to re-render from fresh data. Pass
+  // `undefined` for `expertFeedback` on delete, the persisted feedback
+  // object on submit.
+  //
+  // On delete specifically, ExpertFeedbackPanel.js's own "Delete" button -
+  // which had focus - is removed from the DOM in this same update, and
+  // FeedbackComponent reappears in its place. A sighted admin sees the eval
+  // prompt come back; nothing else signals that to a screen-reader user, so
+  // this both moves focus into the reappeared FeedbackComponent
+  // (reappearedFeedback, matched by messageId+nonce so ChatInterface can
+  // route it to the right instance) and announces the change via the
+  // existing ariaLiveMessage region below (reused rather than adding a
+  // second live-region mechanism).
+  const [reappearedFeedback, setReappearedFeedback] = useState(null);
+  const handleExpertFeedbackChange = useCallback((messageId, expertFeedback) => {
+    setMessages(prevMessages => prevMessages.map(m =>
+      (m.id === messageId && m.interaction)
+        ? { ...m, interaction: { ...m.interaction, expertFeedback } }
+        : m
+    ));
+    if (!expertFeedback) {
+      setReappearedFeedback({ messageId, nonce: Date.now() });
+      announceToLiveRegion(safeAdminT('homepage.feedback.expertFeedbackDeletedAnnouncement'));
+    }
+  }, [announceToLiveRegion, safeAdminT]);
 
   // Add handler for department changes
 
@@ -1040,10 +1125,13 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
         MAX_CONVERSATION_TURNS={MAX_CONVERSATION_TURNS}
         t={t}
         lang={lang}
+        adminLang={adminLang || lang}
         extractSentences={extractSentences}
         chatId={chatId}
         readOnly={readOnly}
         userLeftChatRef={userLeftChatRef}
+        onExpertFeedbackChange={handleExpertFeedbackChange}
+        reappearedFeedback={reappearedFeedback}
       />
       {/* Panels are rendered inline after each AI message in ChatInterface when in readOnly mode. */}
       <div

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -16,6 +16,7 @@ import { buildReadableLocationLabel } from '../../utils/citationAriaLabel.js';
 import { CanadaCaAccessibleLabel } from '../../utils/pronounceCanadaCa.js';
 import { buildAnswerNumberLabel } from '../../hooks/useAnswerNumberLabel.js';
 import { getAnswerLanguage, toLangAttr } from '../../utils/answerLanguage.js';
+import { detectUrlLanguage } from '../../utils/dashboard/urlLanguage.js';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { useActiveScenarioOverride } from '../../hooks/chat/useActiveScenarioOverride.js';
 import ScenarioSubmitInstructions from '../scenario/ScenarioSubmitInstructions.js';
@@ -515,13 +516,22 @@ const ChatInterface = ({
       {referringUrl && (readOnly || messages.length > 0) && (
         readOnly ? (
           <span className="referring-url-label mb-300">
-            <b>{safeT("homepage.chat.input.referringURL")}</b>{" "}
+            {/* Admin-facing label (review mode only) - follows the admin's own
+                toggle language, same as every other piece of review chrome
+                (adminT). The URL itself is real content from the user's
+                actual page, split the same way as CountTable.js's citation
+                links: GcdsLink's own `lang` drives its "(opens in a new
+                tab)" hint (admin chrome, effectiveAdminLang), while the
+                nested span carries the URL's own detected language
+                (detectUrlLanguage) so the text itself is pronounced
+                correctly regardless of the admin's current UI language. */}
+            <b>{safeAdminT("homepage.chat.input.referringURL")}</b>{" "}
 
             <GcdsLink href={referringUrl}
               target="_blank"
-              lang={lang}
+              lang={effectiveAdminLang}
             >
-              {referringUrl}
+              <span lang={detectUrlLanguage(referringUrl, lang)}>{referringUrl}</span>
             </GcdsLink>
           </span>
         ) : (
@@ -931,16 +941,23 @@ const ChatInterface = ({
                     >
                       <strong>{adminT("homepage.chat.review.referringUrl")}</strong>{" "}
                       {referringUrl ? (
+                        // Same split as CountTable.js's citation links: GcdsLink's own
+                        // `lang` drives its auto-generated "(opens in a new tab)" hint,
+                        // which is admin chrome and should announce in the admin's own
+                        // language - while the URL text itself is real content from the
+                        // user's actual page, tagged with its own detected language
+                        // (detectUrlLanguage) so it's pronounced correctly regardless of
+                        // what the admin dashboard happens to be set to.
                         <GcdsLink
                           href={referringUrl}
                           target="_blank"
-                          lang={lang}
+                          lang={effectiveAdminLang}
                           className="url-break-all"
                         >
-                          {referringUrl}
+                          <span lang={detectUrlLanguage(referringUrl, lang)}>{referringUrl}</span>
                         </GcdsLink>
                       ) : (
-                        <span style={{ color: "#666" }}>none</span>
+                        <span style={{ color: "#666" }}>{adminT('reviewPanels.none')}</span>
                       )}
                     </div>
                   )}

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -15,6 +15,8 @@ import { formatNumber } from '../../utils/numberFormat.js';
 import { buildReadableLocationLabel } from '../../utils/citationAriaLabel.js';
 import { CanadaCaAccessibleLabel } from '../../utils/pronounceCanadaCa.js';
 import { buildAnswerNumberLabel } from '../../hooks/useAnswerNumberLabel.js';
+import { getAnswerLanguage, toLangAttr } from '../../utils/answerLanguage.js';
+import { useTranslations } from '../../hooks/useTranslations.js';
 import { useActiveScenarioOverride } from '../../hooks/chat/useActiveScenarioOverride.js';
 import ScenarioSubmitInstructions from '../scenario/ScenarioSubmitInstructions.js';
 import ScenarioOverrideBanner from './ScenarioOverrideBanner.js';
@@ -47,10 +49,13 @@ const ChatInterface = ({
   MAX_CONVERSATION_TURNS,
   t,
   lang,
+  adminLang,
   extractSentences,
   chatId,
   readOnly = false,
   userLeftChatRef,
+  onExpertFeedbackChange,
+  reappearedFeedback,
 }) => {
   // Add safeT helper function
   const safeT = useCallback(
@@ -61,6 +66,29 @@ const ChatInterface = ({
         : result;
     },
     [t]
+  );
+
+  // effectiveAdminLang/adminT/safeAdminT: a second, separately-resolved
+  // translator for the review-mode-only "admin chrome" around the
+  // transcript - the department wrapper's review panels
+  // (ExpertFeedbackPanel/PublicFeedbackPanel/DownloadPanel/UsedChatsPanel/
+  // EvalPanel/FeedbackComponent), and the Chat ID/Referring URL/Date labels.
+  // `lang` above is the chat's own language (what the end user actually saw
+  // - official-languages.md Rule 2); this is the reviewing admin's own
+  // current UI language instead. `adminLang` is only ever set by
+  // ChatAppContainer.js in review mode and otherwise defaults to `lang`, so
+  // live-chat behaviour is unchanged. Resolved once here rather than
+  // `adminLang || lang` at every call site below.
+  const effectiveAdminLang = adminLang || lang;
+  const { t: adminT } = useTranslations(effectiveAdminLang);
+  const safeAdminT = useCallback(
+    (key) => {
+      const result = adminT(key);
+      return typeof result === "object" && result !== null
+        ? result.text
+        : result;
+    },
+    [adminT]
   );
 
   // Add truncateURL helper function 
@@ -560,13 +588,20 @@ const ChatInterface = ({
             ? aiAnswerIndex + 1
             : undefined;
           const { answerText: departmentAnswerText } = buildAnswerNumberLabel(
-            t,
+            adminT,
             aiAnswerIndex !== null ? aiAnswerIndex + 1 : undefined
           );
           const userQuestionIndex = (message.sender === "user" && !message.error)
             ? sequenceableUserMessages.findIndex(m => m.id === message.id)
             : null;
           const citationUrl = getCitationUrl(message.interaction);
+          // Computed once per message rather than inline at each
+          // FeedbackComponent call site below (review-mode and live-chat
+          // both need it) - same fallback chain, just no longer duplicated
+          // verbatim. Optional chaining here (unlike the old inline
+          // versions) since this now also runs for user-sender messages,
+          // which never carry `.interaction`.
+          const englishQuestion = message.interaction?.answer?.englishQuestion || message.interaction?.question?.englishQuestion || '';
           const isLastErrorMessage =
             message.error && message.id === messages[messages.length - 1]?.id;
           // While the AI is still generating a reply, the most recent question
@@ -599,6 +634,19 @@ const ChatInterface = ({
                   {...(message.redactedText?.includes("###") && {
                     "aria-hidden": "true",
                   })}
+                  // Real detected language, not collapsed to English - this is
+                  // the actual conversation transcript (what the end user
+                  // typed), not an admin/eval tool. `message.questionLanguage`
+                  // (not `message.interaction`, which a user-sender message
+                  // never carries - see ChatAppContainer.js/HomePage.js) is
+                  // the same detected language the answer bubble tags itself
+                  // with via getAnswerLanguage(message.interaction), just
+                  // pre-resolved to a plain string at attach-time since the
+                  // two sides of one interaction share it. See
+                  // docs/coding-agent-docs/official-languages.md for why this
+                  // differs from the collapse-to-English rule used in the
+                  // eval/dashboard tools.
+                  lang={toLangAttr(message.questionLanguage)}
                 >
                   {message.text}
                 </p>
@@ -721,19 +769,19 @@ const ChatInterface = ({
                           <h3 className="sr-only">
                             {departmentAnswerText ? `${departmentAnswerText} - ` : ""}
                             {message.interaction.context?.department ||
-                              safeT("homepage.chat.review.noDepartment")}
+                              safeAdminT("homepage.chat.review.noDepartment")}
                           </h3>
                           <p className="department-label-text font-size-text-xsm-nr mb-200" aria-hidden="true">
                             <b>
                               {message.interaction.context?.department ||
-                                safeT("homepage.chat.review.noDepartment")}
+                                safeAdminT("homepage.chat.review.noDepartment")}
                             </b>
                           </p>
                           {caches &&
                             message.interaction.answer.answerType !== "question" &&
                             !message.interaction.expertFeedback && (
                               <FeedbackComponent
-                                lang={lang}
+                                lang={effectiveAdminLang}
                                 sentences={
                                   extractSentences(message.interaction.answer.content) ||
                                   []
@@ -742,6 +790,23 @@ const ChatInterface = ({
                                   extractSentences(message.interaction.answer.content)
                                     .length
                                 }
+                                // Same EN/FR-official-languages display rule (shown
+                                // as-is; non-EN/FR collapses to English) as
+                                // ExpertFeedbackPanel.js/ChatDashboardPage.js -
+                                // getAnswerLanguage handles
+                                // both the live and persisted data shapes.
+                                questionLanguage={getAnswerLanguage(message.interaction)}
+                                // TODO(sentence-pairing-risk): see the
+                                // resolveDisplayContent TODO in
+                                // answerLanguage.js - sentences/sentencesEnglish
+                                // are paired purely by array index with no
+                                // enforced guarantee of matching segmentation.
+                                sentencesEnglish={
+                                  message.interaction.answer.englishAnswer
+                                    ? extractSentences(message.interaction.answer.englishAnswer)
+                                    : []
+                                }
+                                englishQuestion={englishQuestion}
                                 chatId={chatId}
                                 userMessageId={message.id}
                                 answerNumber={reviewAnswerNumber}
@@ -752,25 +817,47 @@ const ChatInterface = ({
                                 skipButtonLabel={safeT(
                                   "homepage.chat.textarea.ariaLabel.skipfo"
                                 )}
+                                onExpertFeedbackChange={(expertFeedback) =>
+                                  onExpertFeedbackChange?.(message.id, expertFeedback)
+                                }
+                                // Only set for the one message whose expert
+                                // feedback was just deleted - tells
+                                // FeedbackComponent to move focus into
+                                // itself, since it just reappeared in place
+                                // of ExpertFeedbackPanel's summary and the
+                                // Delete button that had focus is now gone
+                                // from the DOM.
+                                reappearedAfterDeleteNonce={
+                                  reappearedFeedback?.messageId === message.id
+                                    ? reappearedFeedback.nonce
+                                    : undefined
+                                }
                               />
                             )}
                           <div className="inline-review-panels">
                             <ExpertFeedbackPanel
                               message={message}
                               extractSentences={extractSentences}
-                              t={t}
-                              lang={lang}
+                              t={adminT}
+                              lang={effectiveAdminLang}
                               answerNumber={reviewAnswerNumber}
+                              onDeleted={() => onExpertFeedbackChange?.(message.id, undefined)}
                             />
                             <PublicFeedbackPanel
                               message={message}
                               extractSentences={extractSentences}
-                              t={t}
+                              t={adminT}
                               answerNumber={reviewAnswerNumber}
                             />
-                            <DownloadPanel message={message} t={t} lang={lang} answerNumber={reviewAnswerNumber} />
-                            <UsedChatsPanel message={message} t={t} lang={lang} answerNumber={reviewAnswerNumber} />
-                            <EvalPanel message={message} t={t} lang={lang} answerNumber={reviewAnswerNumber} />
+                            <DownloadPanel message={message} t={adminT} lang={effectiveAdminLang} answerNumber={reviewAnswerNumber} />
+                            {/* lang stays the CURRENT chat's own language here, not adminLang -
+                                it routes buildChatReviewHref to a DIFFERENT matched chat, which
+                                has no known pageLanguage of its own available to this panel
+                                (UsedChatsPanel.js has the full explanation). adminLang still rides
+                                along as the link's adminLang query param, and its translated
+                                labels (t) follow the admin's language. */}
+                            <UsedChatsPanel message={message} t={adminT} lang={lang} adminLang={effectiveAdminLang} answerNumber={reviewAnswerNumber} />
+                            <EvalPanel message={message} t={adminT} lang={effectiveAdminLang} answerNumber={reviewAnswerNumber} />
                           </div>
                         </div>
                       )}
@@ -791,6 +878,13 @@ const ChatInterface = ({
                               )
                               : []
                           }
+                          questionLanguage={getAnswerLanguage(message.interaction)}
+                          sentencesEnglish={
+                            message.interaction.answer.englishAnswer
+                              ? extractSentences(message.interaction.answer.englishAnswer)
+                              : []
+                          }
+                          englishQuestion={englishQuestion}
                           chatId={chatId}
                           userMessageId={message.id}
                           answerNumber={reviewAnswerNumber}
@@ -812,7 +906,7 @@ const ChatInterface = ({
                     {message.sender === "ai" && !message.error && chatId && (
                       <div className="chat-id">
                         <p className="font-size-text-xxs-nr">
-                          {safeT("homepage.chat.chatId")}: {chatId}
+                          {safeAdminT("homepage.chat.chatId")}: {chatId}
                         </p>
                       </div>
                     )}
@@ -835,7 +929,7 @@ const ChatInterface = ({
                         fontSize: "0.9rem"
                       }}
                     >
-                      <strong>{t("homepage.chat.review.referringUrl")}</strong>{" "}
+                      <strong>{adminT("homepage.chat.review.referringUrl")}</strong>{" "}
                       {referringUrl ? (
                         <GcdsLink
                           href={referringUrl}
@@ -1119,7 +1213,7 @@ const ChatInterface = ({
       {/* Show chat date at bottom for review mode */}
       {readOnly && chatCreatedAt && (
         <div className="admin-date">
-          <b>{safeT("homepage.chat.review.chatDate")}</b> {formatChatDate(chatCreatedAt)}
+          <b>{safeAdminT("homepage.chat.review.chatDate")}</b> {formatChatDate(chatCreatedAt)}
         </div>
       )}
     </div>

--- a/src/components/chat/ExpertFeedbackComponent.js
+++ b/src/components/chat/ExpertFeedbackComponent.js
@@ -6,6 +6,8 @@ import { useAnswerNumberLabel } from '../../hooks/useAnswerNumberLabel.js';
 import FeedbackInlineError from './FeedbackInlineError.js';
 import ExplanationErrorSummary from './ExplanationErrorSummary.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { resolveDisplayContent, toLangAttr } from '../../utils/answerLanguage.js';
+import OriginalLanguagePill from './review/OriginalLanguagePill.js';
 
 // Shows ratings for a maximum of 4 sentences, and for the citation score
 // if there are somehow 5 sentences, the 5th sentence is ignored _YES THIS IS A HACK
@@ -16,6 +18,8 @@ const ExpertFeedbackComponent = ({
   lang = 'en',
   sentenceCount = 1,
   sentences = [],
+  questionLanguage = '',
+  sentencesEnglish = [],
   answerNumber,
   citationUrl,
   department,
@@ -139,6 +143,19 @@ const ExpertFeedbackComponent = ({
       }))
     : null;
 
+  // Same EN/FR-official-languages display rule (shown as-is; non-EN/FR
+  // collapses to English) as ExpertFeedbackPanel.js/ChatDashboardPage.js
+  // (resolveDisplayContent) -
+  // questionLanguage drives every sentence uniformly, since the AI answers
+  // in whatever language was detected for the question (agenticBase.js),
+  // not a separately-tracked language per sentence. Resolved once here
+  // (not inside the .map() below) since sentences[index] is also read
+  // directly for the aria-describedby presence check.
+  const sentenceDisplays = sentences.map((sentence, index) =>
+    resolveDisplayContent({ language: questionLanguage, original: sentence, english: sentencesEnglish[index] })
+  );
+  const isSource = sentenceDisplays.some((d) => d.isSource);
+
   const handleRadioChange = (event) => {
     const { name, value } = event.target;
     const sentenceNumber = name.replace('Score', '');
@@ -258,12 +275,17 @@ const ExpertFeedbackComponent = ({
     // (type="url") input, with no replacement check in its place. Confirm
     // whether that's an acceptable gap (optional field, trusted admin
     // input) before adding a replacement check — not adding one blind.
-    <form onSubmit={handleSubmit} className="expert-rating-container" noValidate>
+    <form onSubmit={handleSubmit} className="expert-rating-container" noValidate lang={lang}>
       <FontAwesomeIcon
         icon="fa-solid fa-close"
         className="close-icon"
         onClick={onClose}
-        onKeyDown={(e) => e.key === 'Enter' && onClose()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClose();
+          }
+        }}
         role="button"
         tabIndex={0}
         aria-label={t('common.close')}
@@ -275,6 +297,11 @@ const ExpertFeedbackComponent = ({
             <span className="feedback-answer-number">{answerText}</span>
           )}
         </h4>
+        {isSource && (
+          <div className="mb-100">
+            <OriginalLanguagePill languageCode={toLangAttr(questionLanguage)} lang={lang} t={t} />
+          </div>
+        )}
         {explanationSummaryLinks && (
           <ExplanationErrorSummary
             id={`${uid}-explanation-summary`}
@@ -307,7 +334,7 @@ const ExpertFeedbackComponent = ({
               </legend>
               {sentences[index] && (
                 <div className="sentence-text mb-200" id={`${uid}-sentence${index + 1}-text`}>
-                  "{sentences[index]}"
+                  "<span lang={sentenceDisplays[index].lang}>{sentenceDisplays[index].text}</span>"
                 </div>
               )}
               <ul className="list-unstyled lst-spcd-2">

--- a/src/components/chat/ExpertFeedbackComponent.js
+++ b/src/components/chat/ExpertFeedbackComponent.js
@@ -8,6 +8,7 @@ import ExplanationErrorSummary from './ExplanationErrorSummary.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { resolveDisplayContent, toLangAttr } from '../../utils/answerLanguage.js';
 import OriginalLanguagePill from './review/OriginalLanguagePill.js';
+import { detectUrlLanguage } from '../../utils/dashboard/urlLanguage.js';
 
 // Shows ratings for a maximum of 4 sentences, and for the citation score
 // if there are somehow 5 sentences, the 5th sentence is ignored _YES THIS IS A HACK
@@ -456,7 +457,16 @@ const ExpertFeedbackComponent = ({
                 can rate its absence as good, needs improvement, or incorrect
                 (e.g. an answer that should have cited a source but didn't). */}
             <div className="citation-text mb-200" id={`${uid}-citation-text`}>
-              {citationUrl || t('homepage.expertRating.citationNoneProvided')}
+              {citationUrl ? (
+                // Real content pulled straight from the source, not the
+                // reviewer's own conversation - tag it with the URL's own
+                // language (detectUrlLanguage, from its /en//fr/ path
+                // segment), same as the citation link fix elsewhere in this
+                // PR (CountTable.js), not the admin UI's lang.
+                <span lang={detectUrlLanguage(citationUrl, lang)}>{citationUrl}</span>
+              ) : (
+                t('homepage.expertRating.citationNoneProvided')
+              )}
             </div>
             <ul className="list-unstyled lst-spcd-2">
               <li className="radio">

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -1,10 +1,13 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import ExpertFeedbackComponent from "./ExpertFeedbackComponent.js";
 import PublicFeedbackComponent from "./PublicFeedbackComponent.js";
+import SourceViewComponent from "./SourceViewComponent.js";
 import { useHasAnyRole } from "../RoleBasedUI.js";
 import { useTranslations } from "../../hooks/useTranslations.js";
 import { useFocusOnChange } from "../../hooks/useFocusOnChange.js";
 import { useReturnFocusOnClose } from "../../hooks/useReturnFocusOnClose.js";
+import { useAnswerNumberLabel } from "../../hooks/useAnswerNumberLabel.js";
+import { resolveDisplayContent } from "../../utils/answerLanguage.js";
 import FeedbackService from "../../services/FeedbackService.js";
 
 const FeedbackComponent = ({
@@ -13,6 +16,9 @@ const FeedbackComponent = ({
   chatId,
   userMessageId,
   sentences = [],
+  questionLanguage = "",
+  sentencesEnglish = [],
+  englishQuestion = "",
   answerNumber,
   citationUrl,
   department,
@@ -21,21 +27,85 @@ const FeedbackComponent = ({
   onSkip = () => { }, // Function to call when skip link is activated
   skipButtonLabel = "", // Accessible label for the skip link
   skipToId = "message", // id of the element the skip link navigates to
+  // Optional - only meaningful for the expert eval flow. Tells the parent
+  // (ChatAppContainer.js, via ChatInterface.js) that this interaction's
+  // expertFeedback changed, so `messages` state actually updates instead of
+  // only the shared `message` object being mutated in place. See the
+  // click-anywhere effect below for when this fires.
+  onExpertFeedbackChange,
+  // Optional - only set by ChatInterface.js for the one message whose
+  // expert feedback was just deleted. This component doesn't get toggled
+  // visible/hidden within one mounted instance for that case - it wasn't
+  // rendered at all while expertFeedback existed (see the !expertFeedback
+  // guard in ChatInterface.js), so this is a fresh mount, not a state
+  // change on an existing one. A plain boolean would still work since a
+  // fresh mount only happens once per reappearance, but a changing value
+  // (Date.now(), from ChatAppContainer.js) is used anyway for consistency
+  // with useFocusOnChange's counter convention elsewhere in this file.
+  reappearedAfterDeleteNonce,
 }) => {
   const { t } = useTranslations(lang);
+  const { withAnswerNumber } = useAnswerNumberLabel(t, answerNumber);
   const [feedbackGiven, setFeedbackGiven] = useState(false);
   const [feedbackError] = useState(false);
   const [showExpertRating, setShowExpertRating] = useState(false);
   const [showPublicRating, setShowPublicRating] = useState(false);
+  const [showSourceView, setShowSourceView] = useState(false);
   const [publicPositive, setPublicPositive] = useState(true);
+  // Set only on the expert-eval submit path (quick "Yes" or the full rating
+  // form) - holds the just-persisted feedback until the reviewer clicks
+  // anywhere, at which point it's handed up via onExpertFeedbackChange so
+  // this "Thank you" gives way to ExpertFeedbackPanel's read-only summary.
+  // Not used for public feedback - there's no equivalent summary swap there.
+  const [pendingExpertFeedback, setPendingExpertFeedback] = useState(null);
   const hasExpertRole = useHasAnyRole(["admin", "partner"]);
   const thankYouRef = useFocusOnChange(feedbackGiven);
   const expertRatingTitleRef = useFocusOnChange(showExpertRating);
   const publicRatingTitleRef = useFocusOnChange(showPublicRating);
+  const sourceViewTitleRef = useFocusOnChange(showSourceView);
   const yesButtonRef = useRef(null);
   const noButtonRef = useRef(null);
+  const viewSourceButtonRef = useRef(null);
+  const usefulButtonRef = useRef(null);
   useReturnFocusOnClose(showExpertRating, noButtonRef);
   useReturnFocusOnClose(showPublicRating, publicPositive ? yesButtonRef : noButtonRef);
+  useReturnFocusOnClose(showSourceView, viewSourceButtonRef);
+
+  // Runs once per fresh mount triggered by an expert-feedback deletion (see
+  // the reappearedAfterDeleteNonce prop comment) - focuses whichever of the
+  // two possible first controls this render actually shows, since which one
+  // exists depends on isSource. useEffect runs after the initial render too,
+  // so the ref is already attached by the time this fires.
+  useEffect(() => {
+    if (!reappearedAfterDeleteNonce) return;
+    (viewSourceButtonRef.current || usefulButtonRef.current)?.focus();
+  }, [reappearedAfterDeleteNonce]);
+
+  // Same EN/FR-official-languages rule (shown as-is; non-EN/FR collapses to
+  // English) used everywhere else this displays (resolveDisplayContent,
+  // src/utils/answerLanguage.js). "Review the English source text" only
+  // makes sense to offer when there's actually AI Answers' own English
+  // working text to show - i.e. the answer language isn't already EN/FR.
+  // This is AI Answers' own source/working text, not a translation service -
+  // don't reintroduce "translation" language here.
+  //
+  // TODO(sentence-pairing-risk): this is the highest-stakes consumer of the
+  // sentences/sentencesEnglish pairing risk documented on resolveDisplayContent
+  // (answerLanguage.js) - `isSource` here gates whether a reviewer sees
+  // the mandatory "Review the English source text" step at all before rating
+  // a non-EN/FR answer, not just a decorative pill. A naive fix that makes a
+  // sentence-count mismatch fall back to `english: undefined` would flip this
+  // to false and drop the reviewer straight into Good/Needs improvement on
+  // text they can't read, with no indication anything was skipped - worse
+  // than the current mispairing risk it would "fix". See the full TODO on
+  // resolveDisplayContent before touching this.
+  const isSource = sentences.some((sentence, index) =>
+    resolveDisplayContent({
+      language: questionLanguage,
+      original: sentence,
+      english: sentencesEnglish[index],
+    }).isSource
+  );
 
   const handleFeedback = (isPositive) => {
     let feedbackPayload = null;
@@ -51,6 +121,7 @@ const FeedbackComponent = ({
           interactionId: userMessageId,
           expertFeedback: feedbackPayload,
         });
+        setPendingExpertFeedback(feedbackPayload);
         setFeedbackGiven(true);
       } else {
         setPublicPositive(true);
@@ -65,6 +136,15 @@ const FeedbackComponent = ({
       }
     }
   };
+  // Used by the Good/Needs improvement choice living inside the source-text
+  // popout (isSource case) instead of directly on the prompt - closes
+  // the popout and defers to the same handleFeedback the direct buttons use,
+  // so both paths persist/branch identically.
+  const handleSourceViewFeedback = (isPositive) => {
+    setShowSourceView(false);
+    handleFeedback(isPositive);
+  };
+
   const handleExpertFeedback = (expertFeedback) => {
     console.log("Expert feedback received:", expertFeedback);
     const feedbackWithType = {
@@ -77,8 +157,33 @@ const FeedbackComponent = ({
       interactionId: userMessageId,
       expertFeedback: feedbackWithType,
     });
+    setPendingExpertFeedback(feedbackWithType);
     setFeedbackGiven(true);
   };
+
+  // Once "Thank you" is showing for an expert eval, any click anywhere hands
+  // the persisted feedback up to the parent (onExpertFeedbackChange), which
+  // updates `messages` state - that flips ChatInterface.js's
+  // `!message.interaction.expertFeedback` check, so this component stops
+  // being rendered at all and ExpertFeedbackPanel's summary takes over.
+  // The listener is attached via setTimeout(0), not synchronously in this
+  // effect, so it doesn't also catch the very click (still bubbling to
+  // document) that triggered feedbackGiven in the first place.
+  useEffect(() => {
+    if (!pendingExpertFeedback || !onExpertFeedbackChange) return;
+    let listenerAttached = false;
+    const handleClickAnywhere = () => onExpertFeedbackChange(pendingExpertFeedback);
+    const attachTimer = setTimeout(() => {
+      listenerAttached = true;
+      document.addEventListener('click', handleClickAnywhere);
+    }, 0);
+    return () => {
+      clearTimeout(attachTimer);
+      if (listenerAttached) {
+        document.removeEventListener('click', handleClickAnywhere);
+      }
+    };
+  }, [pendingExpertFeedback, onExpertFeedbackChange]);
 
   const handlePublicFeedback = (publicFeedback) => {
     FeedbackService.persistPublicFeedback({
@@ -92,7 +197,7 @@ const FeedbackComponent = ({
 
   if (feedbackGiven) {
     return (
-      <p className="thank-you" role="status" ref={thankYouRef} tabIndex={-1}>
+      <p className="thank-you" role="status" ref={thankYouRef} tabIndex={-1} lang={lang}>
         <span className="gcds-icon fa fa-solid fa-check-circle" aria-hidden="true"></span>
         {t("homepage.feedback.thankYou")}
       </p>
@@ -100,7 +205,7 @@ const FeedbackComponent = ({
   }
   if (feedbackError) {
     return (
-      <p className="feedback-error">
+      <p className="feedback-error" lang={lang}>
         <span
           className="gcds-icon fa fa-solid fa-exclamation-circle"
           style={{ color: "red" }}
@@ -109,6 +214,24 @@ const FeedbackComponent = ({
       </p>
     );
   }
+  if (showSourceView) {
+    return (
+      <SourceViewComponent
+        onClose={() => setShowSourceView(false)}
+        onFeedback={handleSourceViewFeedback}
+        lang={lang}
+        sentenceCount={sentenceCount}
+        sentences={sentences}
+        questionLanguage={questionLanguage}
+        sentencesEnglish={sentencesEnglish}
+        englishQuestion={englishQuestion}
+        answerNumber={answerNumber}
+        titleRef={sourceViewTitleRef}
+        noButtonRef={noButtonRef}
+      />
+    );
+  }
+
   if (showExpertRating) {
     return (
       <ExpertFeedbackComponent
@@ -117,6 +240,8 @@ const FeedbackComponent = ({
         lang={lang}
         sentenceCount={sentenceCount}
         sentences={sentences}
+        questionLanguage={questionLanguage}
+        sentencesEnglish={sentencesEnglish}
         answerNumber={answerNumber}
         citationUrl={citationUrl}
         department={department}
@@ -142,14 +267,14 @@ const FeedbackComponent = ({
   // Show public mode question: Was this helpful? Yes No
   if (!hasExpertRole) {
     return (
-      <div className="feedback-container">
+      <div className="feedback-container" lang={lang}>
         <span className="feedback-text" aria-hidden="true">
           {t("homepage.publicFeedback.question")}
         </span>
         <span className="feedback-buttons">
           <button
             ref={yesButtonRef}
-            className="feedback-link button-as-link link-default hover:link-hover"
+            className="feedback-link button-as-link link-default hover:link-hover feedback-icon-up"
             onClick={() => handleFeedback(true)}
             tabIndex="0"
             aria-label={`${t("homepage.publicFeedback.question")} ${t("common.yes", "Yes")}`}
@@ -159,7 +284,7 @@ const FeedbackComponent = ({
           <span className="feedback-separator">·</span>
           <button
             ref={noButtonRef}
-            className="feedback-link button-as-link link-default hover:link-hover"
+            className="feedback-link button-as-link link-default hover:link-hover feedback-icon-down"
             onClick={() => handleFeedback(false)}
             tabIndex="0"
             aria-label={`${t("homepage.publicFeedback.question")} ${t("common.no", "No")}`}
@@ -184,28 +309,47 @@ const FeedbackComponent = ({
   }
 
   return (
-    <div className="feedback-container">
+    <div className="feedback-container" lang={lang}>
       <span className="feedback-text" aria-hidden="true">{t("homepage.feedback.question")} </span>
-      <button
-        className="feedback-link button-as-link"
-        onClick={() => handleFeedback(true)}
-        tabIndex="0"
-        aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.useful")}`}
-      >
-        {t("homepage.feedback.useful")}
-      </button>
-      <span className="feedback-separator">·</span>
-      <span className="feedback-text">{t("homepage.feedback.or")}</span>
-      <span className="feedback-separator">·</span>
-      <button
-        ref={noButtonRef}
-        className="feedback-link button-as-link"
-        onClick={() => handleFeedback(false)}
-        tabIndex="0"
-        aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.notUseful")}`}
-      >
-        {t("homepage.feedback.notUseful")}
-      </button>
+      {isSource ? (
+        // Answer isn't already EN/FR - a reviewer can't meaningfully rate
+        // what they can't read, so AI Answers' own English source text comes
+        // first and Good/Needs improvement live inside that view instead of
+        // here.
+        <button
+          ref={viewSourceButtonRef}
+          className="feedback-link button-as-link font-size-text-sm-nr"
+          onClick={() => setShowSourceView(true)}
+          tabIndex="0"
+          aria-label={withAnswerNumber(t("homepage.feedback.viewSource"))}
+        >
+          {t("homepage.feedback.viewSource")}
+        </button>
+      ) : (
+        <>
+          <button
+            ref={usefulButtonRef}
+            className="feedback-link button-as-link feedback-icon-up"
+            onClick={() => handleFeedback(true)}
+            tabIndex="0"
+            aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.useful")}`}
+          >
+            {t("homepage.feedback.useful")}
+          </button>
+          <span className="feedback-separator">·</span>
+          <span className="feedback-text">{t("homepage.feedback.or")}</span>
+          <span className="feedback-separator">·</span>
+          <button
+            ref={noButtonRef}
+            className="feedback-link button-as-link feedback-icon-down"
+            onClick={() => handleFeedback(false)}
+            tabIndex="0"
+            aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.notUseful")}`}
+          >
+            {t("homepage.feedback.notUseful")}
+          </button>
+        </>
+      )}
 
       {/* Add the skip link after the other buttons, in the same line */}
       {showSkipButton && (

--- a/src/components/chat/PublicFeedbackComponent.js
+++ b/src/components/chat/PublicFeedbackComponent.js
@@ -54,14 +54,19 @@ const PublicFeedbackComponent = ({
   };
 
   return (
-    <form className="expert-rating-container" noValidate onSubmit={(e) => { e.preventDefault(); handleSend(); }}>
+    <form className="expert-rating-container" noValidate onSubmit={(e) => { e.preventDefault(); handleSend(); }} lang={lang}>
       <span
         className="close-icon"
         role="button"
         tabIndex={0}
         aria-label={t('common.close')}
         onClick={onClose}
-        onKeyDown={(e) => e.key === 'Enter' && onClose()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClose();
+          }
+        }}
       >
         <i className="fa-solid fa-close"></i>
       </span>

--- a/src/components/chat/SourceViewComponent.js
+++ b/src/components/chat/SourceViewComponent.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { useTranslations } from '../../hooks/useTranslations.js';
+import { useAnswerNumberLabel } from '../../hooks/useAnswerNumberLabel.js';
+import { resolveDisplayContent, toLangAttr } from '../../utils/answerLanguage.js';
+import OriginalLanguagePill from './review/OriginalLanguagePill.js';
+
+// Popout showing the AI's own English source/working text on the expert
+// (admin/partner) "How was this answer?" prompt in FeedbackComponent.js,
+// shown in place of direct Good/Needs improvement whenever the answer isn't
+// already EN/FR - a reviewer who can't read the original can't meaningfully
+// rate it without seeing what AI Answers actually worked from first. This is
+// NOT a translation service and must never be framed as one - it's AI
+// Answers' own English draft, the same text the model generated before
+// producing the non-EN/FR answer. Reuses the same quoted-sentence markup and
+// EN/FR-official-languages display rule (shown as-is; non-EN/FR collapses to
+// English) (resolveDisplayContent, src/utils/answerLanguage.js) as
+// ExpertFeedbackComponent's "Needs
+// improvement" flow. The Good/Needs improvement choice itself lives at the
+// bottom, once there's something to judge it against.
+const SourceViewComponent = ({
+  onClose,
+  onFeedback,
+  lang = 'en',
+  sentenceCount = 1,
+  sentences = [],
+  questionLanguage = '',
+  sentencesEnglish = [],
+  englishQuestion = '',
+  answerNumber,
+  titleRef,
+  noButtonRef,
+}) => {
+  const { t } = useTranslations(lang);
+  const { withAnswerNumber } = useAnswerNumberLabel(t, answerNumber);
+
+  const sentenceDisplays = sentences.map((sentence, index) =>
+    resolveDisplayContent({ language: questionLanguage, original: sentence, english: sentencesEnglish[index] })
+  );
+
+  return (
+    <div className="expert-rating-container" lang={lang}>
+      <span
+        className="close-icon"
+        role="button"
+        tabIndex={0}
+        aria-label={t('common.close')}
+        onClick={onClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      >
+        <i className="fa-solid fa-close"></i>
+      </span>
+      <h4 className="feedback-followup-title" ref={titleRef} tabIndex={-1}>
+        {withAnswerNumber(t('homepage.expertRating.sourceView.title'))}
+      </h4>
+      <div className="mb-100">
+        <OriginalLanguagePill languageCode={toLangAttr(questionLanguage)} lang={lang} t={t} />
+      </div>
+      {/* The question the AI actually worked from too, not just the answer -
+          without it a reviewer can't judge whether the answer is even
+          relevant to what was asked, only whether the English reads well. */}
+      {englishQuestion && (
+        <div className="sentence-text mb-200">
+          {/* englishQuestion is guaranteed-English text (this whole popout
+              exists to show it) - the container above is tagged lang={lang}
+              (the reviewer's own UI language), so without its own lang="en"
+              here it would inherit that and get mispronounced for a French-
+              interface reviewer, same as every sentence below already
+              guards against via its own lang={sentenceDisplays[index].lang}. */}
+          <strong>{t('reviewPanels.question')}</strong> "<span lang="en">{englishQuestion}</span>"
+        </div>
+      )}
+      {[...Array(Math.min(4, sentenceCount))].map((_, index) => (
+        sentences[index] && (
+          <div key={index + 1} className="sentence-text mb-200">
+            "<span lang={sentenceDisplays[index].lang}>{sentenceDisplays[index].text}</span>"
+          </div>
+        )
+      ))}
+      {onFeedback && (
+        <div className="feedback-container mt-200">
+          <span className="feedback-text" aria-hidden="true">{t("homepage.feedback.question")} </span>
+          <button
+            className="feedback-link button-as-link feedback-icon-up"
+            onClick={() => onFeedback(true)}
+            tabIndex="0"
+            aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.useful")}`}
+          >
+            {t("homepage.feedback.useful")}
+          </button>
+          <span className="feedback-separator">·</span>
+          <span className="feedback-text">{t("homepage.feedback.or")}</span>
+          <span className="feedback-separator">·</span>
+          <button
+            ref={noButtonRef}
+            className="feedback-link button-as-link feedback-icon-down"
+            onClick={() => onFeedback(false)}
+            tabIndex="0"
+            aria-label={`${t("homepage.feedback.question")} ${t("homepage.feedback.notUseful")}`}
+          >
+            {t("homepage.feedback.notUseful")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SourceViewComponent;

--- a/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
@@ -64,4 +64,38 @@ describe('ChatAppContainer - formatAIResponse blank-sentence filtering', () => {
         expect(paragraphs).toHaveLength(1);
         expect(paragraphs[0].textContent).toBe('Real sentence.');
     });
+
+    // Regression: the citation heading and disclaimer used to render with no
+    // explicit lang attribute of their own, relying on document.documentElement.lang
+    // (App.js) inheriting the route's own lang - which happened to equal this
+    // message's own language before review mode's admin/chat language split
+    // existed. Now that document.documentElement.lang can follow the reviewing
+    // admin's own adminLang instead (App.js's computeAlternateLangHref, review
+    // mode), these need their own explicit lang so they stay locked to the
+    // answer's actual language - like every other bubble element from Q to
+    // answer - independent of whatever the site-wide EN/FR toggle is currently set to.
+    it('tags the citation heading and disclaimer with the answer\'s own language, not the ambient page lang', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        expect(capturedFormatAIResponse).toBeInstanceOf(Function);
+
+        const message = {
+            id: 'm2',
+            interaction: {
+                citationUrl: 'https://www.canada.ca/fr/exemple.html',
+                answer: {
+                    paragraphs: ['<s-1>Une phrase.</s-1>'],
+                    questionLanguage: 'fra',
+                },
+            },
+        };
+
+        const { container } = render(<div>{capturedFormatAIResponse('openai', message)}</div>);
+
+        const heading = container.querySelector('p.citation-head');
+        const disclaimer = container.querySelector('.disclaimer p');
+        expect(heading.getAttribute('lang')).toBe('fr');
+        expect(disclaimer.getAttribute('lang')).toBe('fr');
+    });
 });

--- a/src/components/chat/__tests__/ChatAppContainer.userInteraction.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.userInteraction.test.js
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup, act } from '@testing-library/react';
+import ChatAppContainer from '../ChatAppContainer';
+import { usePageContext } from '../../../hooks/usePageParam';
+import { ChatWorkflowService } from '../../../services/ChatWorkflowService';
+
+vi.mock('../../../hooks/usePageParam', () => ({
+    usePageContext: vi.fn(() => ({ url: '', department: '' })),
+    DEPARTMENT_MAPPINGS: {}
+}));
+
+vi.mock('../../../hooks/useTranslations', () => ({
+    useTranslations: vi.fn(() => ({ t: (k) => k })),
+}));
+
+vi.mock('../../../services/DataStoreService', () => ({ default: { getPublicSetting: vi.fn(() => Promise.resolve('azure')) } }));
+vi.mock('../../../services/SessionService', () => ({ default: { getChatId: vi.fn(() => Promise.resolve('abc')) } }));
+vi.mock('../../../services/AuthService', () => ({ default: { isAuthenticated: vi.fn(() => Promise.resolve(false)), getUserId: vi.fn(() => null) } }));
+
+const fakeInteraction = {
+    chatId: 'abc',
+    interactionId: 'int-1',
+    question: { language: 'fra', redactedQuestion: 'Puis-je renouveler en ligne?' },
+    answer: { questionLanguage: 'fra', content: 'Oui.', answerType: 'normal' },
+};
+vi.mock('../../../services/ChatWorkflowService', () => ({
+    ChatWorkflowService: { processResponse: vi.fn(() => Promise.resolve(fakeInteraction)) },
+    RedactionError: class { },
+    ShortQueryValidation: class { },
+    ChatRunInProgressError: class { }
+}));
+
+// Capture messages/handleInputChange/handleSendMessage in place of rendering
+// the full ChatInterface (same pattern as formatAIResponse.test.js).
+let latestProps = null;
+vi.mock('../ChatInterface', () => ({
+    default: (props) => {
+        latestProps = props;
+        return <div data-testid="chat-interface" />;
+    }
+}));
+
+// Regression: the user message used to be pushed with no `interaction` at
+// all, and never updated once the response came back - so
+// getAnswerLanguage(message.interaction) on the question bubble
+// (ChatInterface.js) always read undefined and rendered no lang attribute,
+// even though the answer bubble right next to it tagged itself correctly.
+//
+// The fix is NOT to attach the whole `interaction` object to the user
+// message (that was tried first, then reverted - see
+// project_sentence_pairing_translation_fallback_todo.md and
+// ChatAppContainer.js's own comment): `.interaction` presence is a signal
+// other, unrelated server-side code (ContextAgentService.js,
+// AnswerGenerationService.js) reads as "this is the AI's real turn" when
+// building conversationHistory for the next request - the client `messages`
+// array *is* that conversationHistory. A user message also carrying
+// `.interaction` silently double-counted every historical turn for both of
+// those. So only the resolved language string is attached, under its own
+// field, and `.interaction` stays exclusively an AI-message thing.
+describe('ChatAppContainer - user message gets the resolved question language attached', () => {
+    afterEach(() => {
+        cleanup();
+        latestProps = null;
+        vi.clearAllMocks();
+    });
+
+    it('attaches the resolved question language (not the whole interaction) to the user\'s own message once the response comes back', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        await act(async () => {
+            latestProps.handleInputChange({ target: { value: 'Puis-je renouveler en ligne?' } });
+        });
+        await act(async () => {
+            await latestProps.handleSendMessage();
+        });
+
+        const userMessage = latestProps.messages.find((m) => m.sender === 'user');
+        const aiMessage = latestProps.messages.find((m) => m.sender === 'ai');
+
+        expect(userMessage).toBeTruthy();
+        expect(userMessage.questionLanguage).toBe('fra');
+        expect(userMessage.interaction).toBeUndefined();
+        expect(aiMessage.interaction).toEqual(fakeInteraction);
+        expect(ChatWorkflowService.processResponse).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/chat/__tests__/ExpertFeedbackComponent.test.js
+++ b/src/components/chat/__tests__/ExpertFeedbackComponent.test.js
@@ -190,3 +190,59 @@ describe('ExpertFeedbackComponent — explanation required on non-good ratings',
     expect(document.querySelector('.explanation-error-summary')).toBeNull();
   });
 });
+
+// EN/FR-official-languages display rule (shown as-is; non-EN/FR collapses to
+// English) (resolveDisplayContent, src/utils/answerLanguage.js) - same rule already
+// applied to ExpertFeedbackPanel.js and ChatDashboardPage.js.
+describe('ExpertFeedbackComponent — language display', () => {
+  it('shows the original sentence untagged for English, no pill', () => {
+    renderComponent({
+      sentenceCount: 1,
+      sentences: ['Can I renew online?'],
+      questionLanguage: 'eng',
+      sentencesEnglish: ['Can I renew online?'],
+    });
+
+    const sentenceText = screen.getByText('Can I renew online?');
+    expect(sentenceText.getAttribute('lang')).toBe('en');
+    expect(screen.queryByText(/admin.common.originallyAskedIn/)).toBeNull();
+  });
+
+  it('shows the original sentence for French, tagged lang="fr" - not the English fallback', () => {
+    renderComponent({
+      sentenceCount: 1,
+      sentences: ['Puis-je renouveler en ligne?'],
+      questionLanguage: 'fra',
+      sentencesEnglish: ['Can I renew online?'],
+    });
+
+    const sentenceText = screen.getByText('Puis-je renouveler en ligne?');
+    expect(sentenceText.getAttribute('lang')).toBe('fr');
+    expect(screen.queryByText('Can I renew online?')).toBeNull();
+  });
+
+  it('collapses a non-EN/FR sentence to the English version, tags lang="en", and shows the pill below the heading', () => {
+    renderComponent({
+      sentenceCount: 1,
+      sentences: ['هل يمكنني التجديد عبر الإنترنت؟'],
+      questionLanguage: 'ara',
+      sentencesEnglish: ['Can I renew online?'],
+    });
+
+    const sentenceText = screen.getByText('Can I renew online?');
+    expect(sentenceText.getAttribute('lang')).toBe('en');
+    expect(screen.queryByText('هل يمكنني التجديد عبر الإنترنت؟')).toBeNull();
+
+    // The mocked t() just echoes its key, so this asserts presence/position
+    // rather than the real interpolated sentence.
+    const heading = screen.getByText('homepage.expertRating.intro');
+    const pill = screen.getByText(/admin.common.originallyAskedIn/);
+    expect(heading.compareDocumentPosition(pill) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('does not show the pill when no language is known at all (legacy data)', () => {
+    renderComponent({ sentenceCount: 1, sentences: ['x'] }); // no questionLanguage/sentencesEnglish props
+
+    expect(screen.queryByText(/admin.common.originallyAskedIn/)).toBeNull();
+  });
+});

--- a/src/components/chat/__tests__/FeedbackComponent.test.js
+++ b/src/components/chat/__tests__/FeedbackComponent.test.js
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, render, fireEvent, screen, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const mockUseHasAnyRole = vi.fn();
+vi.mock('../../RoleBasedUI.js', () => ({
+  useHasAnyRole: (...args) => mockUseHasAnyRole(...args),
+}));
+
+const mockPersistExpertFeedback = vi.fn();
+vi.mock('../../../services/FeedbackService.js', () => ({
+  default: {
+    persistExpertFeedback: (...args) => mockPersistExpertFeedback(...args),
+    persistPublicFeedback: vi.fn(),
+  },
+}));
+
+import FeedbackComponent from '../FeedbackComponent.js';
+
+afterEach(() => {
+  cleanup();
+  mockPersistExpertFeedback.mockClear();
+});
+
+const renderComponent = (props = {}) => {
+  return render(
+    <FeedbackComponent
+      chatId="chat-1"
+      userMessageId="msg-1"
+      sentenceCount={1}
+      sentences={['x']}
+      {...props}
+    />
+  );
+};
+
+const sourceProps = {
+  sentences: ['هل يمكنني التجديد عبر الإنترنت؟'],
+  questionLanguage: 'ara',
+  sentencesEnglish: ['Can I renew online?'],
+};
+
+// "Review the English source text" reuses ExpertFeedbackComponent's
+// sentence-display flow (resolveDisplayContent, src/utils/answerLanguage.js)
+// but with no detailed rating UI - just the sentences, plus a simple
+// Good/Needs improvement choice at the bottom. Shown in place of direct
+// Good/Needs improvement on the expert "How was this answer?" prompt
+// (homepage.feedback.question) whenever the answer isn't already EN/FR - a
+// reviewer can't meaningfully rate what they can't read without seeing AI
+// Answers' own English source/working text first. This is not a translation
+// service - the popout shows what AI Answers actually worked from, not a
+// translation of anything.
+describe('FeedbackComponent — source text view', () => {
+  it('shows Good/Needs improvement directly for an expert reviewer when the answer is already EN/FR, no source-text link', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    renderComponent({
+      sentences: ['Can I renew online?'],
+      questionLanguage: 'eng',
+      sentencesEnglish: ['Can I renew online?'],
+    });
+
+    expect(screen.getByText('homepage.feedback.useful')).toBeTruthy();
+    expect(screen.getByText('homepage.feedback.notUseful')).toBeTruthy();
+    expect(screen.queryByText('homepage.feedback.viewSource')).toBeNull();
+  });
+
+  it('shows only "Review the English source text" (no direct Good/Needs improvement) for an expert reviewer when the answer needed AI Answers\' own English source text', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    renderComponent(sourceProps);
+
+    expect(screen.getByText('homepage.feedback.viewSource')).toBeTruthy();
+    expect(screen.queryByText('homepage.feedback.useful')).toBeNull();
+    expect(screen.queryByText('homepage.feedback.notUseful')).toBeNull();
+  });
+
+  it('opens a sentence view with a simple Good/Needs improvement choice but no detailed rating form', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    renderComponent(sourceProps);
+
+    fireEvent.click(screen.getByText('homepage.feedback.viewSource'));
+
+    // The English fallback sentence is shown, tagged lang="en" ...
+    const sentenceText = screen.getByText('Can I renew online?');
+    expect(sentenceText.getAttribute('lang')).toBe('en');
+    // ... a plain Good/Needs improvement choice is offered ...
+    expect(screen.getByText('homepage.feedback.useful')).toBeTruthy();
+    expect(screen.getByText('homepage.feedback.notUseful')).toBeTruthy();
+    // ... but none of ExpertFeedbackComponent's detailed rating UI (radios,
+    // explanation textarea, submit) renders - that's a separate, later step.
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: 'homepage.expertRating.submit' })).toBeNull();
+  });
+
+  it('persists positive expert feedback and shows the thank-you message when "Good" is chosen from inside the source-text view', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    renderComponent(sourceProps);
+
+    fireEvent.click(screen.getByText('homepage.feedback.viewSource'));
+    fireEvent.click(screen.getByText('homepage.feedback.useful'));
+
+    expect(mockPersistExpertFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFeedback: expect.objectContaining({ feedback: 'positive', totalScore: 100 }),
+      })
+    );
+    expect(screen.getByText('homepage.feedback.thankYou')).toBeTruthy();
+  });
+
+  it('opens the full detailed rating form when "Needs improvement" is chosen from inside the source-text view', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    renderComponent(sourceProps);
+
+    fireEvent.click(screen.getByText('homepage.feedback.viewSource'));
+    fireEvent.click(screen.getByText('homepage.feedback.notUseful'));
+
+    // The source-text-only view is gone, replaced by ExpertFeedbackComponent's
+    // real rating form (radios present, submit button present).
+    expect(screen.queryAllByRole('radio').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'homepage.expertRating.submit' })).toBeTruthy();
+  });
+
+  it('never shows "Review the English source text" for a public (non-expert) reviewer, even when the answer needed it', () => {
+    mockUseHasAnyRole.mockReturnValue(false);
+    renderComponent(sourceProps);
+
+    expect(screen.queryByText('homepage.feedback.viewSource')).toBeNull();
+  });
+});
+
+// Regression: after submitting an expert eval, this component used to show
+// "Thank you" and stay that way forever - onSubmit only persisted to the
+// server, it never told the parent (ChatAppContainer.js's `messages` state)
+// that expertFeedback changed, so ChatInterface.js's
+// `!message.interaction.expertFeedback` check never flipped and
+// ExpertFeedbackPanel's summary never appeared without a full page reload.
+describe('FeedbackComponent — expert eval submit hands off on next click', () => {
+  it('does not call onExpertFeedbackChange immediately after a quick "Good" submit', () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    const onExpertFeedbackChange = vi.fn();
+    renderComponent({
+      sentences: ['Can I renew online?'],
+      questionLanguage: 'eng',
+      sentencesEnglish: ['Can I renew online?'],
+      onExpertFeedbackChange,
+    });
+
+    fireEvent.click(screen.getByText('homepage.feedback.useful'));
+
+    expect(screen.getByText('homepage.feedback.thankYou')).toBeTruthy();
+    expect(onExpertFeedbackChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onExpertFeedbackChange with the persisted feedback on the next click anywhere, no timer wait needed', async () => {
+    mockUseHasAnyRole.mockReturnValue(true);
+    const onExpertFeedbackChange = vi.fn();
+    renderComponent({
+      sentences: ['Can I renew online?'],
+      questionLanguage: 'eng',
+      sentencesEnglish: ['Can I renew online?'],
+      onExpertFeedbackChange,
+    });
+
+    fireEvent.click(screen.getByText('homepage.feedback.useful'));
+    // Listener attachment is deferred one tick (setTimeout(0)) so it doesn't
+    // also catch this same click while it's still bubbling to document.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    fireEvent.click(document.body);
+
+    expect(onExpertFeedbackChange).toHaveBeenCalledWith(
+      expect.objectContaining({ feedback: 'positive', totalScore: 100, type: 'expert' })
+    );
+  });
+});

--- a/src/components/chat/__tests__/SourceViewComponent.test.js
+++ b/src/components/chat/__tests__/SourceViewComponent.test.js
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import SourceViewComponent from '../SourceViewComponent.js';
+
+const TRANSLATIONS = {
+  'homepage.expertRating.sourceView.title': "AI Answers' source text",
+  'reviewPanels.question': 'Question:',
+  'homepage.feedback.question': 'How was this answer?',
+  'homepage.feedback.useful': 'Good',
+  'homepage.feedback.notUseful': 'Needs improvement',
+  'admin.common.originallyAskedIn': 'Originally asked in: {language}',
+};
+const mockT = (key) => TRANSLATIONS[key] || key;
+
+vi.mock('../../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({ t: mockT }),
+}));
+
+describe('SourceViewComponent', () => {
+  afterEach(cleanup);
+
+  // Regression: the popout's own container is tagged lang={lang} - the
+  // reviewer's own UI language, e.g. "fr" for a French-interface admin -
+  // but englishQuestion is guaranteed-English text (the whole point of this
+  // popout). Without its own lang="en" wrapper it silently inherits the
+  // surrounding "fr" and gets mispronounced by a screen reader, unlike every
+  // answer sentence rendered right below it, which already gets its own
+  // per-item lang tag.
+  it('tags englishQuestion lang="en" even when the popout itself is in French', () => {
+    render(
+      <SourceViewComponent
+        lang="fr"
+        sentenceCount={1}
+        sentences={['Original sentence.']}
+        questionLanguage="ara"
+        sentencesEnglish={['English sentence.']}
+        englishQuestion="What is the English question?"
+      />
+    );
+
+    const questionText = screen.getByText('What is the English question?');
+    expect(questionText.tagName).toBe('SPAN');
+    expect(questionText.getAttribute('lang')).toBe('en');
+
+    // The container itself still carries the reviewer's own UI language.
+    expect(questionText.closest('.expert-rating-container').getAttribute('lang')).toBe('fr');
+  });
+
+  it('does not render the question block at all when englishQuestion is empty', () => {
+    render(
+      <SourceViewComponent
+        lang="fr"
+        sentenceCount={1}
+        sentences={['Original sentence.']}
+        questionLanguage="ara"
+        sentencesEnglish={['English sentence.']}
+        englishQuestion=""
+      />
+    );
+
+    expect(screen.queryByText('Question:')).toBeNull();
+  });
+});

--- a/src/components/chat/review/ExpertFeedbackPanel.js
+++ b/src/components/chat/review/ExpertFeedbackPanel.js
@@ -4,8 +4,10 @@ import FeedbackService from '../../../services/FeedbackService.js';
 import ClientLoggingService from '../../../services/ClientLoggingService.js';
 import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 import { formatNumber } from '../../../utils/numberFormat.js';
+import { resolveDisplayContent, toLangAttr, getAnswerLanguage } from '../../../utils/answerLanguage.js';
+import OriginalLanguagePill from './OriginalLanguagePill.js';
 
-const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answerNumber }) => {
+const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answerNumber, onDeleted }) => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [data, setData] = useState(null);
@@ -63,12 +65,21 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                 message.expertFeedback = undefined;
             }
             await ClientLoggingService.info(interactionId, 'Expert feedback deleted', {});
+            // The mutation above only updates this shared `message` object in
+            // place - it doesn't tell React anything changed, so
+            // ChatInterface.js's own `!message.interaction.expertFeedback`
+            // check (deciding whether to show the eval form again) would keep
+            // evaluating against its last render until something else forced
+            // a re-render. This tells the actual owner of `messages` state
+            // (ChatAppContainer.js) so the eval form reappears immediately,
+            // no page refresh needed.
+            onDeleted?.();
         } catch (err) {
             setError(err.message || String(err));
         } finally {
             setDeleting(false);
         }
-    }, [message, t]);
+    }, [message, t, onDeleted]);
 
     const handleNeverStaleToggle = useCallback(async () => {
         try {
@@ -162,10 +173,45 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
         englishQuestion = '';
     }
 
+    // The original-language question text, for the same EN/FR-official-
+    // languages display rule resolveDisplayContent applies below - the real
+    // original-language text only exists when interaction.question arrived
+    // here as the actual populated Question document (models/question.js),
+    // not just an id string. When it isn't populated, fall back to
+    // englishQuestion (which has its own broader fallback chain above,
+    // independent of interaction.question) rather than '' - matches what
+    // this panel showed unconditionally before the original-language
+    // display work (englishQuestion, no language distinction) instead of
+    // silently hiding the whole Question block. Only wrong in the narrow
+    // case of a genuinely French question arriving unpopulated (shows the
+    // English text tagged lang="fr"), which is exactly as imprecise as - not
+    // worse than - that prior behaviour.
+    const originalQuestion = (interaction.question && typeof interaction.question === 'object')
+        ? (interaction.question.redactedQuestion || '') : (englishQuestion || '');
+    // Question.language (models/question.js) - the AI answers in whatever
+    // language was detected here (agents/prompts/agenticBase.js), so this
+    // same value also drives the answer-sentence table below, not just the
+    // question header. getAnswerLanguage (answerLanguage.js) also checks
+    // interaction.answer.questionLanguage, which - unlike
+    // interaction.question.language - is always available once an answer
+    // exists, regardless of whether interaction.question got populated.
+    // Without this broader fallback, an unpopulated interaction.question
+    // resolved questionLanguage to '' here, which resolveDisplayContent
+    // treats as "already EN/FR, show original as-is" - silently hiding the
+    // whole Question block (originalQuestion was also '' in that case) and,
+    // worse, showing the untranslated original-language answer sentences
+    // below instead of falling back to their English text.
+    const questionLanguage = getAnswerLanguage(interaction);
+    const questionDisplay = resolveDisplayContent({
+        language: questionLanguage,
+        original: originalQuestion,
+        english: englishQuestion,
+    });
+
     const getExpertScore = (idx) => {
         // expert schema stores sentence scores as sentence1Score, sentence2Score...
         const key = `sentence${idx + 1}Score`;
-        return (expert && typeof expert[key] !== 'undefined' && expert[key] !== null) ? expert[key] : 'N/A';
+        return (expert && typeof expert[key] !== 'undefined' && expert[key] !== null) ? expert[key] : t('reviewPanels.notAvailable');
     };
 
     if (sentences.length === 0) return null;
@@ -183,7 +229,7 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
     if (!hasExpert) return null;
 
     return (
-        <details className="review-details" onToggle={(e) => {
+        <details className="review-details" lang={lang} onToggle={(e) => {
             // e.target is the native <details> element; check its open property
             try {
                 // call load when panel is being opened
@@ -226,11 +272,24 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                         const totalVal = (efSource && typeof efSource.totalScore !== 'undefined' && efSource.totalScore !== null) ? efSource.totalScore : computeTotal(efSource, sentenceCount);
                         return (
                             <div>
-                                {/* English question shown above total score when available */}
-                                {englishQuestion ? (
-                                    <div style={{ marginBottom: '6px' }}><strong>{t('reviewPanels.englishQuestion') || 'English question'}:</strong> {englishQuestion}</div>
+                                {/* Question shown above total score when available - EN/FR stay in
+                                    their original language (resolveDisplayContent), only a
+                                    genuinely non-EN/FR question falls back to englishQuestion, with
+                                    the pill flagging that it happened. */}
+                                {questionDisplay.text ? (
+                                    <>
+                                        {questionDisplay.isSource && (
+                                            <div style={{ marginBottom: '4px' }}>
+                                                <OriginalLanguagePill languageCode={toLangAttr(questionLanguage)} lang={lang} t={t} />
+                                            </div>
+                                        )}
+                                        <div style={{ marginBottom: '6px' }}>
+                                            <strong>{t('reviewPanels.question')}</strong>{' '}
+                                            <span lang={questionDisplay.lang}>{questionDisplay.text}</span>
+                                        </div>
+                                    </>
                                 ) : null}
-                                <div><strong>{t('reviewPanels.totalScore') || 'Total score'}:</strong> {totalVal !== null ? totalVal : (t('reviewPanels.notAvailable') || 'N/A')}</div>
+                                <div><strong>{t('reviewPanels.totalScore')}:</strong> {totalVal !== null ? totalVal : t('reviewPanels.notAvailable')}</div>
                                 {/* Show expert email if available */}
                                 {efSource && (efSource.expertEmail || efSource.expert_email) ? (
                                     <div><strong>{t('reviewPanels.expertEmail') || 'Expert email'}:</strong> {efSource.expertEmail || efSource.expert_email}</div>
@@ -243,19 +302,26 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                 <table className="review-table">
                     <thead>
                         <tr>
-                            <th>{t('reviewPanels.sentence') || 'Sentence'}</th>
-                            <th>{t('reviewPanels.sentenceEnglish') || 'Sentence English'}</th>
-                            <th>{t('reviewPanels.expertScore') || 'Expert score'}</th>
-                            <th>{t('homepage.expertRating.options.harmful') || 'Harmful'}</th>
-                            <th>{t('homepage.expertRating.options.contentIssue') || 'Content Issue'}</th>
-                            <th>{t('reviewPanels.explanation') || 'Explanation'}</th>
+                            {/* Column header names what's actually in it, not just always
+                                "Sentence" - the AI answers in whatever language was detected
+                                for the question (agenticBase.js), same questionDisplay signal
+                                driving the question header above, so this table is either all
+                                original-language or all English, never a mix. "Source text"
+                                (not "Sentence in English") since the English shown here is what
+                                AI Answers actually worked from, same framing as EvalPanel.js's
+                                reviewPanels.sourceText column, reused rather than duplicated. */}
+                            <th>{questionDisplay.isSource ? t('reviewPanels.sourceText') : t('reviewPanels.sentence')}</th>
+                            <th>{t('reviewPanels.expertScore')}</th>
+                            <th>{t('homepage.expertRating.options.harmful')}</th>
+                            <th>{t('homepage.expertRating.options.contentIssue')}</th>
+                            <th>{t('reviewPanels.explanation')}</th>
                         </tr>
                     </thead>
                     <tbody>
                         {sentences.map((s, i) => {
                             const row = (data && data.sentences && data.sentences[i]) || {};
                             const scoreVal = (typeof row.score !== 'undefined' && row.score !== null) ? row.score : getExpertScore(i);
-                            const explVal = (row.explanation || (expert && expert[`sentence${i + 1}Explanation`])) || (t('reviewPanels.notAvailable') || 'N/A');
+                            const explVal = (row.explanation || (expert && expert[`sentence${i + 1}Explanation`])) || t('reviewPanels.notAvailable');
                             const harmfulVal = (typeof row.harmful !== 'undefined') ? row.harmful : (expert && expert[`sentence${i + 1}Harmful`]);
                             const contentIssueVal = (typeof row.contentIssue !== 'undefined') ? row.contentIssue : (expert && expert[`sentence${i + 1}ContentIssue`]);
 
@@ -268,14 +334,22 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                             } else {
                                 englishVal = null;
                             }
+                            // The answer is generated in whatever language was detected for the
+                            // question (agenticBase.js), so questionLanguage drives this same
+                            // EN/FR-official-languages display rule for each answer sentence too - not a
+                            // separately-tracked per-sentence language.
+                            const sentenceDisplay = resolveDisplayContent({
+                                language: questionLanguage,
+                                original: s,
+                                english: englishVal,
+                            });
 
                             return (
                                 <tr key={`s-${i}`}>
-                                    <td>{s || (t('reviewPanels.notAvailable') || 'N/A')}</td>
-                                    <td>{englishVal ? englishVal : (t('reviewPanels.notAvailable') || 'N/A')}</td>
-                                    <td>{typeof scoreVal !== 'undefined' && scoreVal !== null ? scoreVal : (t('reviewPanels.notAvailable') || 'N/A')}</td>
-                                    <td>{harmfulVal ? (t('common.yes') || 'Yes') : (t('common.no') || 'No')}</td>
-                                    <td>{contentIssueVal ? (t('common.yes') || 'Yes') : (t('common.no') || 'No')}</td>
+                                    <td lang={sentenceDisplay.lang}>{sentenceDisplay.text || t('reviewPanels.notAvailable')}</td>
+                                    <td>{typeof scoreVal !== 'undefined' && scoreVal !== null ? scoreVal : t('reviewPanels.notAvailable')}</td>
+                                    <td>{harmfulVal ? t('common.yes') : t('common.no')}</td>
+                                    <td>{contentIssueVal ? t('common.yes') : t('common.no')}</td>
                                     <td>{explVal}</td>
                                 </tr>
                             );
@@ -289,7 +363,7 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                         {(() => {
                             const efSource = (data && data.expertFeedback) || expert || {};
                             const citationScore = (typeof efSource.citationScore !== 'undefined' && efSource.citationScore !== null) ? efSource.citationScore : null;
-                            const scoreCell = citationScore !== null ? citationScore : (t('reviewPanels.notAvailable') || 'N/A');
+                            const scoreCell = citationScore !== null ? citationScore : t('reviewPanels.notAvailable');
                             const explCell = (efSource.citationExplanation || efSource.expertCitationUrl) ? (
                                 <>
                                     {efSource.citationExplanation && (
@@ -302,14 +376,13 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
                                         </div>
                                     )}
                                 </>
-                            ) : (t('reviewPanels.notAvailable') || 'N/A');
+                            ) : t('reviewPanels.notAvailable');
                             return (
                                 <tr key="citation-row" className="citation-row">
-                                    <td>{t('reviewPanels.citation') || 'Citation'}</td>
-                                    <td>{(t('reviewPanels.notAvailable') || 'N/A')}</td>
+                                    <td>{t('reviewPanels.citation')}</td>
                                     <td>{scoreCell}</td>
-                                    <td>{(t('reviewPanels.notAvailable') || 'N/A')}</td>
-                                    <td>{(t('reviewPanels.notAvailable') || 'N/A')}</td>
+                                    <td>{t('reviewPanels.notAvailable')}</td>
+                                    <td>{t('reviewPanels.notAvailable')}</td>
                                     <td>{explCell}</td>
                                 </tr>
                             );

--- a/src/components/chat/review/OriginalLanguagePill.js
+++ b/src/components/chat/review/OriginalLanguagePill.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { getOriginallyAskedInLabel } from '../../../utils/answerLanguage.js';
+
+// Shown next to admin/eval content that's displaying the English-translated
+// version because the original wasn't EN or FR (see resolveDisplayContent in
+// answerLanguage.js) — a quiet, informational flag, not a link or expandable
+// detail. The original-language text stays out of the admin UI entirely once
+// it isn't EN/FR; this pill is the only trace of it here. Full fidelity
+// (redactedQuestion, questionLanguage) still lives in the download logs
+// (chat-export-logs.js), untouched by this display rule.
+//
+// Detail views only (e.g. ExpertFeedbackPanel.js) — dense grids like
+// ChatDashboardPage.js's table deliberately skip this: an admin scanning
+// many rows can open the chat itself for that detail, and a pill in every
+// row of a Question/Answer column pair would be clutter, not signal.
+//
+// .filter-pill/.filter-pill--info (admin.css) — the existing non-interactive
+// "informational" pill style already used elsewhere in the admin UI, reused
+// here rather than a new pattern.
+const OriginalLanguagePill = ({ languageCode, lang = 'en', t }) => {
+  const label = getOriginallyAskedInLabel({ languageCode, lang, t });
+  if (!label) return null;
+
+  return (
+    <span className="pill-group">
+      <span className="filter-pill filter-pill--info">
+        {label}
+      </span>
+      {/* French UI only: an EN-UI admin seeing English content is
+          unremarkable, but a FR-UI admin might otherwise expect the French
+          they're reading everywhere else on the page - this pill exists so
+          they don't assume a French version is available (there never is
+          one for a non-EN/FR question; see official-languages.md Rule 1). */}
+      {lang === 'fr' && (
+        <span className="filter-pill filter-pill--info">
+          {t('admin.common.aiAnswersSource')}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default OriginalLanguagePill;

--- a/src/components/chat/review/UsedChatsPanel.js
+++ b/src/components/chat/review/UsedChatsPanel.js
@@ -4,7 +4,7 @@ import { useAnswerNumberLabel } from '../../../hooks/useAnswerNumberLabel.js';
 import { formatNumber } from '../../../utils/numberFormat.js';
 import { buildChatReviewHref } from '../../../utils/reviewLink.js';
 
-const UsedChatsPanel = ({ message, t, lang = 'en', answerNumber }) => {
+const UsedChatsPanel = ({ message, t, lang = 'en', adminLang, answerNumber }) => {
     const { withAnswerNumber } = useAnswerNumberLabel(t, answerNumber);
     const qaMatches = message?.interaction?.context?.qaMatches;
 
@@ -26,7 +26,15 @@ const UsedChatsPanel = ({ message, t, lang = 'en', answerNumber }) => {
                             <tr key={match.interactionId || `${match.chatId}-${index}`}>
                                 <td>
                                     {match.chatId ? (
-                                        <GcdsLink href={buildChatReviewHref(match.chatId, lang)} target="_blank" lang={lang}>
+                                        // The matched chat's own pageLanguage isn't available here
+                                        // (agents/graphs/GenericWithQAGraph.js's qaMatches carries no
+                                        // language field), so `lang` (this - the CURRENT chat's own
+                                        // language) is the best routing guess for the href. The visible
+                                        // text is just the opaque chatId though, not real content - its
+                                        // `lang` attribute (driving GcdsLink's own "opens in a new tab"
+                                        // hint) is admin-facing chrome, so it follows the admin's own
+                                        // language instead, same reasoning as ContentIssueChatsCard.js.
+                                        <GcdsLink href={buildChatReviewHref(match.chatId, lang, null, adminLang)} target="_blank" lang={adminLang || lang}>
                                             {match.chatId}
                                         </GcdsLink>
                                     ) : ''}

--- a/src/components/chat/review/__tests__/ExpertFeedbackPanel.test.js
+++ b/src/components/chat/review/__tests__/ExpertFeedbackPanel.test.js
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ExpertFeedbackPanel from '../ExpertFeedbackPanel.js';
+import FeedbackService from '../../../../services/FeedbackService.js';
+
+// EN/FR-official-languages display rule (shown as-is; non-EN/FR collapses to
+// English) - see answerLanguage.js's resolveDisplayContent. Proves the
+// wiring end-to-end (real component, real DOM), not just the resolver
+// function in isolation.
+
+const TRANSLATIONS = {
+  'reviewPanels.question': 'Question:',
+  'reviewPanels.sentence': 'Sentence',
+  'reviewPanels.sourceText': 'Source text',
+  'reviewPanels.notAvailable': 'N/A',
+  'admin.common.originallyAskedIn': 'Originally asked in: {language}',
+};
+const mockT = (key) => TRANSLATIONS[key] || key;
+
+vi.mock('../../../../services/FeedbackService.js', () => ({
+  default: { getExpertFeedback: vi.fn(), deleteExpertFeedback: vi.fn(), setExpertNeverStale: vi.fn() },
+}));
+vi.mock('../../../../services/ClientLoggingService.js', () => ({
+  default: { info: vi.fn() },
+}));
+vi.mock('@gcds-core/components-react', () => ({
+  GcdsButton: ({ children, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  GcdsLink: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+const answer = {
+  sentences: ['Original sentence one.', 'Original sentence two.'],
+  sentencesEnglish: ['English sentence one.', 'English sentence two.'],
+};
+const expertFeedback = { _id: 'ef1', totalScore: 100, sentence1Score: 100, sentence2Score: 100 };
+const extractSentences = (text) => [text];
+
+const buildMessage = ({ language, redactedQuestion, englishQuestion }) => ({
+  id: 'msg1',
+  interaction: {
+    _id: 'int1',
+    question: { language, redactedQuestion, englishQuestion },
+    answer,
+    expertFeedback,
+  },
+});
+
+describe('ExpertFeedbackPanel language display', () => {
+  afterEach(() => cleanup());
+
+  it('shows the original English question and sentences untranslated, no pill', () => {
+    const message = buildMessage({
+      language: 'eng',
+      redactedQuestion: 'Can I renew online?',
+      englishQuestion: 'Can I renew online?',
+    });
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={mockT} lang="en" />);
+
+    const questionText = screen.getByText('Can I renew online?');
+    expect(questionText.getAttribute('lang')).toBe('en');
+    expect(screen.getByText('Sentence')).toBeTruthy();
+    expect(screen.queryByText('Source text')).toBeNull();
+    expect(screen.getByText('Original sentence one.').closest('td').getAttribute('lang')).toBe('en');
+    expect(screen.queryByText(/Originally asked in/)).toBeNull();
+  });
+
+  it('shows the original French question and sentences untranslated, tagged lang="fr" - not collapsed to English', () => {
+    const message = buildMessage({
+      language: 'fra',
+      redactedQuestion: 'Puis-je renouveler en ligne?',
+      // Still translated internally for the AI service, per the signed-off
+      // rule - display must ignore this and show the French original.
+      englishQuestion: 'Can I renew online?',
+    });
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={mockT} lang="fr" />);
+
+    const questionText = screen.getByText('Puis-je renouveler en ligne?');
+    expect(questionText.getAttribute('lang')).toBe('fr');
+    expect(screen.queryByText('Can I renew online?')).toBeNull();
+    expect(screen.getByText('Sentence')).toBeTruthy();
+    expect(screen.queryByText('Source text')).toBeNull();
+    expect(screen.getByText('Original sentence one.').closest('td').getAttribute('lang')).toBe('fr');
+    expect(screen.queryByText(/Originally asked in/)).toBeNull();
+  });
+
+  it('collapses a non-EN/FR question to the English version, tags lang="en", and shows the pill', () => {
+    const message = buildMessage({
+      language: 'ara',
+      redactedQuestion: 'هل يمكنني التجديد عبر الإنترنت؟',
+      englishQuestion: 'Can I renew online?',
+    });
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={mockT} lang="en" />);
+
+    const questionText = screen.getByText('Can I renew online?');
+    expect(questionText.getAttribute('lang')).toBe('en');
+    expect(screen.queryByText('هل يمكنني التجديد عبر الإنترنت؟')).toBeNull();
+    expect(screen.getByText('Source text')).toBeTruthy();
+    expect(screen.queryByText('Sentence', { selector: 'th' })).toBeNull();
+    expect(screen.getByText('English sentence one.').closest('td').getAttribute('lang')).toBe('en');
+    expect(screen.queryByText('Original sentence one.')).toBeNull();
+    expect(screen.getByText('Originally asked in: Arabic')).toBeTruthy();
+  });
+
+  // Regression: interaction.question isn't always a populated Question
+  // document (models/question.js) - some code paths only carry an id
+  // reference, or omit it entirely. questionLanguage/originalQuestion used
+  // to derive purely from interaction.question, so an unpopulated question
+  // meant questionLanguage stayed '' - which resolveDisplayContent treats
+  // as "already EN/FR, show as-is" - silently hiding the whole Question
+  // block AND showing the untranslated original-language sentences below
+  // instead of falling back to English, even though answer.englishQuestion
+  // and answer.questionLanguage (independent of interaction.question) were
+  // both available the whole time.
+  it('still shows the question and falls back to English sentences when interaction.question is not a populated object', () => {
+    const message = {
+      id: 'msg1',
+      interaction: {
+        _id: 'int1',
+        // No `question` field at all - not populated, matching a real API
+        // shape gap rather than the exact "string/id" case, since a raw id
+        // string would itself get picked up as a (meaningless) englishQuestion
+        // fallback value by this component's own rawQuestion chain.
+        answer: {
+          ...answer,
+          questionLanguage: 'ara',
+          englishQuestion: 'Can I renew online?',
+        },
+        expertFeedback,
+      },
+    };
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={mockT} lang="en" />);
+
+    const questionText = screen.getByText('Can I renew online?');
+    expect(questionText.getAttribute('lang')).toBe('en');
+    expect(screen.getByText('Source text')).toBeTruthy();
+    expect(screen.getByText('English sentence one.').closest('td').getAttribute('lang')).toBe('en');
+    expect(screen.queryByText('Original sentence one.')).toBeNull();
+  });
+
+  // Regression: the per-sentence "expert score" column used to render a
+  // hardcoded literal 'N/A' string, bypassing t() entirely, when a sentence
+  // had no score set - so it stayed in English even on the French UI. It's
+  // now t('reviewPanels.notAvailable'), matching the rest of this table's
+  // N/A cells. A distinct sentinel value (not literally 'N/A') proves the
+  // cell actually goes through t() rather than falling back to the literal.
+  it('renders the missing-score cell through t(), not a hardcoded literal', () => {
+    const sentinelT = (key) => (key === 'reviewPanels.notAvailable' ? 'SENTINEL-NOT-AVAILABLE' : TRANSLATIONS[key] || key);
+    const message = buildMessage({
+      language: 'eng',
+      redactedQuestion: 'Can I renew online?',
+      englishQuestion: 'Can I renew online?',
+    });
+    // No sentence1Score/sentence2Score on this expertFeedback at all.
+    message.interaction.expertFeedback = { _id: 'ef2', totalScore: 100 };
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={sentinelT} lang="fr" />);
+
+    expect(screen.getAllByText('SENTINEL-NOT-AVAILABLE').length).toBeGreaterThan(0);
+    expect(screen.queryByText('N/A')).toBeNull();
+  });
+});
+
+// Regression: deleting an eval used to only mutate the shared `message`
+// object in place (message.interaction.expertFeedback = undefined) - React
+// never learns that happened, so ChatInterface.js's own
+// `!message.interaction.expertFeedback` check (deciding whether to show the
+// eval form again) kept evaluating against its last render and the form
+// stayed hidden until a full page refresh. onDeleted is how this panel now
+// tells the actual owner of `messages` state that the eval is gone.
+describe('ExpertFeedbackPanel delete', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('calls onDeleted after a successful delete, so the parent can update messages state immediately', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(FeedbackService.deleteExpertFeedback).mockResolvedValue({});
+    const onDeleted = vi.fn();
+    const message = buildMessage({
+      language: 'eng',
+      redactedQuestion: 'Can I renew online?',
+      englishQuestion: 'Can I renew online?',
+    });
+
+    render(<ExpertFeedbackPanel message={message} extractSentences={extractSentences} t={mockT} lang="en" onDeleted={onDeleted} />);
+
+    // Open the panel (delete button lives inside the <details>).
+    fireEvent.click(screen.getByText(/Expert evaluation|reviewPanels.expertFeedbackTitle|homepage.expertRating.title/));
+
+    const deleteButton = await screen.findByText(/Delete Expert Feedback|reviewPanels.deleteExpertFeedback/);
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/components/chat/review/__tests__/OriginalLanguagePill.test.js
+++ b/src/components/chat/review/__tests__/OriginalLanguagePill.test.js
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import OriginalLanguagePill from '../OriginalLanguagePill.js';
+
+// Mimics real i18n interpolation for the one key with a {language}
+// placeholder; admin.common.aiAnswersSource just needs a real, distinct
+// value per language.
+const t = (lang) => (key) => {
+  const values = {
+    en: {
+      'admin.common.originallyAskedIn': 'Originally asked in: {language}',
+      'admin.common.aiAnswersSource': 'English only',
+    },
+    fr: {
+      'admin.common.originallyAskedIn': 'Posée à l\'origine en : {language}',
+      'admin.common.aiAnswersSource': 'En anglais seulement',
+    },
+  };
+  return values[lang][key] ?? key;
+};
+
+afterEach(() => cleanup());
+
+// The "English only" companion pill exists because a FR-UI admin might
+// otherwise assume French is available somewhere for a non-EN/FR question -
+// it never is (official-languages.md Rule 1). Only meaningful on the FR UI;
+// an EN-UI admin seeing English content needs no such reminder.
+describe('OriginalLanguagePill — English-only companion pill', () => {
+  it('shows only the language pill on the English UI, no companion pill', () => {
+    render(<OriginalLanguagePill languageCode="ar" lang="en" t={t('en')} />);
+
+    expect(screen.getByText(/Originally asked in/)).toBeTruthy();
+    expect(screen.queryByText('English only')).toBeNull();
+  });
+
+  it('shows both the language pill and the "English only" companion pill on the French UI', () => {
+    render(<OriginalLanguagePill languageCode="ar" lang="fr" t={t('fr')} />);
+
+    expect(screen.getByText(/Posée à l'origine en/)).toBeTruthy();
+    expect(screen.getByText('En anglais seulement')).toBeTruthy();
+  });
+
+  it('renders nothing at all when there is no language to show', () => {
+    const { container } = render(<OriginalLanguagePill languageCode="" lang="fr" t={t('fr')} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,8 +27,10 @@
       "useful": "Good",
       "notUseful": "Needs improvement",
       "or": "or",
+      "viewSource": "Review the English source text",
       "thankYou": "Thank you for your feedback!",
-      "error": "Error submitting feedback, contact admin."
+      "error": "Error submitting feedback, contact admin.",
+      "expertFeedbackDeletedAnnouncement": "Expert feedback deleted. You can evaluate this answer again."
     },
     "publicFeedback": {
       "send": "Send feedback",
@@ -173,6 +175,7 @@
         "heading": "Continue with this link:"
       },
       "review": {
+        "eyebrow": "Admin view",
         "chatDate": "Date (YYYY-MM-DD):",
         "referringUrl": "Referring URL:",
         "noDepartment": "None"
@@ -215,7 +218,10 @@
       "submit": "Submit evaluation",
       "intro": "Rate the answer sentences and/or citation",
       "answerNumberLabel": "Answer {number}",
-      "labelWithAnswer": "{label}: {answer}"
+      "labelWithAnswer": "{label}: {answer}",
+      "sourceView": {
+        "title": "AI Answers' source text"
+      }
     }
   },
   "batch": {
@@ -800,6 +806,10 @@
       "noSearchResults": "No search results found.",
       "filtersClearedAnnouncement": "Filters cleared.",
       "viewChatById": "View chat by ID",
+      "originallyAskedIn": "Originally asked in: {language}",
+      "sourceText": "Source",
+      "workingTextTooltip": "AI Answers' source text",
+      "aiAnswersSource": "Source text only in English",
       "chatIdRequired": "Please enter a chat ID.",
       "chatIdPlaceholder": "Enter full chat ID",
       "chatNotFound": "No chat found with that ID.",
@@ -811,18 +821,22 @@
       "searchResultsAnnouncement": "{count} results found.",
       "searchResultsUpdatedAnnouncement": "Search results updated.",
       "metricsLoading": "Loading metrics...",
-      "resultsHeading": "Results"
+      "resultsHeading": "Results",
+      "columns": {
+        "chatId": "Chat ID",
+        "department": "Department",
+        "program": "Service",
+        "pageLanguage": "Page",
+        "pageLanguageAriaLabel": "Page language"
+      }
     },
     "chatDashboard": {
       "title": "Chat dashboard",
       "loading": "Loading chats...",
       "error": "Unable to load chat data.",
       "columns": {
-        "chatId": "Chat ID",
-        "department": "Department",
         "question": "Question",
         "answer": "Answer",
-        "program": "Service",
         "citationUrl": "Citation link",
         "referringUrl": "Referring URL",
         "date": "Date",
@@ -854,16 +868,11 @@
       "searchChatIdPlaceholder": "Enter chat ID (partial or full)",
       "searchButton": "Search for chat ID",
       "columns": {
-        "chatId": "Chat ID",
         "questionNumber": "#",
         "questionNumberAriaLabel": "Question number",
         "partnerEval": "Partner",
         "aiEval": "AI",
-        "department": "Department",
-        "program": "Service",
         "action": "Action",
-        "pageLanguage": "Page",
-        "pageLanguageAriaLabel": "Page language",
         "creatorEmail": "Creator",
         "expertEmail": "Expert",
         "feedback": "Public",
@@ -1271,8 +1280,7 @@
   },
   "reviewPanels": {
     "sentence": "Sentence",
-    "sentenceEnglish": "Sentence English",
-    "englishQuestion": "English question",
+    "question": "Question:",
     "expertScore": "Expert score",
     "feedback": "Feedback",
     "helpfulYes": "Helpful - yes",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -27,8 +27,10 @@
       "useful": "Bonne",
       "notUseful": "Nécessite une amélioration",
       "or": "ou",
+      "viewSource": "Consulter le texte source en anglais",
       "thankYou": "Merci d'avoir donné votre rétroaction !",
-      "error": "Erreur lors de la soumission de la rétroaction, contactez l'administrateur."
+      "error": "Erreur lors de la soumission de la rétroaction, contactez l'administrateur.",
+      "expertFeedbackDeletedAnnouncement": "Rétroaction d'expert supprimée. Vous pouvez évaluer cette réponse à nouveau."
     },
     "publicFeedback": {
       "send": "Envoyer la rétroaction",
@@ -173,6 +175,7 @@
         "heading": "Continuez avec ce lien :"
       },
       "review": {
+        "eyebrow": "Vue administrateur",
         "chatDate": "Date (AAAA-MM-JJ):",
         "referringUrl": "URL de provenance :",
         "noDepartment": "Aucun"
@@ -215,7 +218,10 @@
       "submit": "Soumettre l'évaluation",
       "intro": "Évaluez les phrases de la réponse et/ou la citation",
       "answerNumberLabel": "Réponse {number}",
-      "labelWithAnswer": "{label} : {answer}"
+      "labelWithAnswer": "{label} : {answer}",
+      "sourceView": {
+        "title": "Texte source de Réponses IA"
+      }
     }
   },
   "batch": {
@@ -800,6 +806,10 @@
       "noSearchResults": "Aucun résultat de recherche trouvé.",
       "filtersClearedAnnouncement": "Filtres réinitialisés.",
       "viewChatById": "Voir le chat par ID",
+      "originallyAskedIn": "Posée à l'origine en : {language}",
+      "sourceText": "Source",
+      "workingTextTooltip": "Texte source de Réponses IA",
+      "aiAnswersSource": "Texte source : en anglais seulement",
       "chatIdRequired": "Veuillez entrer un identifiant de clavardage.",
       "chatIdPlaceholder": "Entrez l'ID complet du chat",
       "chatNotFound": "Aucun chat trouvé avec cet ID.",
@@ -811,18 +821,22 @@
       "searchResultsAnnouncement": "{count} résultats trouvés.",
       "searchResultsUpdatedAnnouncement": "Résultats de recherche mis à jour.",
       "metricsLoading": "Chargement des métriques...",
-      "resultsHeading": "Résultats"
+      "resultsHeading": "Résultats",
+      "columns": {
+        "chatId": "ID de chat",
+        "department": "Ministère",
+        "program": "Service",
+        "pageLanguage": "Page",
+        "pageLanguageAriaLabel": "Langue de la page"
+      }
     },
     "chatDashboard": {
       "title": "Tableau de bord de chat",
       "loading": "Chargement des chats...",
       "error": "Impossible de charger les données de chat.",
       "columns": {
-        "chatId": "ID de chat",
-        "department": "Ministère",
         "question": "Question",
         "answer": "Réponse",
-        "program": "Service",
         "citationUrl": "Lien de citation",
         "referringUrl": "URL de référence",
         "date": "Date",
@@ -854,16 +868,11 @@
       "searchChatIdPlaceholder": "Entrez l'ID de chat (partiel ou complet)",
       "searchButton": "Rechercher l'ID de chat",
       "columns": {
-        "chatId": "ID de chat",
         "questionNumber": "#",
         "questionNumberAriaLabel": "Numéro de question",
         "partnerEval": "Partenaire",
         "aiEval": "IA",
-        "department": "Ministère",
-        "program": "Service",
         "action": "Action",
-        "pageLanguage": "Page",
-        "pageLanguageAriaLabel": "Langue de la page",
         "creatorEmail": "Créateur",
         "expertEmail": "Expert",
         "feedback": "Public",
@@ -1271,8 +1280,7 @@
   },
   "reviewPanels": {
     "sentence": "Phrase",
-    "sentenceEnglish": "Phrase en anglais",
-    "englishQuestion": "Question en anglais",
+    "question": "Question :",
     "expertScore": "Note de l'expert",
     "feedback": "Rétroaction",
     "helpfulYes": "Utile - oui",

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -8,7 +8,7 @@ import FilterPanel from '../components/admin/FilterPanel.js';
 import EvaluationService from '../services/EvaluationService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import LoadingOverlay from '../components/admin/LoadingOverlay.js';
-import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml, chatLangFromPageLanguage } from '../utils/reviewLink.js';
 import { wireTableAccessibility } from '../utils/admin/dataTableAccessibility.js';
 
 DataTable.use(DT);
@@ -102,8 +102,10 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
       data: 'chatId',
       render: (value, type, row) => {
         if (!value) return '';
-        const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id);
+        // Route to the reviewed chat's own pageLanguage, not the admin's
+        // current UI language - see the same note in ChatDashboardPage.js.
+        const chatLang = chatLangFromPageLanguage(row.pageLanguage);
+        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id, lang);
       },
       searchable: true,
       orderable: true
@@ -123,7 +125,7 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
     { title: t('admin.autoEvalDashboard.columns.fallback', 'Fallback'), data: 'fallbackType', searchable: true, orderable: true },
     { title: t('admin.autoEvalDashboard.columns.reason', 'No-match reason'), data: 'noMatchReasonType', render: (v) => v ? t(`eval.noMatchReasonTypes.${v}`, v) : '', searchable: true, orderable: true },
     { title: t('admin.autoEvalDashboard.columns.date', 'Date'), data: 'date', render: (v) => formatDate(v), searchable: true, orderable: true }
-  ]), [formatDate, t]);
+  ]), [formatDate, t, lang]);
 
   return (
     <GcdsContainer layout="page" className="mb-600">

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -8,11 +8,13 @@ import FilterPanel from '../components/admin/FilterPanel.js';
 import DashboardService from '../services/DashboardService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import LoadingOverlay from '../components/admin/LoadingOverlay.js';
-import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml, chatLangFromPageLanguage } from '../utils/reviewLink.js';
+import { detectUrlLanguage } from '../utils/dashboard/urlLanguage.js';
 import { normalizeAnswerText } from '../utils/answerText.js';
 import { formatNumber } from '../utils/numberFormat.js';
 import { wireTableAccessibility } from '../utils/admin/dataTableAccessibility.js';
 import { useSearchAnnouncement } from '../hooks/admin/useSearchAnnouncement.js';
+import { resolveDisplayContent } from '../utils/answerLanguage.js';
 
 DataTable.use(DT);
 
@@ -81,13 +83,72 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
     }
   }, []);
 
-  // Question/Answer cell text: strip pipeline-added sentence markers
-  // (<s-1>...</s-1>, added for per-sentence citation/scoring) so they never
-  // show up as literal text, and render the full content - no truncation.
-  const renderAnswerText = useCallback((value) => {
-    if (!value) return '';
-    return escapeHtmlAttribute(normalizeAnswerText(value));
-  }, []);
+  // Same EN/FR-official-languages display rule (shown as-is; non-EN/FR
+  // collapses to English) as ExpertFeedbackPanel.js (resolveDisplayContent) -
+  // questionLanguage drives
+  // both the Question and Answer columns, since the AI answers in whatever
+  // language was detected for the question (agenticBase.js), not a
+  // separately-tracked language per column. DataTables `render` returns a
+  // raw HTML string here, not JSX, so this can't reuse OriginalLanguagePill
+  // (React) directly.
+  //
+  // Wrapping div is position:relative + reserved bottom padding, icon is
+  // position:absolute within it, anchored to the wrapper's own bottom edge
+  // - a static position regardless of how many lines the text above it
+  // wraps to, instead of flowing inline right after text of varying length
+  // (which put it in a different spot every row, and inline-after-text
+  // also pushed translated rows' text down a line vs. untranslated rows'
+  // single-line cells, breaking the table's row-height rhythm).
+  //
+  // Icon font-size is on the <i> itself, not on the .eval-tooltip wrapper -
+  // .eval-tooltip::after (admin.css) has no font-size reset of its own, so
+  // it inherits whatever font-size sits on the element carrying the
+  // eval-tooltip class. Sizing the <i> instead of that wrapper keeps the
+  // tooltip text at its normal size and only enlarges the glyph. 1.3em -
+  // a modest bump over EvalDashboardPage.js's own 1.2em/1.4em icons: the
+  // icon + visible "AI text" label together carry this pill's meaning
+  // at a glance; the fuller "AI Answers' working text" explanation lives in
+  // the tooltip/accessible name below, not visibly on the pill itself -
+  // short label for scanning, full explanation on demand.
+  //
+  // .eval-tooltip/data-tooltip, not the native title attribute - same
+  // reasoning as EvalDashboardPage.js's own icon cells: title's hover
+  // delay is fixed by the browser and can't be shortened, this CSS
+  // mechanism controls it. Accessible name for the icon+"AI text" pair
+  // comes from the sibling .wb-inv span carrying the fuller explanation,
+  // not aria-label, matching that same established pattern - the icon and
+  // the visible "AI text" label both stay aria-hidden so a screen
+  // reader gets the one, fuller phrase instead of "AI text" followed
+  // redundantly by "AI Answers' working text".
+  const renderLanguageAwareText = useCallback((original, english, questionLanguage) => {
+    const resolved = resolveDisplayContent({ language: questionLanguage, original, english });
+    if (!resolved.text) return '';
+    const langAttr = resolved.lang ? ` lang="${escapeHtmlAttribute(resolved.lang)}"` : '';
+    const text = escapeHtmlAttribute(normalizeAnswerText(resolved.text));
+    if (!resolved.isSource) {
+      return `<span${langAttr}>${text}</span>`;
+    }
+    const shortLabel = escapeHtmlAttribute(t('admin.common.sourceText'));
+    // "AI Answers' working text" - not "Originally asked in: {language}"
+    // (that's the question's language; this pill is about what the cell
+    // itself is showing - the English text AI Answers worked from/with,
+    // same framing as SourceViewComponent.js's own title).
+    const fullLabel = escapeHtmlAttribute(t('admin.common.workingTextTooltip'));
+    // The pill is a direct sibling here, not nested inside the text div -
+    // its position:absolute needs to resolve against the <td> itself
+    // (position:relative via this column's createdCell, so its box always
+    // matches the row's actual height), not this div, so Question's and
+    // Answer's pills land at the exact same Y position even when one
+    // column's text runs longer than the other's in the same row.
+    return `<div style="padding-bottom: 2.2em;">` +
+      `<span${langAttr}>${text}</span>` +
+      `</div>` +
+      `<span class="filter-pill eval-tooltip" data-tooltip="${fullLabel}" style="position: absolute; bottom: 0.5em; left: 0;">` +
+      `<i class="fa-solid fa-language" style="font-size: 1.3em;" aria-hidden="true"></i>` +
+      `<span aria-hidden="true">${shortLabel}</span>` +
+      `<span class="wb-inv">${fullLabel}</span>` +
+      `</span>`;
+  }, [t]);
 
   useEffect(() => {
     setTimeout(() => setDataTableReady(true), 0);
@@ -158,25 +219,34 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
 
   const columns = useMemo(() => ([
     {
-      title: t('admin.chatDashboard.columns.chatId', 'Chat ID'),
+      title: t('admin.common.columns.chatId'),
       data: 'chatId',
       searchable: false,
       orderable: false,
       render: (value, type, row) => {
         if (!value) return '';
-        const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        return buildChatReviewLinkHtml(value, chatLang, row.interactionId);
+        // Route to the chat's OWN pageLanguage, not the admin's current UI
+        // language - the reviewed transcript (answer bubbles, citation
+        // heading) must show what the end user actually saw
+        // (docs/coding-agent-docs/official-languages.md Rule 2), so the
+        // route itself has to land on that language. The admin's own
+        // language is carried separately as the `adminLang` query param
+        // (4th arg) for the review page's own chrome (ExpertFeedbackPanel,
+        // "How was this answer?", Chat ID/Date/Referring URL labels) to use
+        // instead - see reviewLink.js and HomePage.js's `adminLang`.
+        const chatLang = chatLangFromPageLanguage(row.pageLanguage);
+        return buildChatReviewLinkHtml(value, chatLang, row.interactionId, lang);
       }
     },
     {
-      title: t('admin.chatDashboard.columns.department', 'Department'),
+      title: t('admin.common.columns.department'),
       data: 'department',
       searchable: false,
       orderable: true,
       render: (value) => escapeHtmlAttribute(value || '')
     },
     {
-      title: t('admin.chatDashboard.columns.program', 'Service'),
+      title: t('admin.common.columns.program'),
       data: 'program',
       searchable: false,
       orderable: true,
@@ -190,18 +260,32 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       data: 'redactedQuestion',
       searchable: false,
       orderable: false,
-      render: (value) => renderAnswerText(value)
+      render: (value, type, row) => renderLanguageAwareText(value, row && row.englishQuestion, row && row.questionLanguage),
+      // position:relative belongs on the <td> itself, not a wrapper div
+      // inside it - the <td>'s own box stretches to match the row's
+      // tallest cell (normal table behaviour), a div inside it doesn't.
+      // The "Translated" pill's position:absolute needs to resolve
+      // against that actual row-height box to stay anchored to the row's
+      // real bottom edge, not just this cell's own shorter content height.
+      createdCell: (td) => { td.style.position = 'relative'; }
     },
     {
       title: t('admin.chatDashboard.columns.answer', 'Answer'),
       data: 'answerContent',
       searchable: false,
       orderable: false,
-      render: (value) => renderAnswerText(value)
+      render: (value, type, row) => renderLanguageAwareText(value, row && row.englishAnswer, row && row.questionLanguage),
+      createdCell: (td) => { td.style.position = 'relative'; }
     },
     {
       title: t('admin.chatDashboard.columns.citationUrl', 'Citation link'),
       data: 'citationUrl',
+      // Capped so Question/Answer (no fixed width - they auto-fill
+      // remaining space) don't get squeezed by this column growing to fit
+      // a long citation URL - the visible text is already shortened via
+      // truncateUrl() below, this just stops the column itself from
+      // stretching past what that short text actually needs.
+      width: '160px',
       searchable: false,
       orderable: false,
       render: (value) => {
@@ -212,12 +296,35 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         // and handles the new-tab icon/rel/accessible text itself. href is
         // the full citation URL; the visible text stays the shorthand
         // truncated form.
+        //
+        // gcds-link's own `lang` attribute does two unrelated jobs at once:
+        // native HTML lang inheritance (how a screen reader pronounces the
+        // slotted text) AND a plain JS property read (gcds-link.js's
+        // assignLanguage/i18n[lang]) that picks which language string labels
+        // its own icon - here, the "(Opens destination in a new tab.)"
+        // accessible text. Those need different values: the outer element
+        // keeps the admin's own `lang` so that hint announces in the
+        // admin's language, and an inner span carries the citation URL's own
+        // language (detectUrlLanguage) so the truncated citation text itself
+        // is still pronounced correctly (WCAG 3.1.2) - same reasoning as
+        // CountTable.js's citation links, applied here to the raw HTML form.
         const safeHref = escapeHtmlAttribute(value);
         const safeDisplay = escapeHtmlAttribute(truncateUrl(value));
-        return `<gcds-link href="${safeHref}" target="_blank" lang="${lang}">${safeDisplay}</gcds-link>`;
+        const citationLang = escapeHtmlAttribute(detectUrlLanguage(value, lang));
+        return `<gcds-link href="${safeHref}" target="_blank" lang="${lang}"><span lang="${citationLang}">${safeDisplay}</span></gcds-link>`;
       }
     }
-  ]), [renderAnswerText, truncateUrl, t, lang]);
+    // The "Page" language column (row.pageLanguage) used to live here as
+    // the admin's only advance warning of which language route the Chat ID
+    // link would drop them on - the review page used to switch its whole
+    // chrome to that language. Now that review mode is its own page
+    // (ChatReviewPage.js), the admin's own review chrome stays in their own
+    // language regardless of the reviewed chat's pageLanguage, so that
+    // warning no longer applies - removed rather than left as a now-
+    // pointless column. row.pageLanguage itself is still used internally by
+    // the Chat ID column's render() above (chatLangFromPageLanguage) to
+    // route the transcript correctly; only the visible column is gone.
+  ]), [renderLanguageAwareText, truncateUrl, t, lang]);
 
   return (
     <GcdsContainer layout="page" className="mb-600">

--- a/src/pages/ChatReviewPage.js
+++ b/src/pages/ChatReviewPage.js
@@ -1,0 +1,71 @@
+// src/pages/ChatReviewPage.js
+import React from "react";
+import { GcdsContainer, GcdsLink } from "@gcds-core/components-react";
+import ChatAppContainer from "../components/chat/ChatAppContainer.js";
+import { useTranslations } from "../hooks/useTranslations.js";
+
+// Dedicated admin view for reviewing a finished chat - swapped in by
+// HomePage.js (same URL: /{lang}?chat=...&review=1&adminLang=...) instead of
+// the public "ask a new question" homepage chrome (H1/subtitle/privacy
+// disclosure), which made no sense for an admin reviewing a chat that's
+// already happened - only the bottom "built by..." footer was ever actually
+// hidden in review mode before this, leaving the public framing intact.
+//
+// This page's own header/H1/nav is always `adminLang` (the reviewing
+// admin's own current UI language) - no per-element language decision here,
+// since the whole page other than the transcript itself IS admin chrome.
+// `lang` (the reviewed chat's own pageLanguage - unchanged, still the route
+// itself, per docs/coding-agent-docs/official-languages.md Rule 2) and
+// `adminLang` both still get threaded into ChatAppContainer exactly as
+// before this page existed - readOnly rendering (bubbles + inline review
+// panels, citation heading) is unchanged, only the surrounding page chrome
+// moved. No separate "Viewing chat" H2 here - ChatAppContainer already has
+// its own (visually hidden) H2 for the conversation region
+// (homepage.chat.section.heading), so the heading hierarchy is already
+// sound without one.
+const ChatReviewPage = ({
+  lang,
+  adminLang,
+  chatId,
+  initialMessages,
+  chatCreatedAt,
+  referringUrl,
+  targetInteractionId,
+  onSessionError,
+  onChatIdUpdate,
+}) => {
+  const { t } = useTranslations(adminLang);
+
+  return (
+    <GcdsContainer layout="page" className="mb-600">
+      {/* Split/"stacked" h1 - see admin.css's .canada-ca-h1-stacked__eyebrow
+          comment for the full explanation of this Canada.ca Specifications/
+          GCWeb pattern. "Admin view" as the small eyebrow, the site's own
+          brand name ("AI Answers") as the large title below it - same brand
+          name/key as HomePage.js's own H1, just reordered under the eyebrow
+          here instead of standing alone. */}
+      <h1 className="mb-400" lang={adminLang}>
+        <span className="canada-ca-h1-stacked__eyebrow">{t('homepage.chat.review.eyebrow')}</span>
+        <span className="canada-ca-h1-stacked__title">{t('homepage.title')}</span>
+      </h1>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')} lang={adminLang}>
+        <GcdsLink href={`/${adminLang}/admin`}>{t('common.backToAdmin')}</GcdsLink>
+      </nav>
+      <ChatAppContainer
+        lang={lang}
+        chatId={chatId}
+        readOnly
+        initialMessages={initialMessages}
+        initialReferringUrl={referringUrl}
+        chatCreatedAt={chatCreatedAt}
+        adminLang={adminLang}
+        clientReferrer={null}
+        targetInteractionId={targetInteractionId}
+        onSessionError={onSessionError}
+        onChatIdUpdate={onChatIdUpdate}
+      />
+    </GcdsContainer>
+  );
+};
+
+export default ChatReviewPage;

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -12,7 +12,7 @@ import LoadingOverlay from '../components/admin/LoadingOverlay.js';
 import FeedbackInlineError from '../components/chat/FeedbackInlineError.js';
 import { useInlineFormError } from '../hooks/useInlineFormError.js';
 import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
-import { escapeHtmlAttribute, buildChatReviewLinkHtml } from '../utils/reviewLink.js';
+import { escapeHtmlAttribute, buildChatReviewLinkHtml, chatLangFromPageLanguage } from '../utils/reviewLink.js';
 import { formatNumber } from '../utils/numberFormat.js';
 import { wireTableAccessibility } from '../utils/admin/dataTableAccessibility.js';
 import { useSearchAnnouncement } from '../hooks/admin/useSearchAnnouncement.js';
@@ -295,12 +295,14 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
 
   const columns = useMemo(() => ([
     {
-      title: t('admin.evalDashboard.columns.chatId'),
+      title: t('admin.common.columns.chatId'),
       data: 'chatId',
       render: (value, type, row) => {
         if (!value) return '';
-        const chatLang = row.pageLanguage && (row.pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
-        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id);
+        // Route to the reviewed chat's own pageLanguage, not the admin's
+        // current UI language - see the same note in ChatDashboardPage.js.
+        const chatLang = chatLangFromPageLanguage(row.pageLanguage);
+        return buildChatReviewLinkHtml(value, chatLang, row.interactionId || row._id, lang);
       },
       searchable: false,
       orderable: false
@@ -399,11 +401,11 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       },
       width: '50px', className: 'eval-center-cell', searchable: false, orderable: true
     },
-    { title: t('admin.evalDashboard.columns.department'), data: 'department', width: '110px', searchable: false, orderable: true },
-    { title: t('admin.evalDashboard.columns.program'), data: 'program', width: '160px', render: (v, type, row) => { const d = (lang === 'fr' && row && row.programFr) ? row.programFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: false, orderable: true },
+    { title: t('admin.common.columns.department'), data: 'department', width: '110px', searchable: false, orderable: true },
+    { title: t('admin.common.columns.program'), data: 'program', width: '160px', render: (v, type, row) => { const d = (lang === 'fr' && row && row.programFr) ? row.programFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.action'), data: 'action', width: '90px', render: (v, type, row) => { const d = (lang === 'fr' && row && row.actionFr) ? row.actionFr : v; return d ? escapeHtmlAttribute(d) : ''; }, searchable: false, orderable: true },
     { title: t('admin.chatDashboard.columns.referringUrl'), data: 'referringUrl', render: v => v ? escapeHtmlAttribute(truncateUrl(v)) : `<span style="color: #666;">${escapeHtmlAttribute(t('reviewPanels.none'))}</span>`, searchable: false, orderable: true },
-    { title: t('admin.evalDashboard.columns.pageLanguage'), data: 'pageLanguage', width: '50px', className: 'eval-center-cell', render: v => v ? escapeHtmlAttribute(v.toUpperCase()) : '', searchable: false, orderable: true },
+    { title: t('admin.common.columns.pageLanguage'), data: 'pageLanguage', width: '50px', className: 'eval-center-cell', render: v => v ? escapeHtmlAttribute(v.toUpperCase()) : '', searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.creatorEmail'), data: 'creatorEmail', render: v => escapeHtmlAttribute(truncateEmail(v || '')), searchable: false, orderable: true },
     { title: t('admin.evalDashboard.columns.expertEmail'), data: 'expertEmail', render: v => escapeHtmlAttribute(truncateEmail(v || '')), searchable: false, orderable: true },
     {
@@ -705,11 +707,28 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
                     // column becomes the active sort, matching GC DS's own
                     // table pattern (see admin.css comment above the CSS
                     // rules this feeds).
-                    api.columns().header().each((header) => {
+                    // Columns whose visible header is shortened (e.g. "Page",
+                    // "#") get the same spelled-out text here that their
+                    // aria-label already carries (set in initComplete below)
+                    // - a sighted mouse user hovering the header has the same
+                    // ambiguity problem the aria-label exists to solve for
+                    // screen-reader users, so the visible tooltip needs the
+                    // same fix, not just the aria-label. Built from `columns`
+                    // (already in scope) rather than reading the header's own
+                    // aria-label attribute back out of the DOM, since that's
+                    // set in initComplete - which runs after this drawCallback
+                    // on the very first draw, so reading it here could work
+                    // after a later sort but show the short text on first load.
+                    const columnTitleOverrides = {
+                      pageLanguage: t('admin.common.columns.pageLanguageAriaLabel'),
+                      questionNumber: t('admin.evalDashboard.columns.questionNumberAriaLabel'),
+                    };
+                    api.columns().header().each((header, idx) => {
                       if (!header.classList.contains('dt-orderable-asc') && !header.classList.contains('dt-orderable-desc')) return;
                       const orderSpan = header.querySelector('.dt-column-order');
                       if (!orderSpan) return;
-                      const title = (header.textContent || '').trim();
+                      const columnData = columns[idx]?.data;
+                      const title = columnTitleOverrides[columnData] || (header.textContent || '').trim();
                       const currentSort = header.getAttribute('aria-sort');
                       // DataTables' own default per-column click cycle is
                       // 3-state, not 2 - asSorting: ['asc', 'desc', ''] in
@@ -752,7 +771,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
                     // - aria-label carries the spelled-out meaning instead.
                     const pageLanguageHeader = api.column(columns.findIndex((c) => c.data === 'pageLanguage')).header();
                     if (pageLanguageHeader) {
-                      pageLanguageHeader.setAttribute('aria-label', t('admin.evalDashboard.columns.pageLanguageAriaLabel'));
+                      pageLanguageHeader.setAttribute('aria-label', t('admin.common.columns.pageLanguageAriaLabel'));
                     }
                   } catch (e) { /* ignore initComplete errors */ }
                 },

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import ChatAppContainer from "../components/chat/ChatAppContainer.js";
+import ChatReviewPage from "./ChatReviewPage.js";
 import {
   GcdsContainer,
   GcdsDetails,
@@ -12,9 +13,9 @@ import { useTranslations } from "../hooks/useTranslations.js";
 import { useAuth } from "../contexts/AuthContext.js";
 import DataStoreService from "../services/DataStoreService.js";
 import OutageComponent from "../components/OutageComponent.js";
-import { useHasAnyRole } from "../components/RoleBasedUI.js";
 import { getPath } from "../utils/routes.js";
 import { CanadaCaAccessibleLabel } from "../utils/pronounceCanadaCa.js";
+import { getAnswerLanguage } from "../utils/answerLanguage.js";
 
 // Error Boundary
 class ErrorBoundary extends React.Component {
@@ -57,6 +58,16 @@ const HomePage = ({ lang = "en" }) => {
   const [searchParams] = useSearchParams();
   const reviewChatId = searchParams.get("chat");
   const reviewMode = searchParams.get("review") === "1";
+  // The reviewing admin's own current UI language, carried forward as a
+  // query param by reviewLink.js's buildChatReviewLinkHtml/buildChatReviewHref
+  // rather than by the route itself - the route (`lang`) stays tied to the
+  // reviewed chat's own pageLanguage so the transcript (answer bubbles,
+  // citation heading) shows what the end user actually saw. `adminLang` is
+  // for the admin-only chrome around that transcript (ExpertFeedbackPanel,
+  // "How was this answer?", Chat ID/Date/Referring URL labels) to use
+  // instead of silently inheriting the chat's language. Falls back to the
+  // route's own `lang` outside review mode / when absent.
+  const adminLang = searchParams.get("adminLang") || lang;
   // Parse interaction from hash (e.g. #interaction=interactionId5abcd)
   const getInteractionFromHash = () => {
     try {
@@ -70,7 +81,6 @@ const HomePage = ({ lang = "en" }) => {
     }
   };
   const [targetInteractionId, setTargetInteractionId] = useState(getInteractionFromHash());
-  // const isPrivileged = useHasAnyRole(["admin", "partner"]);
   const [serviceStatus, setServiceStatus] = useState({
     isAvailable: null,
     sessionAvailable: null,
@@ -154,6 +164,16 @@ const HomePage = ({ lang = "en" }) => {
                 id: inter.interactionId,
                 text: inter.question?.redactedQuestion || "",
                 sender: "user",
+                // The detected question language, not the whole interaction
+                // object the paired AI message gets below - without this,
+                // ChatInterface.js's question-bubble lang tag
+                // (toLangAttr(message.questionLanguage)) has nothing to read
+                // and silently renders no lang attribute at all. Deliberately
+                // not `interaction: inter` here - see ChatAppContainer.js's
+                // matching comment for why a user-sender message should
+                // never carry a real `.interaction` (server-side code reads
+                // `.interaction` presence as "this is the AI's turn").
+                questionLanguage: getAnswerLanguage(inter),
               });
             }
             if (inter) {
@@ -195,13 +215,35 @@ const HomePage = ({ lang = "en" }) => {
     return <OutageComponent lang={lang} />;
   }
 
+  // Swapped in for the whole page, same URL - review mode never needed the
+  // public "ask a new question" chrome below (H1/subtitle/privacy
+  // disclosure), and ChatReviewPage.js gives it its own admin-appropriate
+  // header/H1 instead. Data fetched above (initialMessages, chatCreatedAt,
+  // reviewReferringUrl, targetInteractionId) is review-mode-only already -
+  // reused as-is, not recomputed.
+  if (reviewMode) {
+    return (
+      <ChatReviewPage
+        lang={lang}
+        adminLang={adminLang}
+        chatId={chatId}
+        initialMessages={initialMessages}
+        chatCreatedAt={chatCreatedAt}
+        referringUrl={reviewReferringUrl}
+        targetInteractionId={targetInteractionId}
+        onSessionError={handleSessionError}
+        onChatIdUpdate={setChatId}
+      />
+    );
+  }
+
   return (
     <ErrorBoundary t={t}>
       <div className="mb-600 container-custom">
         <h1 className="mb-400">{t("homepage.title")}</h1>
         <CanadaCaAccessibleLabel
           as="h2"
-          className="homepage-subtitle mt-400"
+          className="homepage-subtitle mt-0"
           text={t("homepage.subtitle")}
           lang={lang}
         />
@@ -241,10 +283,14 @@ const HomePage = ({ lang = "en" }) => {
         <ChatAppContainer
           lang={lang}
           chatId={chatId}
-          readOnly={reviewMode}
           initialMessages={initialMessages}
-          // Pass saved review value separately, and clientReferrer separately.
-          // ChatAppContainer will prefer pageUrl when present and ignore clientReferrer.
+          // Populated whenever ?chat= is present, review=1 or not - a
+          // ?chat=X URL with no &review=1 resumes that chatId live
+          // (editable), not read-only, so these still matter here even
+          // though reviewMode is guaranteed false past the early return
+          // above. Pass saved review value separately, and clientReferrer
+          // separately - ChatAppContainer will prefer pageUrl when present
+          // and ignore clientReferrer.
           initialReferringUrl={reviewReferringUrl}
           chatCreatedAt={chatCreatedAt}
           clientReferrer={clientReferrer}
@@ -253,16 +299,14 @@ const HomePage = ({ lang = "en" }) => {
           onChatIdUpdate={setChatId}
         />
       </div>
-      {!reviewMode && (
-        <div className="mb-600 container-custom">
-          <p className="mb-300">
-            <CanadaCaAccessibleLabel as="span" text={t("homepage.about.builtBy")} lang={lang} />{" "}
-            <a href={getPath('about', lang)}>
-              {t("homepage.about.learnMore")}
-            </a>.
-          </p>
-        </div>
-      )}
+      <div className="mb-600 container-custom">
+        <p className="mb-300">
+          <CanadaCaAccessibleLabel as="span" text={t("homepage.about.builtBy")} lang={lang} />{" "}
+          <a href={getPath('about', lang)}>
+            {t("homepage.about.learnMore")}
+          </a>.
+        </p>
+      </div>
     </ErrorBoundary>
   );
 };

--- a/src/pages/__tests__/ChatDashboardPage.test.js
+++ b/src/pages/__tests__/ChatDashboardPage.test.js
@@ -35,10 +35,12 @@ vi.mock('../../services/DashboardService.js', () => ({
 // that a *specific* (e.g. outgoing, pre-Clear) instance's ajax.reload was or
 // wasn't called - the whole point of the regression test below.
 let lastOptions = null;
+let lastColumns = null;
 let mountedInstances = [];
 vi.mock('datatables.net-react', () => {
   const MockDataTable = (props) => {
     lastOptions = props.options;
+    lastColumns = props.columns;
     const apiRef = React.useRef(null);
     const firedRef = React.useRef(false);
     if (!apiRef.current) {
@@ -84,6 +86,7 @@ vi.mock('@gcds-core/components-react', () => ({
 describe('ChatDashboardPage rendering', () => {
   afterEach(() => {
     cleanup();
+    lastColumns = null;
     lastOptions = null;
     mountedInstances = [];
   });
@@ -94,6 +97,37 @@ describe('ChatDashboardPage rendering', () => {
     await waitFor(() => {
       expect(getByText(/Chat dashboard/i)).toBeTruthy();
     });
+  });
+
+  // The chatId column's review link routes to the reviewed chat's own
+  // pageLanguage, not the admin's current UI language - the transcript
+  // (answer bubbles, citation heading) must show what the end user actually
+  // saw (docs/coding-agent-docs/official-languages.md Rule 2). The admin's
+  // own language rides along separately as the `adminLang` query param, for
+  // the review page's own chrome ("How was this answer?", etc.) to use.
+  it('routes the chatId review link to the row\'s pageLanguage, carrying the admin\'s own lang as adminLang', async () => {
+    const { container } = render(<ChatDashboardPage lang="fr" />);
+
+    // Apply the default filters to mount the table (see the "Clear all" test
+    // below for the same pattern).
+    const applyButton = await waitFor(() => {
+      const btn = container.querySelector('#filter-apply-button');
+      if (!btn) throw new Error('apply button not rendered yet');
+      return btn;
+    });
+    await act(async () => {
+      fireEvent.click(applyButton);
+    });
+    await waitFor(() => expect(lastColumns).not.toBeNull());
+
+    const chatIdColumn = lastColumns.find((c) => c.data === 'chatId');
+    // Row's own pageLanguage is 'en' - the route must land on /en/..., not
+    // the admin's own /fr (the page this dashboard itself is rendered in).
+    const html = chatIdColumn.render('chat-123', 'display', { pageLanguage: 'en', interactionId: 'int-1' });
+
+    expect(html).toContain('href="/en?chat=chat-123');
+    expect(html).not.toContain('href="/fr?chat=chat-123');
+    expect(html).toContain('adminLang=fr');
   });
 
   it('Clear all hides the results entirely rather than auto-fetching the reset defaults (restart, not re-apply)', async () => {

--- a/src/pages/__tests__/HomePage.reviewMode.test.js
+++ b/src/pages/__tests__/HomePage.reviewMode.test.js
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import HomePage from '../HomePage.js';
+
+const { mockGetChatSessionAvailability, mockGetChat, mockGetPublicSetting } = vi.hoisted(() => ({
+  mockGetChatSessionAvailability: vi.fn(() => Promise.resolve({ siteStatus: true, sessionAvailable: true })),
+  mockGetChat: vi.fn(() => Promise.resolve({ chat: null })),
+  mockGetPublicSetting: vi.fn(() => Promise.resolve(null)),
+}));
+vi.mock('../../services/DataStoreService.js', () => ({
+  default: {
+    getChatSessionAvailability: mockGetChatSessionAvailability,
+    getChat: mockGetChat,
+    getPublicSetting: mockGetPublicSetting,
+  }
+}));
+
+vi.mock('../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({
+    t: (key) => key,
+  })
+}));
+
+vi.mock('../../contexts/AuthContext.js', () => ({
+  useAuth: () => ({ loading: false, user: null }),
+}));
+
+// Hoisted so each test can set its own query params before rendering.
+let currentSearchParams = new URLSearchParams();
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [currentSearchParams, vi.fn()],
+}));
+
+vi.mock('../../components/OutageComponent.js', () => ({
+  default: () => <div data-testid="outage-component">Service unavailable</div>,
+}));
+
+// Stub ChatAppContainer so we don't pull in its dependency tree - both
+// HomePage.js's own live-chat call and ChatReviewPage.js's call render this
+// same marker, distinguishable by the readOnly prop it's given.
+vi.mock('../../components/chat/ChatAppContainer.js', () => ({
+  default: ({ readOnly }) => <div data-testid="chat-app">{readOnly ? 'readonly' : 'live'}</div>,
+}));
+
+vi.mock('@gcds-core/components-react', () => ({
+  GcdsContainer: ({ children }) => <div>{children}</div>,
+  GcdsDetails: ({ children }) => <div>{children}</div>,
+  GcdsText: ({ children }) => <div>{children}</div>,
+  GcdsLink: ({ children, href }) => <a href={href}>{children}</a>,
+  GcdsNotice: ({ children }) => <div>{children}</div>,
+}));
+
+// Regression: review mode (?chat=...&review=1) used to render straight
+// through HomePage.js's own public "ask a new question" chrome (H1
+// "AI Answers", subtitle "Get answers to your Canada.ca questions", privacy
+// disclosure) - meaningless framing for an admin looking at an
+// already-finished chat. It now swaps in ChatReviewPage.js's own
+// admin-appropriate header/H1 instead, same URL.
+describe('HomePage review mode', () => {
+  afterEach(() => {
+    cleanup();
+    mockGetChatSessionAvailability.mockReset().mockResolvedValue({ siteStatus: true, sessionAvailable: true });
+    mockGetChat.mockReset().mockResolvedValue({ chat: null });
+    mockGetPublicSetting.mockReset().mockResolvedValue(null);
+    currentSearchParams = new URLSearchParams();
+  });
+
+  it('renders the review shell (not the public homepage chrome) when review=1', async () => {
+    currentSearchParams = new URLSearchParams('chat=abc123&review=1&adminLang=fr');
+
+    render(<HomePage lang="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('homepage.chat.review.eyebrow')).toBeTruthy();
+    });
+    expect(screen.getByTestId('chat-app').textContent).toBe('readonly');
+    // ChatReviewPage.js's own H1 reuses the same brand-consistent
+    // "homepage.title" ("AI Answers") text as the public homepage's H1 -
+    // "homepage.chat.review.eyebrow" ("Admin view") is the small eyebrow
+    // stacked above it, not a replacement for the H1. The public "Get
+    // answers..." *subtitle* is what's actually absent in review mode -
+    // that specific key is unique to the public homepage chrome.
+    expect(screen.queryByText('homepage.subtitle')).toBeNull();
+  });
+
+  it('still renders the normal public homepage chrome with no review param', async () => {
+    currentSearchParams = new URLSearchParams();
+
+    render(<HomePage lang="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-app').textContent).toBe('live');
+    });
+    expect(screen.getByText('homepage.subtitle')).toBeTruthy();
+    expect(screen.queryByText('homepage.chat.review.eyebrow')).toBeNull();
+  });
+
+  it('a chat= URL without review=1 resumes that chatId live (not read-only), keeping the public chrome', async () => {
+    currentSearchParams = new URLSearchParams('chat=abc123');
+
+    render(<HomePage lang="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-app').textContent).toBe('live');
+    });
+    expect(screen.getByText('homepage.subtitle')).toBeTruthy();
+  });
+});

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -2678,6 +2678,17 @@ table.dataTable.dashboard-table thead th[data-tooltip]::after {
   color: var(--gcds-text-primary);
 }
 
+/* Wraps 2+ pills that need to sit together inline with breathing room
+   between them - e.g. OriginalLanguagePill.js's language pill plus its
+   FR-only "English only" companion pill. Same 6px gap as
+   .filter-bar__pills-row, for visual consistency with the rest of the pill
+   system, but flex-wrap isn't needed here (always just 1-2 short pills). */
+.pill-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 /* GC DS–style filter pill */
 .filter-pill {
   display: inline-flex;

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -462,6 +462,18 @@
   text-decoration: underline;
 }
 
+/* .font-size-text-sm-nr (global.css) has no !important of its own, so
+   .feedback-link's 18px !important above would win regardless - today
+   that's a coincidental match (both currently resolve to 18px), but tying
+   this to the token via a compound selector (one class more specific, wins
+   outright regardless of file load order) means the "See translation" link
+   (FeedbackComponent.js) actually tracks --gcds-font-sizes-text-small if
+   that token ever changes, instead of silently drifting from .feedback-
+   link's own hardcoded magic number. */
+.feedback-link.font-size-text-sm-nr {
+  font-size: var(--gcds-font-sizes-text-small) !important;
+}
+
 .feedback-link:hover {
   color: var(--gcds-link-hover);
   text-decoration-thickness: var(--gcds-link-hover-decoration-thickness);
@@ -478,9 +490,19 @@
   cursor: pointer;
   font-family: inherit;
   font-size: inherit;
+  /* Native <button> UA stylesheets default to text-align: center - fine for
+     a short single-line label, but a longer wrapped one (e.g. the "See
+     translation" link's full sentence) centers its second+ line instead of
+     staying left-aligned like real inline link text would. */
+  text-align: left;
 }
 
-.feedback-link.button-as-link:first-of-type::before {
+/* Explicit rating classes rather than :first-of-type/:nth-of-type(2) - those
+   matched on structural position, not meaning, so a non-rating control (e.g.
+   "See translation") placed first in the group picked up a thumbs-up icon it
+   has no business showing. Apply feedback-icon-up/-down only to buttons that
+   are actually a Good/Needs improvement (or Yes/No) choice. */
+.feedback-link.button-as-link.feedback-icon-up::before {
   font-family: "Font Awesome 6 Free";
   font-weight: 900;
   content: "\f164"; /* thumbs-up */
@@ -489,7 +511,7 @@
   display: inline-block;
 }
 
-.feedback-link.button-as-link:nth-of-type(2)::before {
+.feedback-link.button-as-link.feedback-icon-down::before {
   font-family: "Font Awesome 6 Free";
   font-weight: 900;
   content: "\f165"; /* thumbs-down */

--- a/src/utils/__tests__/answerLanguage.test.js
+++ b/src/utils/__tests__/answerLanguage.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getAnswerLanguage, toLangAttr } from '../answerLanguage.js';
+import { getAnswerLanguage, toLangAttr, resolveDisplayContent } from '../answerLanguage.js';
 
 describe('getAnswerLanguage', () => {
   it('prefers the live-session shape (answer.questionLanguage) over the persisted shape', () => {
@@ -68,5 +68,48 @@ describe('toLangAttr', () => {
     expect(toLangAttr('arb')).toBe('ar');
     expect(toLangAttr('zho')).toBe('zh');
     expect(toLangAttr('cmn')).toBe('zh');
+  });
+});
+
+// Signed-off admin/eval display rule: EN and FR show their own original
+// text; only a genuinely non-EN/FR language falls back to the English
+// version.
+describe('resolveDisplayContent', () => {
+  it('shows the original text for English, tagged lang="en"', () => {
+    expect(resolveDisplayContent({ language: 'eng', original: 'Can I renew online?', english: 'Can I renew online?' }))
+      .toEqual({ text: 'Can I renew online?', lang: 'en', isSource: false });
+  });
+
+  it('shows the original text for French, tagged lang="fr" - not the English fallback', () => {
+    expect(resolveDisplayContent({ language: 'fra', original: 'Puis-je renouveler en ligne?', english: 'Can I renew online?' }))
+      .toEqual({ text: 'Puis-je renouveler en ligne?', lang: 'fr', isSource: false });
+  });
+
+  it('falls back to the English version for a non-EN/FR language, tagged lang="en", and flags isSource', () => {
+    expect(resolveDisplayContent({ language: 'ara', original: 'هل يمكنني التجديد عبر الإنترنت؟', english: 'Can I renew online?' }))
+      .toEqual({ text: 'Can I renew online?', lang: 'en', isSource: true });
+  });
+
+  it('falls back to the original text when a non-EN/FR language has no English version available', () => {
+    // Shouldn't happen once the translation pipeline has run, but a missing
+    // english value must not silently produce empty/undefined display text.
+    expect(resolveDisplayContent({ language: 'ara', original: 'هل يمكنني التجديد عبر الإنترنت؟', english: '' }))
+      .toEqual({ text: 'هل يمكنني التجديد عبر الإنترنت؟', lang: 'ar', isSource: false });
+  });
+
+  it('defaults to showing the original text untagged when no language is known at all', () => {
+    // Legacy data, or a field this hasn't been wired up for yet - matches
+    // pre-existing display behaviour instead of guessing at a language.
+    expect(resolveDisplayContent({ language: '', original: 'Can I renew online?', english: '' }))
+      .toEqual({ text: 'Can I renew online?', lang: undefined, isSource: false });
+  });
+
+  it('treats an already-BCP-47 "en"/"fr" the same as the ISO-639-3 form', () => {
+    expect(resolveDisplayContent({ language: 'en', original: 'Can I renew online?', english: '' }).isSource).toBe(false);
+    expect(resolveDisplayContent({ language: 'fr', original: 'Puis-je renouveler en ligne?', english: '' }).isSource).toBe(false);
+  });
+
+  it('never returns undefined text, even with no original and no english', () => {
+    expect(resolveDisplayContent({ language: 'ara', original: undefined, english: undefined }).text).toBe('');
   });
 });

--- a/src/utils/answerLanguage.js
+++ b/src/utils/answerLanguage.js
@@ -105,3 +105,117 @@ export function toLangAttr(rawLanguage) {
   if (code === 'und' || code === 'zxx') return undefined;
   return ISO3_TO_BCP47[code] || code;
 }
+
+// Admin/eval display rule - two separate, unrelated constraints that happen
+// to produce one rule (see docs/coding-agent-docs/official-languages.md for
+// the full reasoning):
+//   1. EN/FR side - the OL requirement. A question/answer that arrived in
+//      French stays displayed in French, full stop, even though an English
+//      translation may still exist for it internally (GraphWorkflowHelper.
+//      translateQuestion runs unconditionally, so it does). Not a linguistic
+//      "native" preference or an absence-of-data coincidence - the same OL
+//      requirement that governs every other page in this app.
+//   2. Non-EN/FR side - the tool can't output what was never produced.
+//      translateQuestion always targets English, never French, so English
+//      is the only translated form that can ever exist for a non-EN/FR
+//      question - a ceiling on the data, not a fallback of convenience.
+// The original-language text is never shown to an admin outside the
+// download logs once it isn't EN/FR — chat-export-logs.js already keeps
+// full fidelity there independently of this function.
+//
+// Returns { text, lang, isSource }: `lang` is a ready-to-use BCP-47
+// value (or undefined for 'und'/'zxx', same as toLangAttr), `isSource`
+// is true only when the non-EN/FR fallback actually fired — the signal an
+// "Originally asked in: {language}" pill should key off, not just "language
+// isn't en/fr" (an und/zxx question has no meaningful language to show).
+// Plain-string version of the "Originally asked in: {language}" label,
+// shared by OriginalLanguagePill.js (React, for JSX-rendered surfaces like
+// ExpertFeedbackPanel.js) and any DataTables `render` function (which
+// returns raw HTML strings, not React elements, so can't use the component
+// directly - ChatDashboardPage.js's Question/Answer columns). Both call
+// this rather than duplicating the Intl.DisplayNames lookup.
+//
+// Intl.DisplayNames over a hand-maintained code->name table: it's built
+// into every supported browser, already locale-aware (shows the name in
+// whatever language `lang` is), and covers far more of BCP-47 than this app
+// would want to hand-maintain. Falls back to the raw code on the rare
+// unrecognized/unsupported value rather than showing nothing.
+// One Intl.DisplayNames instance per display `lang`, reused across every
+// languageCode looked up in that language - this is called once per rendered
+// pill (e.g. once per row in a DataTables render function), so constructing
+// a fresh instance per call would mean re-doing the same per-language ICU
+// setup on every row instead of once per dashboard render.
+const displayNamesByLang = new Map();
+function getDisplayNamesFor(lang) {
+  let names = displayNamesByLang.get(lang);
+  if (!names) {
+    names = new Intl.DisplayNames([lang], { type: 'language' });
+    displayNamesByLang.set(lang, names);
+  }
+  return names;
+}
+
+export function getOriginallyAskedInLabel({ languageCode, lang = 'en', t }) {
+  // toLangAttr maps 'und'/'zxx' to undefined, so languageCode is falsy for
+  // those - deliberately no label, an "Originally asked in: Undetermined"
+  // pill wouldn't be meaningful. In practice this can't leave a gap next to
+  // a rendered pill either: runPostTranslationGuardrail hard-blocks both
+  // 'und' and 'zxx' before an answer is ever generated
+  // (agents/graphs/guardrails/translationGuardrail.js), so no interaction
+  // that reaches an eval/review UI can have questionLanguage 'und'/'zxx' in
+  // the first place.
+  if (!languageCode) return '';
+  let displayName = languageCode;
+  try {
+    displayName = getDisplayNamesFor(lang).of(languageCode) || languageCode;
+  } catch (e) {
+    // Intl.DisplayNames throws on a code it can't resolve at all (not just
+    // an unrecognized one, which normally just returns the code back) -
+    // rare, but fall back to the raw code rather than letting this crash
+    // whatever it's rendered inside.
+  }
+  return t('admin.common.originallyAskedIn').replace('{language}', () => displayName);
+}
+
+// TODO(sentence-pairing-risk): callers that map sentences[i] to
+// sentencesEnglish[i] one at a time (ChatInterface.js, FeedbackComponent.js,
+// ExpertFeedbackComponent.js, ExpertFeedbackPanel.js) trust that the two
+// arrays segment 1:1 in the same order. extractSentences (ChatAppContainer.js)
+// only parses the explicit <s-1>...</s-1> tags the model is instructed to
+// emit identically in <answer> and <english-answer> - not
+// punctuation/NLP sentence-splitting - so the risk is narrowly "did the
+// model comply with the tag-count instruction," not a segmentation-algorithm
+// mismatch across languages. Believed rare/unconfirmed in production
+// (verifiable via a ChatViewer JSON export + scripts/check-chat-logs.js
+// --filter answer, per CLAUDE.md); not yet observed, so left as a known,
+// low-probability risk rather than fixed now. If it needs fixing: a naive
+// `sentences.length === sentencesEnglish.length` guard falling back to
+// `english: undefined` is NOT a safe fix on its own - `isSource` below is
+// derived from `hasEnglish`, so that guard silently makes a genuinely
+// non-EN/FR answer look like ordinary already-EN/FR content: the
+// OriginalLanguagePill goes dark in ExpertFeedbackPanel.js/
+// SourceViewComponent.js, and FeedbackComponent.js's `isSource`
+// gate (deciding whether to show "Review the English source text" at all
+// before rating) goes false, meaning a reviewer would be dropped straight
+// into Good/Needs improvement on unreadable text with zero indication
+// translation was needed. A real fix needs `resolveDisplayContent` to
+// distinguish "needed translation but unavailable" from "never needed
+// translation" (e.g. a separate `needsTranslation` field, independent of
+// `hasEnglish`) before any caller can safely fall back to original-only
+// display on a count mismatch.
+export function resolveDisplayContent({ language, original, english }) {
+  const code = (language || '').trim().toLowerCase();
+  const isEnglishOrFrench = code === 'eng' || code === 'en' || code === 'fra' || code === 'fr';
+  if (isEnglishOrFrench || !code) {
+    // No detected language at all (legacy data, or a field this wasn't
+    // wired up for yet) defaults to showing the original text as-is,
+    // untagged — matches current behaviour instead of guessing.
+    return { text: original ?? '', lang: isEnglishOrFrench ? toLangAttr(code) : undefined, isSource: false };
+  }
+  const hasEnglish = typeof english === 'string' && english.trim().length > 0;
+  return {
+    text: hasEnglish ? english : (original ?? ''),
+    lang: hasEnglish ? 'en' : toLangAttr(code),
+    isSource: hasEnglish,
+  };
+}

--- a/src/utils/dashboard/urlLanguage.js
+++ b/src/utils/dashboard/urlLanguage.js
@@ -1,0 +1,25 @@
+// Detects a Canada.ca URL's own language from its path (the reliable
+// `/en/...` or `/fr/...` first segment convention), independent of whatever
+// language the admin dashboard viewing it happens to be set to. Citation/
+// referral URLs shown in a table (CountTable.js) are real, fixed-language
+// content pulled from search results or logged data - unlike admin UI chrome,
+// their `lang` attribute must describe the link's own destination, not the
+// viewer's current page language, or a screen reader announces the wrong
+// pronunciation language for it (WCAG 3.1.2).
+export function detectUrlLanguage(url, fallbackLang = 'en') {
+  if (typeof url !== 'string' || !url) {
+    return fallbackLang;
+  }
+
+  let pathname;
+  try {
+    pathname = new URL(url, 'https://www.canada.ca').pathname;
+  } catch {
+    return fallbackLang;
+  }
+
+  const firstSegment = pathname.split('/').find(Boolean);
+  return firstSegment === 'en' || firstSegment === 'fr' ? firstSegment : fallbackLang;
+}
+
+export default detectUrlLanguage;

--- a/src/utils/dashboard/urlLanguage.test.js
+++ b/src/utils/dashboard/urlLanguage.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { detectUrlLanguage } from './urlLanguage.js';
+
+describe('detectUrlLanguage', () => {
+  it('detects /en/ URLs regardless of the fallback language', () => {
+    expect(detectUrlLanguage('https://www.canada.ca/en/services/taxes.html', 'fr')).toBe('en');
+  });
+
+  it('detects /fr/ URLs regardless of the fallback language', () => {
+    expect(detectUrlLanguage('https://www.canada.ca/fr/services/impots.html', 'en')).toBe('fr');
+  });
+
+  it('falls back to the given language for a URL with no /en//fr/ segment', () => {
+    expect(detectUrlLanguage('https://www.canada.ca/', 'fr')).toBe('fr');
+    expect(detectUrlLanguage('https://example.com/some/other/path', 'en')).toBe('en');
+  });
+
+  it('falls back to "en" by default when no fallback is given', () => {
+    expect(detectUrlLanguage('https://example.com/some/path')).toBe('en');
+  });
+
+  it('falls back safely for non-string/empty/malformed input', () => {
+    expect(detectUrlLanguage(undefined, 'fr')).toBe('fr');
+    expect(detectUrlLanguage(null, 'fr')).toBe('fr');
+    expect(detectUrlLanguage('', 'fr')).toBe('fr');
+    expect(detectUrlLanguage('not a url at all ://', 'fr')).toBe('fr');
+  });
+});

--- a/src/utils/reviewLink.js
+++ b/src/utils/reviewLink.js
@@ -1,8 +1,19 @@
 // Shared "open this chat in review mode" link builders
-// (`/{lang}?chat={chatId}&review=1[#interaction=...]`), used by dashboards
-// (ChatDashboardPage, EvalDashboardPage, AutoEvalDashboardPage,
-// SimilarChatsDashboard) and review panels (ContentIssueChatsCard,
-// EvalAnalysisReport, UsedChatsPanel).
+// (`/{lang}?chat={chatId}&review=1&adminLang={adminLang}[#interaction=...]`),
+// used by dashboards (ChatDashboardPage, EvalDashboardPage,
+// AutoEvalDashboardPage, SimilarChatsDashboard) and review panels
+// (ContentIssueChatsCard, EvalAnalysisReport, UsedChatsPanel).
+//
+// `lang` (the route itself) is the reviewed CHAT's own pageLanguage, not the
+// admin's - the review page's route, and everything embedded in the actual
+// transcript (the answer bubbles, the citation heading), must show what the
+// end user actually experienced (official-languages.md Rule 2), not get
+// swapped for the admin's own preference. `adminLang` carries the admin's
+// own current UI language separately, forward as a query param, for the
+// admin-only chrome around that transcript (ExpertFeedbackPanel, "How was
+// this answer?", Chat ID/Date/Referring URL labels, etc.) to use instead -
+// see HomePage.js's review-mode fetch and ChatAppContainer.js's `adminLang`
+// prop for where this gets read back out and threaded to those components.
 //
 // Two flavours: a plain href for React <GcdsLink>, and a full <gcds-link>
 // HTML string for DataTables render functions, which render raw HTML
@@ -15,6 +26,17 @@ const buildInteractionHash = (interactionId) => {
   return `#interaction=${encodeURIComponent(`interactionId${interactionId}`)}`;
 };
 
+const buildAdminLangParam = (adminLang) =>
+  adminLang ? `&adminLang=${encodeURIComponent(adminLang)}` : '';
+
+// Shared 'en'/'fr' normalization for a stored pageLanguage value (which can
+// be a full BCP-47/ISO tag like 'fr-CA' or 'fra', not just 'fr') - every
+// review-link caller that routes by the reviewed chat's own language needs
+// this same fallback-to-'en' rule, so it lives here once rather than being
+// copy-pasted per dashboard/panel.
+export const chatLangFromPageLanguage = (pageLanguage) =>
+  (pageLanguage && pageLanguage.toLowerCase().includes('fr')) ? 'fr' : 'en';
+
 // Re-exported under this file's existing name so its consumers
 // (ChatDashboardPage.js, EvalDashboardPage.js, UsersPage.js) don't need to
 // change their imports - see htmlEscape.js for the actual implementation,
@@ -23,13 +45,26 @@ const buildInteractionHash = (interactionId) => {
 export const escapeHtmlAttribute = escapeHtml;
 
 // For React <GcdsLink href={...}>.
-export const buildChatReviewHref = (chatId, lang, interactionId) =>
-  `/${lang}?chat=${encodeURIComponent(chatId)}&review=1${buildInteractionHash(interactionId)}`;
+export const buildChatReviewHref = (chatId, lang, interactionId, adminLang) =>
+  `/${lang}?chat=${encodeURIComponent(chatId)}&review=1${buildAdminLangParam(adminLang)}${buildInteractionHash(interactionId)}`;
 
 // For DataTables render funcs: a full <gcds-link> HTML string. The custom
 // element auto-upgrades once inserted and handles the icon/rel/accessible
 // new-tab text itself.
-export const buildChatReviewLinkHtml = (chatId, lang, interactionId) => {
+//
+// The link's `lang` HTML attribute deliberately does NOT use `lang` (the
+// route's language) - the visible text here is always just the opaque
+// chatId, never real content needing destination-language pronunciation
+// (contrast CountTable.js's citation links, where the visible text *is*
+// real content and must match the URL's own language). What `lang` here
+// actually drives is GcdsLink's own auto-generated "(opens in a new tab)"
+// hint text, which is admin-facing navigation chrome - it should match the
+// admin's own current language (adminLang), the same reasoning already
+// applied to ContentIssueChatsCard.js's <GcdsLink>. Falls back to `lang`
+// (the route) only when no adminLang was supplied at all.
+export const buildChatReviewLinkHtml = (chatId, lang, interactionId, adminLang) => {
   const safeId = escapeHtmlAttribute(chatId);
-  return `<gcds-link href="/${lang}?chat=${safeId}&review=1${buildInteractionHash(interactionId)}" target="_blank" lang="${lang}">${safeId}</gcds-link>`;
+  const adminLangParam = adminLang ? `&adminLang=${escapeHtmlAttribute(adminLang)}` : '';
+  const attrLang = escapeHtmlAttribute(adminLang || lang);
+  return `<gcds-link href="/${lang}?chat=${safeId}&review=1${adminLangParam}${buildInteractionHash(interactionId)}" target="_blank" lang="${attrLang}">${safeId}</gcds-link>`;
 };


### PR DESCRIPTION
## Summary

  Fixes WCAG 3.1.2 and Official Languages gaps in how non-EN/FR chat content displays and is tagged.

  - Chat transcript bubbles are now correctly tagged with the real detected language on both sides — question and answer.
  - Citation/referral links in admin dashboard tables (`CountTable.js`) are now tagged with the linked URL's actual language, not the admin dashboard's own UI language — a French-UI admin viewing an `/en/` citation was getting `lang="fr"` on it.

  ### WCAG 2.1.1 (keyboard)

  - Close buttons (`ChatInterface.js`, `SourceViewComponent.js`, `ExpertFeedbackComponent.js`, `PublicFeedbackComponent.js`) now respond to Space as well as Enter, matching native button behaviour.

  ### Official Languages

  - One explicit rule, applied consistently: admin/eval tooling shows EN/FR as themselves and falls back to English for anything else (the AI pipeline never translates to French); the live/review transcript always shows the real language.
  - Reviewers can't rate a non-EN/FR answer without first seeing the English source text AI Answers actually worked from to generate it (not a separate translation — the real draft the final answer was produced from) — that view now also shows the question, not just the answer, so a reviewer can judge relevance, not just prose quality.
  - Wording pass across that flow: pills/tooltip/link text now consistently frame this as "AI Answers' working text" / the English source the AI actually generated from, rather than a generic "translation."
  - A French-UI-only label clarifies that AI Answers' source text is English-only — not a translation being withheld.
  - Clicking through to review a chat now keeps the review page in the admin's own language, so they have access to evaluation tools in their preferred language.
  - Fixed hardcoded English `'N/A'` fallbacks in the expert evaluation table (`ExpertFeedbackPanel.js`) — total score, explanation, source text, English text, and per-sentence score all showed a literal `"N/A"` instead of a translated string.

  ### Also

  - Duplicate column-label keys shared between Chat/Eval dashboards, consolidated.

  ### Testing

  Full chat/dashboard suites pass, new regression tests added, 0 locale parity gaps.