### PR TITLE
fix: batch pages accessibility overhaul (live regions, focus, pause c…

### DIFF
--- a/.claude/skills/accessibility-review/SKILL.md
+++ b/.claude/skills/accessibility-review/SKILL.md
@@ -242,6 +242,56 @@ commits) — check new code follows it rather than reinventing it:
 - Focus is visible — never `outline: none` without a replacement that meets
   contrast requirements (GC DS focus tokens, e.g. `var(--gcds-focus-border)`,
   already provide this — flag any custom override that suppresses it).
+- **A focus-restoration mechanism that removes the interacted-with content
+  entirely (not just re-renders it) needs its own explicit fallback target —
+  don't assume the general remount-consumption path covers this case too.**
+  A common shape: click a control → arm a ref/flag with the clicked item's id
+  → a later redraw/remount consumes it and refocuses. This works when the
+  item survives the redraw (edited, reordered, status-changed). It
+  structurally cannot work when the action's own *success* removes the item
+  from the next render (a delete, a dismiss that also deletes) — nothing
+  ever redraws that id again, so the consuming side never fires and focus
+  drops to `<body>`. This is decidable from the code: find the success path,
+  confirm whether the item is still present in the data the next render
+  works from, and if not, confirm a *different*, explicit redirect exists
+  for that specific branch (e.g. a nearby always-mounted control) rather
+  than reusing the generic redraw-consumption logic. Real example: a delete
+  handler's `finally` block still called the shared re-fetch, and the
+  reviewer's first pass confirmed *a* button gets focused after Process/
+  Cancel — but never separately checked delete's own success path, where the
+  row genuinely never comes back.
+- **When a focus-restoration mechanism picks a target by querying "the first
+  interactive element" rather than the specific one that was clicked, check
+  whether that set's order or membership can vary.** `querySelector('button,
+  [tabindex]')`-style fallbacks silently refocus the *wrong* control whenever
+  the clicked item isn't reliably first — e.g. a row's action buttons differ
+  by status (Cancel before Delete in one branch, Delete alone in another), so
+  clicking Delete and having it fail can land focus on Cancel instead. This
+  is a real, reportable imprecision distinct from "focus dropped to body" —
+  it doesn't fail SC 2.4.3 outright (focus *did* move somewhere sensible-
+  looking) but it's the wrong somewhere, confusing for a keyboard/AT user who
+  clicked one specific thing. Look for whether the restoration mechanism
+  tracks *which* action was clicked (a key/id alongside the item id) or only
+  *that* something was clicked — the latter is the tell.
+- **A focus redirect issued from a handler running in one React root can
+  lose a real timing race against self-focusing content in a *different*
+  React root**, if that content is mounted via its own `createRoot`/manual
+  `root.render()` (a common pattern for cell-level renders inside a
+  non-React table library like DataTables). The separate root's own commit
+  is scheduled independently — a synchronous `.focus()` call issued from an
+  async callback elsewhere can execute *before* that commit lands, and then
+  the other root's self-focusing element (e.g. a "Processing…" placeholder
+  with its own focus-on-mount ref) steals focus right back immediately
+  after. Symptom: a redirect that appears to work when traced through the
+  code, but doesn't hold in a running app or a real test — the target
+  briefly receives focus, then loses it. Not reliably catchable by reasoning
+  about microtask order alone (a second, third microtask tick doesn't fix
+  it) — the redirect needs to run *after* the other root's commit, which
+  generally means a macrotask (`setTimeout`), not another `await`/`Promise.
+  resolve()`. Flag any synchronous or microtask-deferred focus redirect that
+  competes with a separately-rooted self-focusing element as `Needs
+  validation:` at minimum, and as a real finding if a quick trace confirms
+  the other root's commit isn't already guaranteed to have landed first.
 
 ### 4. ARIA usage
 - ARIA attributes are used to *supplement*, not replace, semantics — flag
@@ -261,6 +311,21 @@ commits) — check new code follows it rather than reinventing it:
   repeat. Reserve `Needs validation:` (see "How to review") for what you
   genuinely can't trace — a reset happening in a code path you can't
   follow, or actual AT-timing behavior — not for this.
+- **When the same live-region pattern is duplicated across multiple
+  sections/tabs/instances of one page (one `StatusMessage` per list, per
+  panel, per filter group), check whether the `nonce`/remount-forcing
+  counter is scoped per-instance or shared globally across all of them.** A
+  shared counter means an unrelated change in instance A still bumps the
+  counter instance B's `key`/`nonce` reads too, forcing B to remount even
+  though its own content never changed — and a remount with content already
+  populated is exactly the "fresh insertion" pattern AT generally
+  re-announces, so B's stale, already-heard message gets spoken again for no
+  reason tied to anything the user just did. This is decidable from the
+  code: find every place the nonce state updates, and confirm each `<Status
+  Message nonce={...}>` call site reads a value that only changes when
+  *that* call site's own message does. Report as a real finding (SC 4.1.3)
+  when a single counter/state variable feeds more than one independently-
+  positioned live region.
 - No redundant/conflicting roles (e.g. `role="button"` on an actual
   `<button>`).
 
@@ -344,6 +409,27 @@ commits) — check new code follows it rather than reinventing it:
    unreachable control > missing form label / broken focus management >
    missing ARIA reference > contrast/colour-only signal > minor semantic
    nit.
+5. **When a fix touches focus restoration or a live region, check whether
+   the diff's own test asserts against an independently-known-correct
+   target, not against "whatever the same selector logic the implementation
+   uses would also find."** A test that greps `document.activeElement`
+   against `container.querySelector('button, [tabindex]')` — the exact same
+   first-match query the code under test uses — passes as long as focus
+   lands on *something* the selector matches, even the wrong something; it
+   can never catch a wrong-target bug because it never independently names
+   the target (e.g. "the button whose text is literally 'Delete'"). This is
+   a real gap in test coverage worth calling out on its own, separate from
+   whether the underlying focus behavior itself is correct — a passing
+   suite next to this pattern is not evidence the fix works.
+6. **A fix confirmed by re-reading the conversation is not the same claim as
+   a fix confirmed by re-reading the file.** When re-verifying a finding —
+   your own from earlier in this session, or one handed off by another
+   review — re-read the current file content directly rather than trusting
+   that a fix which was correctly reasoned through in discussion actually
+   landed on disk. Mid-conversation, "traced the right fix" and "wrote the
+   right fix" are easy to conflate, especially across a task switch or a
+   long back-and-forth; grep the file for the specific line/pattern the fix
+   was supposed to introduce before reporting it as done.
 
 For each finding give: the file/line, what's wrong, which WCAG 2.1 AA
 success criterion it violates, and the concrete fix (not just "improve

--- a/src/components/admin/PauseToggleButton.js
+++ b/src/components/admin/PauseToggleButton.js
@@ -8,9 +8,15 @@ import React from 'react';
 // commits, so aria-pressed was always one click behind for screen readers.
 // A designer hasn't signed off on this specific treatment; revisit once
 // reviewed. Pair with usePauseToggle for the state/ref this button controls.
-export default function PauseToggleButton({ isPaused, onToggle, t, className = '' }) {
+//
+// forwardRef: a durable, always-visible, always-mounted focus target near
+// the table - e.g. BatchList.js redirects focus here after a delete, since
+// the deleted row (and whatever had focus on it) is gone and there's
+// nothing left for the usual row-remount focus-restoration to consume.
+const PauseToggleButton = React.forwardRef(({ isPaused, onToggle, t, className = '' }, ref) => {
   return (
     <button
+      ref={ref}
       type="button"
       className={`filter-button filter-button-outline${className ? ` ${className}` : ''}`}
       onClick={onToggle}
@@ -19,4 +25,8 @@ export default function PauseToggleButton({ isPaused, onToggle, t, className = '
       {isPaused ? t('common.resumeUpdates') : t('common.pauseUpdates')}
     </button>
   );
-}
+});
+
+PauseToggleButton.displayName = 'PauseToggleButton';
+
+export default PauseToggleButton;

--- a/src/components/batch/BatchList.js
+++ b/src/components/batch/BatchList.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { getCellRoot } from '../../utils/dataTableCellRoot.js';
+import { buildLabelPillHtml, escapeHtml } from '../../utils/labelPill.js';
 import DataTable from 'datatables.net-react';
 import 'datatables.net-dt/css/dataTables.dataTables.css';
 import DT from 'datatables.net-dt';
@@ -7,18 +8,223 @@ import { GcdsButton } from '@gcds-core/components-react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { usePausablePolling } from '../../hooks/usePauseToggle.js';
 import PauseToggleButton from '../admin/PauseToggleButton.js';
+import StatusMessage from '../admin/StatusMessage.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
 import { formatNumber } from '../../utils/numberFormat.js';
+import { wireTableAccessibility } from '../../utils/admin/dataTableAccessibility.js';
 import BatchService from '../../services/BatchService.js';
 
 DataTable.use(DT);
 
-const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang, processingBatches = [] }) => {
+// Shared render for a row's Actions cell - previously four near-identical
+// copies (one per status branch below), each hand-rolling the same
+// "clicked -> self-focusing placeholder" logic. Consolidated so the focus-
+// restoration fix below (pendingFocusRef) only has to be wired once instead
+// of once per copy, which is exactly how this kind of bug slips into 3 of 4
+// copies and gets missed in the others.
+//
+// Keeps something in the DOM in place of the button (rather than returning
+// null) so focus isn't dropped to <body> the instant it's clicked, and
+// announces the pending state - the row's cell gets replaced for real once
+// `batches` refreshes and the table remounts (see `key={refreshKey}` below).
+const RowActionButtons = ({ batchId, actions, t, pendingFocusRef }) => {
+  const [clicked, setClicked] = useState(false);
+  // Which `instant` actions (see the actions.map below) currently have an
+  // in-flight async call - CSV/Excel export specifically. Unlike Process/
+  // Delete/Cancel, exporting doesn't warrant swapping the whole row for the
+  // "Processing…" placeholder (it's a near-instant download trigger, not a
+  // multi-second operation, and BatchPage.js's own page-level StatusMessage
+  // already announces the outcome) - this only disables the one button that
+  // was actually clicked, for exactly as long as its own export call is
+  // pending, so a second click on the same button while the first download
+  // is still in flight can't fire a duplicate.
+  const [pendingKeys, setPendingKeys] = useState(() => new Set());
+  const containerRef = useRef(null);
+
+  // Runs after every commit of this cell's content — i.e. once per
+  // createdRow draw of this row, since getCellRoot mounts a brand new React
+  // root (and therefore a brand new instance of this component) on every
+  // draw rather than reusing one. If this draw is the one immediately
+  // following a click on this exact row (armed by the onClick handler
+  // below, consumed here so a later *unrelated* remount — e.g. the 10s
+  // poll, pausable via the control above — doesn't keep stealing focus back
+  // to a row the user has since moved on from), focus whatever this draw
+  // actually rendered instead of leaving it to drop to <body> the way the
+  // whole-table remount otherwise would. useEffect (not a plain post-render
+  // querySelector) specifically because it's guaranteed to run only after
+  // this render has actually committed to the DOM — the earlier version of
+  // this fix queried the DOM immediately after root.render() and raced
+  // React's own commit timing, intermittently focusing nothing at all.
+  useEffect(() => {
+    if (!pendingFocusRef.current.has(batchId)) return;
+    const clickedKey = pendingFocusRef.current.get(batchId);
+    pendingFocusRef.current.delete(batchId);
+    // gcds-button is a shadow-DOM custom element with delegatesFocus: true
+    // (Stencil) — .focus() on the host element itself correctly delegates
+    // into its internal <button>, but a light-DOM querySelector('button')
+    // won't match the host's own tag name, so it has to be named explicitly
+    // alongside the plain-<button>/[tabindex] cases (the "Processing…"
+    // placeholder below, and any future native control in this cell).
+    //
+    // Prefer the exact button that was clicked (data-action-key, set below)
+    // over just "the row's first interactive element" - the actions array's
+    // order isn't fixed across status branches (e.g. Cancel comes first in
+    // one branch, Delete second in another), so grabbing the first match
+    // can land focus on a completely different control than the one the
+    // user actually clicked. Falls back to the first match only if that
+    // specific action no longer exists in the redrawn row (e.g. the status
+    // branch changed enough that the clicked action isn't offered anymore).
+    const target = (clickedKey && containerRef.current?.querySelector(`[data-action-key="${clickedKey}"]`))
+      || containerRef.current?.querySelector('gcds-button, button, [tabindex]');
+    target?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (clicked) {
+    return (
+      <span role="status" aria-live="polite" tabIndex={-1} ref={(el) => el?.focus()}>
+        {t('common.processing')}
+      </span>
+    );
+  }
+  return (
+    <div ref={containerRef} className="table-row-actions" style={{ display: 'flex', gap: '8px' }}>
+      {actions.map(({ key, label, icon, buttonRole, disabled, instant, onClick }) => (
+        <GcdsButton
+          key={key}
+          data-action-key={key}
+          size="small"
+          buttonRole={buttonRole}
+          disabled={disabled || pendingKeys.has(key)}
+          onClick={async () => {
+            if (instant) {
+              // No pendingFocusRef/clicked-placeholder dance for these -
+              // nothing is about to remount just because an export ran, so
+              // there's no focus to rescue, just this one button to
+              // temporarily disable against a double click.
+              setPendingKeys((prev) => new Set(prev).add(key));
+              try {
+                await onClick();
+              } finally {
+                setPendingKeys((prev) => {
+                  const next = new Set(prev);
+                  next.delete(key);
+                  return next;
+                });
+              }
+              return;
+            }
+            // Arm the focus-restoration effect above *before* the click
+            // handler runs — onProcess/onDelete/etc. can synchronously
+            // trigger a `processingBatches`/`batches` change that bumps
+            // `refreshKey`, remounting the whole DataTable (and this cell's
+            // React root along with it) before the `clicked` placeholder
+            // below ever gets to keep its own self-focus.
+            pendingFocusRef.current.set(batchId, key);
+            // A handler can return `false` to mean "the user backed out"
+            // (e.g. handleDelete's window.confirm being cancelled) — don't
+            // show the pending placeholder for that, and nothing is about
+            // to remount, so clear the pending-focus request too.
+            if (onClick() === false) {
+              pendingFocusRef.current.delete(batchId);
+              return;
+            }
+            setClicked(true);
+          }}
+        >
+          {/* Purely decorative - the button's text (label) is already the
+              full accessible name, matching StatusMessage.js's own
+              raw-FA-icon precedent (GC DS's icon font has no download
+              glyph, hence fa- instead of GcdsIcon here too). inline-flex
+              wrapper, not just the icon span alone: GcdsButton's own
+              shadow-DOM slot stacks its light-DOM children in a column by
+              default, so an icon + text passed as two siblings rendered
+              icon-above-text instead of side by side - forcing our own
+              horizontal layout on the wrapper doesn't depend on what the
+              slot itself does with it. */}
+          {icon ? (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4em' }}>
+              <span className={`fa fa-solid fa-${icon}`} aria-hidden="true"></span>
+              {label}
+            </span>
+          ) : label}
+        </GcdsButton>
+      ))}
+    </div>
+  );
+};
+
+const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang, processingBatches = [], announceCompletions = false }) => {
   const [batches, setBatches] = useState([]);
   const [searchText] = useState('');
   // refreshKey forces the DataTable to remount when batches change
   const [refreshKey, setRefreshKey] = useState(0);
   const { t } = useTranslations(lang);
+
+  // Single sr-only, persistent live region shared by every announcement this
+  // component makes (pause/resume, batch completions below) - one region,
+  // not one per event type, so a screen reader user doesn't have several
+  // near-simultaneous live regions competing. nonce forces a remount on
+  // every trigger (see StatusMessage.js's own doc comment) so two
+  // back-to-back announcements with coincidentally identical text - e.g.
+  // pausing twice, or two different batches sharing a name completing in
+  // separate polls - both still get announced instead of the second being a
+  // silent no-op React bails on.
+  const [announcement, setAnnouncement] = useState('');
+  const [announceNonce, setAnnounceNonce] = useState(0);
+  const announce = useCallback((message) => {
+    setAnnouncement(message);
+    setAnnounceNonce((n) => n + 1);
+  }, []);
+
+  // Tracks whether the *previous* render was paused, so the resume
+  // announcement only fires on an actual paused->resumed transition, not on
+  // initial mount (which also starts "not paused").
+  const wasPausedRef = useRef(false);
+
+  // batchId -> normalized status, from the *previous* fetch - lets
+  // fetchBatches below tell "just became processed" apart from "was already
+  // processed last time too" or "first time we've ever seen this batch".
+  const prevStatusMapRef = useRef(new Map());
+
+  // Whether the *previous* render's filtered list was empty - lets the
+  // remount effect below tell "still nothing to show" apart from "something
+  // actually changed." Starts true: nothing's rendered yet on mount either way.
+  const wasEmptyRef = useRef(true);
+
+  // The user's last-chosen sort, carried across the poll-driven remounts
+  // below. Unlike ChatDashboardPage.js/EvalDashboardPage.js, which keep one
+  // DataTables instance alive across a poll (updating its data via
+  // ajax.reload(), so sort/search/page state just naturally survives), this
+  // table remounts a *fresh* DataTables instance on every poll tick (see
+  // key={refreshKey} - needed so row action cells pick up the latest
+  // processingBatches closure). A fresh instance has no memory of its
+  // predecessor, so without this, `order` in options below would silently
+  // reset to the hardcoded default every ~10s, discarding whatever column
+  // the user just clicked to sort by. `initComplete`'s order.dt listener
+  // keeps this updated; the `order` option and the explicit re-sort both
+  // read from it instead of a literal, so each new instance picks up where
+  // the last one left off.
+  const sortOrderRef = useRef([[2, 'desc']]);
+
+  // See handleDelete's own comment - the durable focus target a successful
+  // delete redirects to, since the deleted row's own focus restoration
+  // structurally can't happen.
+  const pauseButtonRef = useRef(null);
+
+  // Maps every batch _id RowActionButtons has armed for focus restoration to
+  // the specific action key that was clicked (added the instant a button is
+  // clicked, consumed/removed once that row's cell re-renders after the
+  // remount below). A Map, not a single scalar: a plain "last clicked id"
+  // would get clobbered if a second row's button is clicked before the
+  // first row's remount lands, silently dropping the first row's focus
+  // restoration. Keyed by action (not just batchId) so the redraw-
+  // consumption path can refocus the *specific* control that was clicked -
+  // see RowActionButtons' own comment for why grabbing the row's first
+  // interactive element isn't good enough (e.g. Cancel is the first button
+  // in some status branches, Delete the second - clicking Delete and
+  // landing back on Cancel is exactly the bug this key exists to prevent).
+  const pendingFocusRef = useRef(new Map());
 
   // Fetch all statuses
   const fetchStatuses = useCallback(async (batches) => {
@@ -52,7 +258,7 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
   // Memoize the columns configuration to prevent unnecessary re-renders
   const columns = useMemo(
     () => [
-  { title: t('batch.list.columns.batchName'), data: 'name' },
+      { title: t('batch.list.columns.batchName'), data: 'name' },
       {
         title: t('batch.list.columns.batchId'),
         data: null,
@@ -62,26 +268,62 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
         },
       },
       { title: t('batch.list.columns.createdDate'), data: 'createdAt' },
-  { title: t('batch.list.columns.provider'), data: 'aiProvider' },
-  { title: t('batch.list.columns.workflow'), data: 'workflow' },
-  {
-    title: t('batch.list.columns.type'),
-    data: 'type',
-    render: (data) => t(`batch.list.types.${data}`) || data,
-  },
-  {
-    title: t('batch.list.columns.status'),
-    data: 'status',
-    render: (data) => {
-      const normalized = normalizeStatus(data);
-      return t(`batch.list.statuses.${normalized}`) || normalized;
-    },
-  },
-      { title: t('batch.list.columns.totals'), data: null },
+      { title: t('batch.list.columns.provider'), data: 'aiProvider' },
+      { title: t('batch.list.columns.workflow'), data: 'workflow' },
       {
+        title: t('batch.list.columns.type'),
+        data: 'type',
+        render: (data) => t(`batch.list.types.${data}`) || data,
+      },
+      {
+        title: t('batch.list.columns.status'),
+        data: 'status',
+        render: (data) => {
+          const normalized = normalizeStatus(data);
+          const label = t(`batch.list.statuses.${normalized}`) || normalized;
+          // Pill treatment matches Chat/Eval dashboards' shared .label
+          // colour tiers (admin.css) - each status's own name is the CSS
+          // class, and admin.css chains it onto the tier it belongs to
+          // (see that file's comments): processed -> green, in_progress ->
+          // blue, uploaded -> grey, unknown -> yellow. These four are the
+          // *only* statuses this column can ever actually show:
+          // BatchService.getBatchStatuses recomputes `status` from item
+          // stats on every fetch and only ever produces one of these four -
+          // completed/failed/validating/finalizing/expired/canceled can
+          // never reach this render function no matter what's stored in the
+          // DB, so they don't get a pill (or a colour decision) at all.
+          const pillStatuses = ['processed', 'in_progress', 'uploaded', 'unknown'];
+          if (pillStatuses.includes(normalized)) {
+            return buildLabelPillHtml(normalized, label);
+          }
+          return escapeHtml(label);
+        },
+      },
+      {
+        // Content is written straight into the cell via totalsCell.innerText
+        // in createdRow below, entirely outside DataTables' own data/render
+        // pipeline (data: null with no render function) - DataTables has no
+        // value to sort or search on here, unlike the Batch ID column above
+        // (data: null too, but its render() return value IS what DataTables
+        // sorts/searches against). Same reasoning as ChatDashboardPage.js/
+        // EvalDashboardPage.js marking their own DOM-injected/non-data
+        // columns orderable: false rather than leaving DataTables' default
+        // (orderable: true) to sort on nothing.
+        title: t('batch.list.columns.totals'),
+        data: null,
+        orderable: false,
+        searchable: false,
+      },
+      {
+        // Same reasoning as the Totals column above, plus this one's content
+        // is a row of buttons (React-rendered via createdRow), not text -
+        // "sorting"/"searching" button labels doesn't mean anything. Matches
+        // ChatDashboardPage.js's own action-type column.
         title: t('batch.list.columns.action'),
         data: null,
         defaultContent: '',
+        orderable: false,
+        searchable: false,
       },
     ],
     [t]
@@ -92,51 +334,74 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
     try {
       const batches = await BatchService.getBatchList();
       const updatedBatches = await fetchStatuses(batches) || batches || [];
-      setBatches(Array.isArray(updatedBatches) ? updatedBatches : []);
+      const list = Array.isArray(updatedBatches) ? updatedBatches : [];
+
+      // Relevant to know regardless of which section (Incomplete/Completed)
+      // the admin is looking at - a batch finishing is exactly the kind of
+      // change polling exists to surface, and unlike every other change
+      // this table announces, it's not tied to something the admin just
+      // clicked themselves. announceCompletions gates this to a single
+      // BatchList instance (see BatchPage.js) - getBatchList() returns
+      // every batch regardless of the batchStatus this instance filters to,
+      // so both instances would otherwise detect and announce the same
+      // transition at the same time.
+      if (announceCompletions) {
+        const newlyCompleted = [];
+        // A batch failing mid-run (a backend error, not a click the admin
+        // made) would be just as worth announcing as a completion - but
+        // there's no way to detect it from here: `status` above always
+        // comes from BatchService.getBatchStatuses, which recomputes it
+        // purely from item stats into one of unknown/uploaded/processed/
+        // processing - 'failed' is never one of the values it produces, no
+        // matter what's actually stored server-side. A real "batch failed"
+        // announcement needs getBatchStatuses itself to expose that as its
+        // own signal (e.g. surfacing stats.failed distinctly) before this
+        // can detect it - not implemented here, flagging as a TODO rather
+        // than a dead branch that silently never fires.
+        for (const b of list) {
+          const id = String(b._id || b.id);
+          const status = normalizeStatus(b.status);
+          const prevStatus = prevStatusMapRef.current.get(id);
+          // prevStatus === undefined means this is the first time this
+          // instance has ever seen the batch (initial load, or a batch
+          // created after mount) - not a completion event, just its
+          // starting state, so it's excluded rather than announced.
+          if (prevStatus === undefined) continue;
+          if (status === 'processed' && prevStatus !== 'processed') {
+            newlyCompleted.push(b.name || id);
+          }
+        }
+        prevStatusMapRef.current = new Map(list.map((b) => [String(b._id || b.id), normalizeStatus(b.status)]));
+        if (newlyCompleted.length) {
+          announce(t('batch.list.completedAnnouncement').replace('{names}', () => newlyCompleted.join(', ')));
+        }
+      }
+
+      setBatches(list);
     } catch (error) {
       console.error('Error fetching batches:', error);
     }
-  }, [fetchStatuses]);
+  }, [fetchStatuses, announceCompletions, announce, t]);
 
   // WCAG 2.2.2 (Pause, Stop, Hide): the 10s poll below keeps rebuilding the
   // table, which is exactly the kind of auto-updating content that
   // criterion requires a way to stop.
   const { isPaused, togglePause } = usePausablePolling(fetchBatches, 10000, [lang, fetchBatches]);
 
-  // Whenever batches or local processing markers change, bump the
-  // refresh key so DataTable remounts. This ensures the action buttons that
-  // are rendered into table cells (via createRoot) see the latest
-  // `processingBatches` value and update immediately when the user clicks
-  // Process instead of waiting for the next polling cycle.
-  // Note: lang is intentionally excluded — language switches always trigger
-  // full page navigation so the component remounts naturally with the correct lang.
-  //
-  // TODO(a11y): this remount undermines the "keep something in the DOM so
-  // focus isn't dropped to <body>" fix on the row action buttons below.
-  // Process marks processingBatches synchronously on click, which bumps
-  // refreshKey almost immediately and tears down the just-focused
-  // "Processing…" span; Delete/Cancel/Export lose it more slowly via the
-  // 10s poll on `batches`. Either avoid remounting the whole table on every
-  // tick (diff the changed row instead), or capture document.activeElement
-  // before the remount and restore focus after redraw, as done in
-  // DashboardFilterBar.js / useExperimentalBatchItems.js.
+  // Pause/resume announcement - shares the same sr-only region as
+  // completions above rather than its own, see `announce`'s own comment.
   useEffect(() => {
-    setRefreshKey((r) => r + 1);
-  }, [batches, processingBatches]);
-
-  // Handle button actions mapped to explicit handlers
-  const handleExport = (batchId, type) => onExport && onExport(batchId, type);
-  const handleDelete = (batchId) => {
-    if (!window.confirm(t('batch.list.actions.confirmDelete'))) return false;
-    onDelete && onDelete(batchId);
-    return true;
-  };
-  // Pass workflow through when invoking onProcess so restarts can reuse the saved workflow
-  const handleProcess = (batchId, provider, workflow) => onProcess && onProcess(batchId, provider, workflow);
-  const handleCancel = (batchId, provider) => onCancel && onCancel(batchId, provider);
+    if (isPaused) {
+      announce(t('common.pausedIndicator'));
+    } else if (wasPausedRef.current) {
+      announce(t('common.resumedIndicator'));
+    }
+    wasPausedRef.current = isPaused;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPaused]);
 
   // Filter batches based on batchStatus and search text (use normalized status)
-  const filteredBatches = (batches || []).filter((batch) => {
+  const filteredBatches = useMemo(() => (batches || []).filter((batch) => {
     const norm = normalizeStatus(batch.status);
     const desired = (batchStatus || '').split(',').map((s) => s.trim()).filter(Boolean);
     // If caller asked for the umbrella "incomplete" group, include unknown statuses
@@ -149,251 +414,361 @@ const BatchList = ({ onProcess, onCancel, onDelete, onExport, batchStatus, lang,
         value?.toString().toLowerCase().includes(searchText.toLowerCase())
       )
     );
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [batches, batchStatus, searchText]);
+
+  // Whenever the *filtered* list or local processing markers change, bump
+  // the refresh key so DataTable remounts. This ensures the action buttons
+  // rendered into table cells (via createRoot) see the latest
+  // `processingBatches` value and update immediately when the user clicks
+  // Process instead of waiting for the next polling cycle.
+  // Note: lang is intentionally excluded — language switches always trigger
+  // full page navigation so the component remounts naturally with the correct lang.
+  //
+  // Two things this list is deliberately frozen against while `isPaused`:
+  //   1. Its own 10s poll, via usePausablePolling's guardPoll - already
+  //      true before this fix, `batches` simply doesn't update while paused.
+  //   2. `processingBatches` - NOT already handled: it's shared BatchPage.js
+  //      state, passed identically to *both* BatchList instances (Incomplete
+  //      and Completed batches), so clicking Process in one list bumped this
+  //      list's own refreshKey too, remounting it regardless of whether
+  //      *this* list's own pause button was on. That's the "pause controls
+  //      cancel each other out" bug - pausing one list never actually froze
+  //      it against activity in the other. Gating the whole effect on
+  //      `isPaused` (not just the fetch) fixes both at once, and doubles as
+  //      "catch up now" on resume: isPaused is a dependency, so flipping it
+  //      back to false re-runs this effect immediately with whatever
+  //      changed while frozen, rather than waiting for the next poll tick.
+  //
+  // Exception, independent of pause: an empty list polling into another
+  // empty list has nothing to remount for - every row-level closure this
+  // remount exists to refresh belongs to a row, and there are none. Skipping
+  // that no-op remount is what stops this list (e.g. "Incomplete batches"
+  // once nothing's left incomplete) from visibly flickering every 10s for as
+  // long as it stays empty.
+  useEffect(() => {
+    if (isPaused) return;
+    const isEmpty = filteredBatches.length === 0;
+    if (isEmpty && wasEmptyRef.current) return;
+    wasEmptyRef.current = isEmpty;
+    setRefreshKey((r) => r + 1);
+  }, [filteredBatches, processingBatches, isPaused]);
+
+  // Handle button actions mapped to explicit handlers
+  const handleExport = (batchId, type, batchName) => onExport && onExport(batchId, type, batchName);
+  const handleDelete = (batchId, batchName) => {
+    // window.confirm()'s own chrome (title bar, OK/Cancel) is fixed browser
+    // styling, but the message text is ours - naming the batch instead of
+    // "this batch" matters here specifically because a delete confirm can
+    // be triggered from a keyboard-focused button with no visual context
+    // (which row it belongs to) still on screen once the dialog covers it.
+    const message = batchName
+      ? t('batch.list.actions.confirmDeleteNamed').replace('{name}', () => batchName)
+      : t('batch.list.actions.confirmDelete');
+    if (!window.confirm(message)) return false;
+    (async () => {
+      try {
+        // onDelete resolves true/false (BatchPage.js) rather than
+        // throwing on failure - it already owns its own page-level
+        // success/error StatusMessage, so this only needs the boolean to
+        // decide whether to name the batch in the shared sr-only region
+        // below, not to duplicate that outcome text itself.
+        const succeeded = await (onDelete && onDelete(batchId, batchName));
+        if (succeeded) {
+          if (batchName) {
+            announce(t('batch.list.deletedAnnouncement').replace('{name}', () => batchName));
+          }
+          // A deleted row never comes back on the next fetch, so createdRow
+          // never runs for this batchId again - the usual
+          // pendingFocusRef-consumption path (RowActionButtons' own effect)
+          // structurally can't fire, and the table remount below would
+          // otherwise tear down the self-focused "Processing…" placeholder
+          // with nothing left to catch focus, dropping it to <body>. Clear
+          // the now-unconsumable entry and land focus somewhere durable and
+          // visible instead - the pause button is the nearest always-
+          // mounted, always-visible control, not torn down by the remount
+          // (it lives outside the remounted DataTable subtree).
+          pendingFocusRef.current.delete(batchId);
+          // Deferred, not called directly here: RowActionButtons' cell is
+          // its own separate React root (getCellRoot/createRoot), and the
+          // "Processing…" placeholder's self-focus (its own ref callback,
+          // still mounted at this exact moment) is scheduled through that
+          // root's own commit - which resolves *after* this microtask, so
+          // calling focus() synchronously here loses the race the instant
+          // that commit lands and the placeholder re-focuses itself.
+          // setTimeout (a real macrotask) reliably runs after React's own
+          // scheduled commit settles, unlike another microtask tick.
+          setTimeout(() => pauseButtonRef.current?.focus(), 0);
+        }
+      } catch (err) {
+        // onDelete doesn't currently throw (BatchPage.js's always resolves
+        // true/false), but this is a fire-and-forget IIFE with nothing else
+        // awaiting it - an uncaught rejection here would otherwise surface
+        // as an unhandled promise rejection with no user-facing feedback at
+        // all, rather than just missing the announcement.
+        console.error('Error deleting batch:', err);
+      } finally {
+        // Reflect the delete as soon as it actually finishes instead of
+        // waiting up to 10s for the next scheduled poll - the delete
+        // request itself is fast, the lag users were seeing was purely the
+        // UI not refetching until the next tick. Respects pause rather than
+        // bypassing it, though: fetchBatches() is only called here directly
+        // (not through the poll's guardPoll) so it's not itself gated by
+        // isPaused - checking it explicitly keeps a paused view genuinely
+        // frozen, same as everywhere else in this file, rather than this
+        // one action quietly overriding the user's own pause choice.
+        if (!isPaused) fetchBatches();
+      }
+    })();
+    return true;
+  };
+  // Pass workflow through when invoking onProcess so restarts can reuse the saved workflow
+  const handleProcess = (batchId, provider, workflow, batchName) => {
+    // Starting a process is a much stronger signal than "leave this alone
+    // while I read the table" (what pause is for) - the opposite, really:
+    // agreeing to kick something off implies wanting to watch it move,
+    // and while paused, this row's own outcome (Process disabling, its
+    // status/totals advancing) would otherwise sit frozen right alongside
+    // the button you just clicked to start it. Simpler than trying to
+    // special-case "this one action stays live while everything else
+    // around it stays frozen" - just resume.
+    //
+    // Resuming un-skips the *next* scheduled poll tick, but that tick is on
+    // its own 10s clock (usePausablePolling) and doesn't reset just because
+    // we resumed - so without an explicit fetch here, the table can sit
+    // looking frozen for up to 10s after a click that was supposed to make
+    // it live again. Force an immediate refetch the same way handleDelete
+    // does, instead of waiting on the poll.
+    if (isPaused) {
+      togglePause();
+      fetchBatches();
+    }
+    onProcess && onProcess(batchId, provider, workflow, batchName);
+  };
+  const handleCancel = (batchId, provider, batchName) => onCancel && onCancel(batchId, provider, batchName);
 
   return (
     <div>
-      <PauseToggleButton isPaused={isPaused} onToggle={togglePause} t={t} className="mb-200" />
-      <DataTable
-        data={filteredBatches}
-        columns={columns} // Use memoized columns
-        options={{
-          paging: true,
-          searching: true,
-          ordering: true,
-          order: [[2, 'desc']], // Order by Created Date (createdAt column) descending
-          language: dataTableLanguage(lang),
-          createdRow: (row, data) => {
-            const { _id, status: rawStatus, aiProvider } = data;
-            const status = normalizeStatus(rawStatus);
-            const cells = row.querySelectorAll('td');
-            // Totals column is after status - find it as the cell before the actions cell
-            const actionsCell = row.querySelector('td:last-child');
-            const totalsCell = actionsCell ? actionsCell.previousElementSibling : cells[cells.length - 2];
-            // Populate totals: prefer stats from service, fallback to 0/0
-            try {
+      <PauseToggleButton ref={pauseButtonRef} isPaused={isPaused} onToggle={togglePause} t={t} className="mb-200" />
+      {/* sr-only + persistent: the accessible half only, shared by every
+          announcement this component makes (pause, resume, batch
+          completions - see `announce`'s own comment above), same pattern as
+          ChatDashboardPage.js/EvalDashboardPage.js's own persistent sr-only
+          search-announcement StatusMessage. Decoupled from the visible
+          pause badge below on purpose - that badge only ever reflects
+          isPaused, but this region also has to carry completion
+          announcements the badge has no visual counterpart for. */}
+      <StatusMessage variant="info" persistent nonce={announceNonce} message={announcement || undefined} className="sr-only" />
+      {/* Visible half - purely decorative (aria-hidden; the sr-only
+          StatusMessage above is the real announcement), a design element
+          rather than a StatusMessage box: reassures a sighted user the
+          table genuinely isn't about to redraw out from under them, not
+          "this table is disabled" - doesn't dim/fade the table itself,
+          since every row action stays fully usable while paused (only the
+          10s auto-refresh poll stops). */}
+      {isPaused && (
+        <div className="dashboard-table-paused-indicator mb-200" aria-hidden="true">
+          <span className="fa fa-solid fa-pause" aria-hidden="true"></span>
+          {t('common.pausedIndicator')}
+        </div>
+      )}
+      <div className="dashboard-table-container">
+        <DataTable
+          data={filteredBatches}
+          columns={columns} // Use memoized columns
+          // Same base classes as ChatDashboardPage.js/EvalDashboardPage.js's
+          // tables - dashboard-table is what every sort-icon/sort-column
+          // rule in admin.css is scoped to (table.dataTable.dashboard-table
+          // thead > tr > th...), so without it sortable headers render with
+          // DataTables' own unstyled defaults instead of matching those
+          // pages. No --grouped modifier: that's specific to their rowspan
+          // grouping (multi-turn chats sharing a Chat ID), which this table
+          // doesn't have - one row per batch, always. zebra-stable-on-hover
+          // is a general-purpose utility (admin.css) for any `display`-class
+          // DataTable that wants its zebra stripe to look identical whether
+          // or not the pointer is over the row - not specific to this table,
+          // reusable on others that want the same thing.
+          className="display dashboard-table zebra-stable-on-hover"
+          options={{
+            paging: true,
+            searching: true,
+            ordering: true,
+            // Read from sortOrderRef, not a literal - carries the user's
+            // last-chosen sort across this table's poll-driven remounts
+            // instead of always resetting to Created Date desc. See
+            // sortOrderRef's own comment above for why that's necessary here
+            // specifically (unlike Chat/Eval's tables, which never remount).
+            order: sortOrderRef.current,
+            // Search top-left, entries-per-page + "Showing X to Y of Z" both
+            // bottom-left above pagination, paging alone bottom-right - same
+            // shared layout as ChatDashboardPage.js/EvalDashboardPage.js's
+            // tables, not this table inventing its own placement.
+            layout: {
+              topStart: 'search',
+              topEnd: {},
+              bottomStart: { features: ['pageLength', 'info'] },
+              bottomEnd: 'paging',
+            },
+            language: {
+              ...dataTableLanguage(lang),
+              // "Search:" label is genuinely shared (admin.common.searchLabel),
+              // but the *placeholder* isn't — admin.common.searchPlaceholder
+              // ("e.g. tax, contact, account") is Chat/Eval-dashboard-specific
+              // example text (topics people ask AI Answers about), meaningless
+              // here where search runs over batch name/ID/provider/etc. Own
+              // key instead of reusing a placeholder that doesn't fit.
+              search: t('admin.common.searchLabel'),
+              searchPlaceholder: t('batch.list.searchPlaceholder'),
+            },
+            initComplete: function () {
+              const api = this.api();
+              try {
+                wireTableAccessibility(api, { t });
+              } catch (e) {
+                console.error('BatchList: wireTableAccessibility failed', e);
+              }
+              try {
+                // Keeps sortOrderRef current so the *next* remount (10s
+                // poll) starts from wherever the user just sorted to,
+                // instead of resetting - see sortOrderRef's own comment.
+                api.on('order.dt', () => { sortOrderRef.current = api.order(); });
+              } catch (e) {
+                console.error('BatchList: order.dt listener registration failed', e);
+              }
+            },
+            createdRow: (row, data) => {
+              const { _id, status: rawStatus, aiProvider } = data;
+              const status = normalizeStatus(rawStatus);
+              const batchId = String(_id);
+              const cells = row.querySelectorAll('td');
+              // Manually paint DataTables' own .sorting_1/2/3 classes onto
+              // the currently-sorted column's cell(s), instead of relying on
+              // DataTables' internal classing (_fnSortingClasses), which
+              // only reruns on redraw once its own internal `bSorted` flag
+              // is set - true automatically for server-side tables, but for
+              // this client-side one (data prop, no ajax) that flag needs an
+              // explicit sort *action*, and three different ways of
+              // triggering one through the DataTables API from initComplete
+              // (synchronously, deferred via setTimeout, different `order`
+              // values) all failed to make it stick. Doing it directly here
+              // sidesteps that internal machinery entirely - createdRow
+              // already reliably runs per row (the action buttons prove it),
+              // and the class names are the only thing admin.css's existing
+              // sort-highlight rules (table.dataTable.display > tbody tr >
+              // .sorting_1, already shared with Chat/Eval) actually need;
+              // nothing else about how DataTables tracks sorting internally
+              // matters for the CSS to apply.
+              cells.forEach((cell) => cell.classList.remove('sorting_1', 'sorting_2', 'sorting_3'));
+              (sortOrderRef.current || []).forEach(([colIndex], i) => {
+                if (i > 2) return; // admin.css/DataTables only define sorting_1/2/3
+                const cell = cells[colIndex];
+                if (cell) cell.classList.add(`sorting_${i + 1}`);
+              });
+              // Totals column is after status - find it as the cell before the actions cell
+              const actionsCell = row.querySelector('td:last-child');
+              const totalsCell = actionsCell ? actionsCell.previousElementSibling : cells[cells.length - 2];
+              // Populate totals: prefer stats from service, fallback to 0/0
+              try {
+                const stats = data.stats || {};
+                const total = Number(stats.total || 0);
+                const processed = Number(stats.processed || 0);
+                const failed = Number(stats.failed || 0);
+                const finished = Number(stats.finished ?? processed + failed);
+                if (totalsCell) {
+                  totalsCell.innerText = t('batch.list.totalsLabel').replace('{finished}', formatNumber(finished, lang)).replace('{total}', formatNumber(total, lang));
+                }
+              } catch (e) {
+                // ignore totals rendering errors
+              }
+              // Unmounts any previous root mounted on this cell before creating
+              // the new one, so redraws don't leak roots.
+              const root = getCellRoot(actionsCell);
+
+              // If processed >= total show download/delete actions
               const stats = data.stats || {};
               const total = Number(stats.total || 0);
-              const processed = Number(stats.processed || 0);
-              const failed = Number(stats.failed || 0);
-              const finished = Number(stats.finished ?? processed + failed);
-              if (totalsCell) {
-                totalsCell.innerText = t('batch.list.totalsLabel').replace('{finished}', formatNumber(finished, lang)).replace('{total}', formatNumber(total, lang));
+              const processedCount = Number(stats.processed || 0);
+              const failedCount = Number(stats.failed || 0);
+              const finishedCount = Number(stats.finished ?? processedCount + failedCount);
+              // Show both Process and Delete buttons for running batches
+              const isLocallyProcessing = processingBatches.includes(batchId);
+              const workflow = data.workflow || data?.workflow || 'Default';
+
+              const deleteAction = {
+                key: 'delete',
+                label: t('batch.list.actions.delete'),
+                buttonRole: 'danger',
+                onClick: () => handleDelete(_id, data.name),
+              };
+
+              let actions;
+              if (
+                (finishedCount >= total && status === 'processed') ||
+                ['in_progress', 'processing', 'inprogress'].includes(status)
+              ) {
+                actions = [
+                  ...(finishedCount >= total && status === 'processed'
+                    ? [
+                        { key: 'csv', label: t('batch.list.actions.csv'), icon: 'download', instant: true, onClick: () => handleExport(_id, 'csv', data.name) },
+                        { key: 'excel', label: t('batch.list.actions.excel'), icon: 'download', instant: true, onClick: () => handleExport(_id, 'excel', data.name) },
+                      ]
+                    : []),
+                  ...(['in_progress', 'processing', 'inprogress'].includes(status) || finishedCount < total
+                    ? [
+                        {
+                          key: 'process',
+                          label: t('batch.list.actions.process'),
+                          disabled: isLocallyProcessing,
+                          onClick: () => {
+                            // Don't allow pressing Process if this batch is marked locally processing
+                            if (isLocallyProcessing) return false;
+                            handleProcess(_id, aiProvider, workflow, data.name);
+                          },
+                        },
+                      ]
+                    : []),
+                  deleteAction,
+                ];
+              } else if (finishedCount < total || total === 0) {
+                actions = [
+                  {
+                    key: 'process',
+                    label: t('batch.list.actions.process'),
+                    disabled: isLocallyProcessing,
+                    onClick: () => {
+                      if (isLocallyProcessing) return false;
+                      handleProcess(_id, aiProvider, workflow, data.name);
+                    },
+                  },
+                  deleteAction,
+                ];
+              } else if (status === 'completed') {
+                actions = [
+                  { key: 'process', label: t('batch.list.actions.process'), onClick: () => handleProcess(_id, aiProvider, workflow, data.name) },
+                  deleteAction,
+                ];
+              } else {
+                actions = [
+                  { key: 'cancel', label: t('batch.list.actions.cancel'), onClick: () => handleCancel(_id, aiProvider, data.name) },
+                  deleteAction,
+                ];
               }
-            } catch (e) {
-              // ignore totals rendering errors
-            }
-            // Unmounts any previous root mounted on this cell before creating
-            // the new one, so redraws don't leak roots.
-            const root = getCellRoot(actionsCell);
 
-            // If processed >= total show download/delete actions
-            const stats = data.stats || {};
-            const total = Number(stats.total || 0);
-            const processedCount = Number(stats.processed || 0);
-            const failedCount = Number(stats.failed || 0);
-            const finishedCount = Number(stats.finished ?? processedCount + failedCount);
-            // Show both Process and Delete buttons for running batches
-            const isLocallyProcessing = processingBatches.includes(String(_id));
-
-            if (
-              (finishedCount >= total && status === 'processed') ||
-              ['in_progress', 'processing', 'inprogress'].includes(status)
-            ) {
-              const ActionButtons = () => {
-                const [clicked, setClicked] = useState(false);
-                // Keep something in the DOM in place of the button (rather than
-                // returning null) so focus isn't dropped to <body>, and announce
-                // the pending state — the row's cell gets replaced for real once
-                // `batches` refreshes and the table remounts (see `key={refreshKey}`).
-                if (clicked) {
-                  return (
-                    <span role="status" aria-live="polite" tabIndex={-1} ref={(el) => el?.focus()}>
-                      {t('common.processing')}
-                    </span>
-                  );
-                }
-                return (
-                  <div style={{ display: 'flex', gap: '8px' }}>
-                    {finishedCount >= total && status === 'processed' && (
-                      <>
-                        <GcdsButton
-                          size="small"
-                          onClick={() => {
-                              handleExport(_id, 'csv');
-                              setClicked(true);
-                            }}
-                        >
-                          {t('batch.list.actions.csv')}
-                        </GcdsButton>
-                        <GcdsButton
-                          size="small"
-                          onClick={() => {
-                            handleExport(_id, 'excel');
-                            setClicked(true);
-                          }}
-                        >
-                          {t('batch.list.actions.excel')}
-                        </GcdsButton>
-                      </>
-                    )}
-                    {(['in_progress', 'processing', 'inprogress'].includes(status) || finishedCount < total) && (
-                      <GcdsButton
-                        size="small"
-                        onClick={() => {
-                          // Don't allow pressing Process if this batch is marked locally processing
-                          if (isLocallyProcessing) return;
-                          // Immediately mark clicked so the button disables in the UI before any async work
-                          setClicked(true);
-                          handleProcess(_id, aiProvider, data.workflow || data?.workflow || 'Default');
-                        }}
-                        disabled={isLocallyProcessing || clicked}
-                      >
-                        {t('batch.list.actions.process')}
-                      </GcdsButton>
-                    )}
-                    <GcdsButton
-                      size="small"
-                      buttonRole="danger"
-                      onClick={() => {
-                        if (handleDelete(_id)) setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.delete')}
-                    </GcdsButton>
-                  </div>
-                );
-              };
-              root.render(<ActionButtons />);
-            } else if (finishedCount < total || total === 0) {
-              // Offer a Process button which triggers provider-side processing
-              const ProcessButton = () => {
-                const [clicked, setClicked] = useState(false);
-                // Keep something in the DOM in place of the button (rather than
-                // returning null) so focus isn't dropped to <body>, and announce
-                // the pending state — the row's cell gets replaced for real once
-                // `batches` refreshes and the table remounts (see `key={refreshKey}`).
-                if (clicked) {
-                  return (
-                    <span role="status" aria-live="polite" tabIndex={-1} ref={(el) => el?.focus()}>
-                      {t('common.processing')}
-                    </span>
-                  );
-                }
-                return (
-                  <div style={{ display: 'flex', gap: '8px' }}>
-                    <GcdsButton
-                      size="small"
-                        onClick={() => {
-                        if (processingBatches.includes(String(_id))) return;
-                        // Immediately set clicked so button disables without waiting for parent state
-                        setClicked(true);
-                          handleProcess(_id, aiProvider, data.workflow || data?.workflow || 'Default');
-                      }}
-                      disabled={processingBatches.includes(String(_id)) || clicked}
-                    >
-                      {t('batch.list.actions.process')}
-                    </GcdsButton>
-                    <GcdsButton
-                      size="small"
-                      buttonRole="danger"
-                      onClick={() => {
-                        if (handleDelete(_id)) setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.delete')}
-                    </GcdsButton>
-                  </div>
-                );
-              };
-              root.render(<ProcessButton />);
-            } else if (status === 'completed') {
-              const ActionButtonComplete = () => {
-                const [clicked, setClicked] = useState(false);
-                // Keep something in the DOM in place of the button (rather than
-                // returning null) so focus isn't dropped to <body>, and announce
-                // the pending state — the row's cell gets replaced for real once
-                // `batches` refreshes and the table remounts (see `key={refreshKey}`).
-                if (clicked) {
-                  return (
-                    <span role="status" aria-live="polite" tabIndex={-1} ref={(el) => el?.focus()}>
-                      {t('common.processing')}
-                    </span>
-                  );
-                }
-                return (
-                  <div style={{ display: 'flex', gap: '8px' }}>
-                    <GcdsButton
-                      size="small"
-                      onClick={() => {
-                        handleProcess(_id, aiProvider, data.workflow || data?.workflow || 'Default');
-                        setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.process')}
-                    </GcdsButton>
-                    <GcdsButton
-                      size="small"
-                      buttonRole="danger"
-                      onClick={() => {
-                        if (handleDelete(_id)) setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.delete')}
-                    </GcdsButton>
-                  </div>
-                );
-              };
-              root.render(<ActionButtonComplete />);
-            } else {
-              const ActionButtonCancel = () => {
-                const [clicked, setClicked] = useState(false);
-                // Keep something in the DOM in place of the button (rather than
-                // returning null) so focus isn't dropped to <body>, and announce
-                // the pending state — the row's cell gets replaced for real once
-                // `batches` refreshes and the table remounts (see `key={refreshKey}`).
-                if (clicked) {
-                  return (
-                    <span role="status" aria-live="polite" tabIndex={-1} ref={(el) => el?.focus()}>
-                      {t('common.processing')}
-                    </span>
-                  );
-                }
-                return (
-                  <div style={{ display: 'flex', gap: '8px' }}>
-                    <GcdsButton
-                      size="small"
-                      onClick={() => {
-                        handleCancel(_id, aiProvider);
-                        setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.cancel')}
-                    </GcdsButton>
-                    <GcdsButton
-                      size="small"
-                      buttonRole="danger"
-                      onClick={() => {
-                        if (handleDelete(_id)) setClicked(true);
-                      }}
-                    >
-                      {t('batch.list.actions.delete')}
-                    </GcdsButton>
-                  </div>
-                );
-              };
-              root.render(<ActionButtonCancel />);
-            }
-          },
-        }}
-        // Key forces a full remount when batches change so rows (and actions)
-        // re-render with the latest statuses returned from the backend.
-        key={refreshKey}
-      />
+              // Focus restoration for the row this cell belongs to (if it was
+              // the one just clicked) happens inside RowActionButtons itself,
+              // via a useEffect that fires once this render actually commits
+              // — see its own comment for why that's more reliable than
+              // trying to coordinate it from out here.
+              root.render(<RowActionButtons batchId={batchId} actions={actions} t={t} pendingFocusRef={pendingFocusRef} />);
+            },
+          }}
+          // Key forces a full remount when batches change so rows (and actions)
+          // re-render with the latest statuses returned from the backend.
+          key={refreshKey}
+        />
+      </div>
     </div>
   );
 };
 
 export default BatchList;
-
-

--- a/src/components/batch/BatchUpload.js
+++ b/src/components/batch/BatchUpload.js
@@ -247,7 +247,7 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
         <GcdsStepper currentStep={2} totalSteps={3} tag="h3">
           {t('batch.upload.steps.step2Title')}
         </GcdsStepper>
-        <div className="feedback-reason-card mb-500">
+        <div className="batch-upload-card mb-500">
           <div className="mt-300 mb-250">
             <GcdsInput
               inputId="batchName"
@@ -425,9 +425,6 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
             {t('batch.upload.steps.step3Title')}
           </GcdsStepper>
           <p className="mb-100">{t('batch.upload.instructions.reviewIncomplete')}</p>
-          <p className="mb-200">
-            <a href="#running-evaluation">{t('batch.upload.instructions.incompleteLinkText')}</a>
-          </p>
           <details className="mb-250">
             <summary className="mb-200">{t('batch.upload.instructions.tipsTitle')}</summary>
             <p>{t('batch.upload.instructions.step6')}</p>

--- a/src/components/batch/__tests__/BatchList.test.js
+++ b/src/components/batch/__tests__/BatchList.test.js
@@ -1,0 +1,424 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import React from 'react';
+import { render, cleanup, act } from '@testing-library/react';
+import BatchList from '../BatchList.js';
+import BatchService from '../../../services/BatchService.js';
+
+vi.mock('../../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({
+    t: (key) => {
+      const map = {
+        'batch.list.actions.process': 'Process',
+        'batch.list.actions.delete': 'Delete',
+        'batch.list.actions.cancel': 'Cancel',
+        'batch.list.actions.csv': 'CSV',
+        'batch.list.actions.excel': 'Excel',
+        'batch.list.actions.confirmDelete': 'Are you sure?',
+        'batch.list.actions.confirmDeleteNamed': 'Are you sure you want to delete "{name}"?',
+        'batch.list.totalsLabel': '{finished}/{total}',
+        'batch.list.deletedAnnouncement': 'Deleted: {name}.',
+        'common.processing': 'Processing…',
+      };
+      return map[key] || key;
+    },
+  }),
+}));
+
+// Mutable so individual tests can flip "paused" without simulating a real
+// click through PauseToggleButton (mocked below to a dumb stub) - the point
+// of these tests is BatchList's own reaction to isPaused, not the toggle
+// button itself. Calls fn() once on setup, same as the real hook's "fetch
+// immediately, then every intervalMs" contract - without that, BatchList's
+// own `batches` state never leaves its initial [], which makes every
+// filteredBatches-empty test degenerate no matter what isPaused does.
+let mockIsPaused = false;
+const mockTogglePause = vi.fn();
+vi.mock('../../../hooks/usePauseToggle.js', () => ({
+  usePausablePolling: (fn) => {
+    React.useEffect(() => { fn(); }, []);
+    return { isPaused: mockIsPaused, togglePause: mockTogglePause };
+  },
+}));
+
+vi.mock('../../admin/PauseToggleButton.js', () => ({
+  default: React.forwardRef((props, ref) => <button type="button" ref={ref}>Pause</button>),
+}));
+
+vi.mock('../../../services/BatchService.js', () => ({
+  default: {
+    getBatchList: vi.fn(() => Promise.resolve([])),
+    getBatchStatuses: vi.fn((batches) => Promise.resolve(batches)),
+  },
+}));
+
+vi.mock('@gcds-core/components-react', () => ({
+  GcdsButton: ({ children, onClick, disabled, buttonRole, 'data-action-key': dataActionKey }) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-button-role={buttonRole} data-action-key={dataActionKey}>
+      {children}
+    </button>
+  ),
+  // StatusMessage.js's info/warning/error variants render this for their icon.
+  GcdsIcon: () => <span aria-hidden="true" />,
+}));
+
+vi.mock('datatables.net-dt', () => ({ default: () => null }));
+
+let lastOptions = null;
+// Increments only on a genuine remount (key change tearing down and
+// recreating the component), not on an ordinary re-render with the same
+// key - a mount-only effect (empty deps) is what makes that distinction,
+// same as React itself.
+let mountCount = 0;
+vi.mock('datatables.net-react', () => {
+  const MockDataTable = (props) => {
+    lastOptions = props.options;
+    React.useEffect(() => { mountCount += 1; }, []);
+    return React.createElement('div', { 'data-testid': 'mock-data-table' });
+  };
+  MockDataTable.use = vi.fn();
+  return { default: MockDataTable };
+});
+
+// Builds a bare 9-<td> row matching BatchList's real column count, so
+// createdRow's `row.querySelectorAll('td')` / `td:last-child` /
+// `previousElementSibling` lookups behave exactly as they do against a real
+// DataTables-rendered row.
+function makeRow() {
+  const row = document.createElement('tr');
+  for (let i = 0; i < 9; i++) row.appendChild(document.createElement('td'));
+  document.body.appendChild(row); // real layout/focus needs the row attached
+  return row;
+}
+
+const baseBatchData = (overrides = {}) => ({
+  _id: 'batch-1',
+  status: 'processed',
+  aiProvider: 'openai-gpt51',
+  workflow: 'Default',
+  stats: { total: 3, processed: 3, failed: 0, finished: 3 },
+  ...overrides,
+});
+
+describe('BatchList row action buttons', () => {
+  beforeEach(() => {
+    lastOptions = null;
+    mountCount = 0;
+    mockIsPaused = false;
+    mockTogglePause.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('restores focus to the row after a click-triggered remount instead of dropping it to <body>', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = vi.fn(() => true); // user confirms the delete
+
+    render(<BatchList lang="en" processingBatches={[]} onDelete={vi.fn()} />);
+    expect(lastOptions).toBeTruthy();
+
+    // First draw: a finished/processed batch -> CSV/Excel/Delete. Delete,
+    // not CSV/Excel - those are `instant` (see RowActionButtons) and no
+    // longer go through the pendingFocusRef/"Processing…" flow this test
+    // targets; Delete still does.
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const deleteButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    expect(deleteButton).toBeTruthy();
+
+    // Click Delete - this arms the pending-focus ref (RowActionButtons'
+    // onClick) and swaps the cell to the self-focusing "Processing…"
+    // placeholder. The remount that actually loses focus in the real bug is
+    // simulated by the second createdRow call below, same as a real
+    // `processingBatches`/`batches` change bumping `refreshKey`.
+    await act(async () => {
+      deleteButton.click();
+    });
+
+    // Simulate the whole-table remount that follows in the real app: the
+    // same row redraws (a fresh cell, fresh buttons - the exact moment the
+    // bug lost focus to <body>, since the old cell's self-focusing
+    // placeholder was torn down before the browser ever settled on it).
+    const secondRow = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(secondRow, baseBatchData());
+    });
+
+    // Specifically the Delete button that was actually clicked - not just
+    // "whatever's first in the row" (CSV, in this row's own action order).
+    // See pendingFocusRef's own comment: the redraw-consumption path
+    // targets the exact clicked action via data-action-key, precisely so
+    // this doesn't land on an unrelated control.
+    const redrawnDeleteButton = Array.from(secondRow.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    expect(redrawnDeleteButton).toBeTruthy();
+    expect(document.activeElement).toBe(redrawnDeleteButton);
+    expect(document.activeElement).not.toBe(document.body);
+
+    window.confirm = originalConfirm;
+  });
+
+  it('does not arm a pending focus request when Delete\'s confirm is cancelled', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = vi.fn(() => false); // user clicks "Cancel"
+
+    render(<BatchList lang="en" processingBatches={[]} onDelete={vi.fn()} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const deleteButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    await act(async () => {
+      deleteButton.click();
+    });
+
+    // Cancelled delete: no "Processing…" placeholder should have replaced
+    // the buttons, and re-drawing the row shouldn't steal focus anywhere -
+    // nothing was armed for this row.
+    expect(row.textContent).not.toContain('Processing…');
+
+    const secondRow = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(secondRow, baseBatchData());
+    });
+    expect(document.activeElement).toBe(document.body);
+
+    window.confirm = originalConfirm;
+  });
+
+  it('disables CSV while its own export is pending, without swapping the row to "Processing…", and re-enables after', async () => {
+    let resolveExport;
+    const onExport = vi.fn(() => new Promise((resolve) => { resolveExport = resolve; }));
+
+    render(<BatchList lang="en" processingBatches={[]} onExport={onExport} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const csvButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'CSV');
+    const excelButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Excel');
+
+    await act(async () => {
+      csvButton.click();
+    });
+
+    // Still the real buttons, not the "Processing…" placeholder - exports
+    // are near-instant, the placeholder swap is for Process/Delete/Cancel.
+    expect(row.textContent).not.toContain('Processing…');
+    expect(csvButton.disabled).toBe(true);
+    // Only the clicked button is disabled - Excel is a separate export.
+    expect(excelButton.disabled).toBe(false);
+
+    // A second click while the first export is still in flight must not
+    // fire onExport again (the whole point - no duplicate downloads).
+    await act(async () => {
+      csvButton.click();
+    });
+    expect(onExport).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveExport();
+      await Promise.resolve();
+    });
+    expect(csvButton.disabled).toBe(false);
+  });
+
+  it('announces the deleted batch by name in the shared sr-only region once onDelete resolves true', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = vi.fn(() => true);
+    const onDelete = vi.fn(() => Promise.resolve(true)); // matches BatchPage.js's onDelete contract
+
+    const { container } = render(<BatchList lang="en" processingBatches={[]} onDelete={onDelete} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData({ name: 'Weekly digest test' }));
+    });
+
+    const deleteButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    await act(async () => {
+      deleteButton.click();
+      await Promise.resolve(); // let the async IIFE's onDelete await settle
+    });
+
+    expect(onDelete).toHaveBeenCalledWith('batch-1', 'Weekly digest test');
+    expect(container.textContent).toContain('Deleted: Weekly digest test.');
+
+    window.confirm = originalConfirm;
+  });
+
+  it('redirects focus to the pause button on a successful delete, since the deleted row never redraws for pendingFocusRef to consume', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = vi.fn(() => true);
+    const onDelete = vi.fn(() => Promise.resolve(true));
+
+    render(<BatchList lang="en" processingBatches={[]} onDelete={onDelete} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const deleteButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    await act(async () => {
+      deleteButton.click();
+      // A real macrotask, not just a microtask: the pause-button focus is
+      // deferred via setTimeout specifically so it runs after the
+      // "Processing…" placeholder's own self-focus (scheduled through its
+      // own separate React root's commit) has already happened - see
+      // handleDelete's own comment on why a microtask tick isn't enough.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Unlike the click-triggered-remount test above, this deliberately does
+    // NOT call createdRow again for this batchId - a real successful delete
+    // never redraws the row (it's gone from the next fetch), so
+    // RowActionButtons' own pendingFocusRef-consuming effect structurally
+    // cannot fire. Focus should land on the pause button instead of being
+    // lost to <body>.
+    const pauseButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent === 'Pause');
+    expect(pauseButton).toBeTruthy();
+    expect(document.activeElement).toBe(pauseButton);
+    expect(document.activeElement).not.toBe(document.body);
+
+    window.confirm = originalConfirm;
+  });
+
+  it('restores focus to Delete specifically (not the row\'s first button) when a delete fails and the row redraws', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = vi.fn(() => true);
+    const onDelete = vi.fn(() => Promise.resolve(false)); // delete failed
+
+    render(<BatchList lang="en" processingBatches={[]} onDelete={onDelete} />);
+    // A finished/processed batch's row order is CSV, Excel, Delete - CSV is
+    // the row's first interactive element, which is exactly the wrong
+    // button the old "grab whatever's first" fallback would land on.
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const deleteButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    await act(async () => {
+      deleteButton.click();
+    });
+
+    // A failed delete doesn't remove the batch - it redraws with the same
+    // actions, same as any other unfinished action. This is the real
+    // "redraw-consumption" path (not the pause-button fallback, which only
+    // fires on success), so pendingFocusRef must still be armed here.
+    const secondRow = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(secondRow, baseBatchData());
+    });
+
+    const redrawnDeleteButton = Array.from(secondRow.querySelectorAll('button')).find((b) => b.textContent === 'Delete');
+    const redrawnCsvButton = Array.from(secondRow.querySelectorAll('button')).find((b) => b.textContent === 'CSV');
+    expect(redrawnDeleteButton).toBeTruthy();
+    expect(document.activeElement).toBe(redrawnDeleteButton);
+    expect(document.activeElement).not.toBe(redrawnCsvButton);
+    expect(document.activeElement).not.toBe(document.body);
+
+    window.confirm = originalConfirm;
+  });
+
+  it('resumes auto-updates when Process is clicked while paused', async () => {
+    mockIsPaused = true;
+    mockTogglePause.mockClear();
+    render(<BatchList lang="en" processingBatches={[]} onProcess={vi.fn()} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData({ status: 'uploaded', stats: { total: 5, processed: 0, failed: 0, finished: 0 } }));
+    });
+
+    const processButton = Array.from(row.querySelectorAll('button')).find((b) => b.textContent === 'Process');
+    const fetchCountBeforeClick = BatchService.getBatchList.mock.calls.length;
+    await act(async () => {
+      processButton.click();
+    });
+
+    // Starting a process is a stronger signal than "leave this be" (what
+    // pause means) - clicking it resumes auto-updates rather than leaving
+    // this row's own progress frozen right next to the button that started it.
+    expect(mockTogglePause).toHaveBeenCalledTimes(1);
+    // Resuming shouldn't just un-skip the *next* scheduled poll tick (up to
+    // 10s away, on usePausablePolling's own clock) - it should refetch right
+    // away, same as delete already does, so the table doesn't sit looking
+    // frozen after a click that was supposed to make it live again.
+    expect(BatchService.getBatchList.mock.calls.length).toBeGreaterThan(fetchCountBeforeClick);
+  });
+
+  it('paints the currently-sorted column\'s cell with DataTables\' own sorting_1 class, manually - not relying on DataTables\' internal (unreliable for this client-side table) classing', async () => {
+    render(<BatchList lang="en" processingBatches={[]} onDelete={vi.fn()} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData());
+    });
+
+    const cells = row.querySelectorAll('td');
+    // Default order is [[2, 'desc']] (Created Date) - see sortOrderRef.
+    expect(cells[2].classList.contains('sorting_1')).toBe(true);
+    // No other cell should carry a stale sorting_1/2/3 from a previous draw.
+    cells.forEach((cell, i) => {
+      if (i !== 2) {
+        expect(cell.classList.contains('sorting_1')).toBe(false);
+        expect(cell.classList.contains('sorting_2')).toBe(false);
+        expect(cell.classList.contains('sorting_3')).toBe(false);
+      }
+    });
+  });
+
+  it('shows Process + Delete (no export buttons) for a batch that is not yet finished', async () => {
+    render(<BatchList lang="en" processingBatches={[]} onDelete={vi.fn()} />);
+    const row = makeRow();
+    await act(async () => {
+      lastOptions.createdRow(row, baseBatchData({ status: 'processing', stats: { total: 5, processed: 2, failed: 0, finished: 2 } }));
+    });
+
+    const labels = Array.from(row.querySelectorAll('button')).map((b) => b.textContent);
+    expect(labels).toContain('Process');
+    expect(labels).toContain('Delete');
+    expect(labels).not.toContain('CSV');
+    expect(labels).not.toContain('Excel');
+  });
+
+  it('does not remount while paused, even when processingBatches changes (the "lists cancel each other out" bug: processingBatches is shared across both BatchList instances on BatchPage.js)', async () => {
+    // A non-empty filtered list - otherwise "empty stays empty" alone would
+    // already explain a skipped remount, independent of the pause fix this
+    // test targets. batchStatus has to actually match, or filteredBatches
+    // is empty regardless of what getBatchList returns (an empty desired[]
+    // list matches nothing).
+    BatchService.getBatchList.mockResolvedValueOnce([baseBatchData({ status: 'uploaded' })]);
+
+    mockIsPaused = true;
+    const { rerender } = render(
+      <BatchList lang="en" batchStatus="uploaded,in_progress" processingBatches={[]} onDelete={vi.fn()} />
+    );
+    await act(async () => {}); // flush the mount-time fetch
+    expect(mountCount).toBe(1);
+
+    // Simulate an action in the *other* BatchList instance changing the
+    // shared processingBatches array - same prop, new reference, this list
+    // untouched by the user.
+    await act(async () => {
+      rerender(<BatchList lang="en" batchStatus="uploaded,in_progress" processingBatches={['some-other-batch']} onDelete={vi.fn()} />);
+    });
+    expect(mountCount).toBe(1); // still frozen - no remount while paused
+
+    // Resuming should immediately catch up rather than waiting for the next
+    // poll tick.
+    mockIsPaused = false;
+    await act(async () => {
+      rerender(<BatchList lang="en" batchStatus="uploaded,in_progress" processingBatches={['some-other-batch']} onDelete={vi.fn()} />);
+    });
+    expect(mountCount).toBe(2);
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -246,7 +246,6 @@
         "step3a": "Select the language of the batch file.",
         "step3b": "(i.e. the language of the page the batch is simulating)",
         "reviewIncomplete": "After a successful upload, initiate processing and/or check on your batch's progress below.",
-        "incompleteLinkText": "Go to the Incomplete batches section",
         "step6": "When it's done (if it gets interrupted and didn't finish, click the Process button again), it will move to the Completed batches section. You can download the file from there.",
         "step7": "All of the chats run in the batch will be available to evaluate in the Evaluation dashboard and Chat viewer with the email address of the person who submitted the batch."
       },
@@ -292,6 +291,7 @@
       }
     },
     "list": {
+      "searchPlaceholder": "Batch name or batch ID",
       "columns": {
         "batchId": "Batch ID",
         "totals": "Totals",
@@ -309,19 +309,28 @@
         "process": "Process",
         "delete": "Delete",
         "confirmDelete": "Are you sure you want to delete this batch?",
+        "confirmDeleteNamed": "Are you sure you want to delete \"{name}\"?",
         "cancel": "Cancel",
         "deleteSuccess": "Batch deleted.",
         "deleteError": "Failed to delete batch.",
+        "deleteErrorNamed": "Failed to delete \"{name}\".",
         "exportSuccess": "Batch exported.",
         "exportEmpty": "No chats found to export for this batch.",
+        "exportEmptyNamed": "No chats found to export for \"{name}\".",
         "exportError": "Failed to export batch.",
+        "exportErrorNamed": "Failed to export \"{name}\".",
         "processError": "Failed to process batch.",
+        "processErrorNamed": "Failed to process \"{name}\".",
         "processSuccess": "Batch processing finished.",
         "cancelSuccess": "Batch cancelled.",
-        "cancelError": "Failed to cancel batch."
+        "cancelError": "Failed to cancel batch.",
+        "cancelErrorNamed": "Failed to cancel \"{name}\"."
       },
+      "completedAnnouncement": "Completed: {names}.",
+      "deletedAnnouncement": "Deleted: {name}.",
       "types": {
-        "client": "Client"
+        "client": "Client",
+        "chat": "Chat"
       },
       "statuses": {
         "in_progress": "In progress",
@@ -1202,7 +1211,9 @@
     "noDataForFilters": "No data found for the selected filters.",
     "notEnoughData": "Not enough data available for the filters selected.",
     "pauseUpdates": "Pause automatic updates",
-    "resumeUpdates": "Resume automatic updates"
+    "resumeUpdates": "Resume automatic updates",
+    "pausedIndicator": "Updates paused",
+    "resumedIndicator": "Automatic updates resumed"
   },
   "eval": {
     "metric": "Metric",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -246,7 +246,6 @@
         "step3a": "Sélectionnez la langue du fichier de lot.",
         "step3b": "(c.-à-d. la langue de la page que le lot simule)",
         "reviewIncomplete": "Après un téléversement réussi, lancez le traitement et/ou suivez la progression de votre lot ci-dessous.",
-        "incompleteLinkText": "Accéder à la section Lots incomplets",
         "step6": "Lorsque c'est terminé (si le traitement est interrompu et n'est pas terminé, cliquez à nouveau sur le bouton Traiter), il sera déplacé vers la section Lots terminés. Vous pouvez télécharger le fichier à partir de là.",
         "step7": "Tous les clavardages exécutés dans le lot seront disponibles pour évaluation dans le Tableau de bord d'évaluation et le Visualiseur de clavardage avec l'adresse courriel de la personne qui a soumis le lot."
       },
@@ -292,6 +291,7 @@
       }
     },
     "list": {
+      "searchPlaceholder": "Nom du lot ou ID du lot",
       "columns": {
         "batchName": "Nom",
         "totals": "Totaux",
@@ -309,19 +309,28 @@
         "process": "Traiter",
         "delete": "Supprimer",
         "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce lot ?",
+        "confirmDeleteNamed": "Êtes-vous sûr de vouloir supprimer « {name} » ?",
         "cancel": "Annuler",
         "deleteSuccess": "Lot supprimé.",
         "deleteError": "Échec de la suppression du lot.",
+        "deleteErrorNamed": "Échec de la suppression de « {name} ».",
         "exportSuccess": "Lot exporté.",
         "exportEmpty": "Aucune conversation trouvée à exporter pour ce lot.",
+        "exportEmptyNamed": "Aucune conversation trouvée à exporter pour « {name} ».",
         "exportError": "Échec de l'exportation du lot.",
+        "exportErrorNamed": "Échec de l'exportation de « {name} ».",
         "processError": "Échec du traitement du lot.",
+        "processErrorNamed": "Échec du traitement de « {name} ».",
         "processSuccess": "Traitement du lot terminé.",
         "cancelSuccess": "Lot annulé.",
-        "cancelError": "Échec de l'annulation du lot."
+        "cancelError": "Échec de l'annulation du lot.",
+        "cancelErrorNamed": "Échec de l'annulation de « {name} »."
       },
+      "completedAnnouncement": "Terminé : {names}.",
+      "deletedAnnouncement": "Supprimé : {name}.",
       "types": {
-        "client": "Client"
+        "client": "Client",
+        "chat": "Clavardage"
       },
       "statuses": {
         "in_progress": "En cours",
@@ -1202,7 +1211,9 @@
     "noDataForFilters": "Aucune donnée trouvée pour les filtres sélectionnés.",
     "notEnoughData": "Données insuffisantes pour les filtres sélectionnés.",
     "pauseUpdates": "Suspendre les mises à jour automatiques",
-    "resumeUpdates": "Reprendre les mises à jour automatiques"
+    "resumeUpdates": "Reprendre les mises à jour automatiques",
+    "pausedIndicator": "Mises à jour suspendues",
+    "resumedIndicator": "Mises à jour automatiques reprises"
   },
   "eval": {
     "metric": "Métrique",

--- a/src/pages/BatchPage.js
+++ b/src/pages/BatchPage.js
@@ -15,15 +15,71 @@ const BatchPage = ({ lang = 'en' }) => {
   // Action-outcome announcement: BatchList's per-row buttons hide themselves
   // immediately on click (see BatchList.js) with no other feedback, so this
   // is the only place delete/export/process/cancel results reach the user.
-  const [statusMessage, setStatusMessage] = useState(null); // { text, isError }
+  //
+  // Success stays sr-only: the table itself already shows the outcome to a
+  // sighted user (the row disappears, moves lists, or its status/totals
+  // update), so a floating visible box repeating that in words is
+  // redundant. Errors stay visible: a failure isn't otherwise self-evident
+  // (the row often just reverts to how it looked before), so it needs to
+  // actually interrupt someone, not just be heard by screen reader users -
+  // and it's scoped per section (`running`/`processed`) so the box renders
+  // next to the table the failing row actually belongs to, not stranded in
+  // one shared spot disconnected from both.
+  const [errors, setErrors] = useState({ running: null, processed: null }); // { text } per section
+  // Nonce is per-section too, not one shared counter - a shared nonce would
+  // force *both* StatusMessages to remount (and therefore re-announce)
+  // whenever either section's error changed, even the section whose
+  // `errors.*` value didn't actually change - re-announcing a stale,
+  // unrelated error just because the other list failed.
+  const [errorNonces, setErrorNonces] = useState({ running: 0, processed: 0 });
+  const setError = (section, text) => {
+    setErrors((prev) => ({ ...prev, [section]: { text } }));
+    // Forces a remount even when two failures in a row produce identical
+    // text (e.g. two different rows both failing with the same generic
+    // error) - see StatusMessage.js's own doc comment on `nonce` for why a
+    // same-value update would otherwise be silently un-announced/unchanged.
+    setErrorNonces((prev) => ({ ...prev, [section]: prev[section] + 1 }));
+  };
+  // Most of these outcomes can name the batch (BatchList.js passes its name
+  // through from the row); falls back to the generic wording for the rare
+  // case a name isn't available, same pattern as confirmDelete/
+  // confirmDeleteNamed already established.
+  const namedOrGeneric = (namedKey, genericKey, name) =>
+    name ? t(namedKey).replace('{name}', () => name) : t(genericKey);
 
-  const onDelete = async (batchId) => {
+  const [successAnnouncement, setSuccessAnnouncement] = useState('');
+  const [successNonce, setSuccessNonce] = useState(0);
+  // `section` is optional only because a couple of hypothetical future
+  // callers might not have one - every actual call site below always
+  // passes it, since every success here is scoped to one of the two
+  // tables. Without this, a section's visible error box (set by an
+  // earlier failed Process/Delete/Export/Cancel) would sit on screen
+  // forever even after a later retry in that same section succeeds -
+  // the old single-shared-statusMessage implementation didn't have this
+  // gap, since every success overwrote the one shared state; splitting
+  // errors per-section (see `errors` above) needs the success side to
+  // clear its own section explicitly instead.
+  const announceSuccess = (text, section) => {
+    setSuccessAnnouncement(text);
+    // Forces a remount even when two successes in a row produce identical
+    // text (e.g. deleting two batches back to back) - see StatusMessage.js's
+    // own doc comment on `nonce` for why a same-value update would otherwise
+    // be silently un-announced.
+    setSuccessNonce((n) => n + 1);
+    if (section) {
+      setErrors((prev) => (prev[section] ? { ...prev, [section]: null } : prev));
+    }
+  };
+
+  const onDelete = async (batchId, batchName, section) => {
     try {
       await BatchService.deleteBatch(batchId);
-      setStatusMessage({ text: t('batch.list.actions.deleteSuccess'), isError: false });
+      announceSuccess(t('batch.list.actions.deleteSuccess'), section);
+      return true;
     } catch (err) {
       console.error('Failed to delete batch:', err);
-      setStatusMessage({ text: t('batch.list.actions.deleteError'), isError: true });
+      setError(section, namedOrGeneric('batch.list.actions.deleteErrorNamed', 'batch.list.actions.deleteError', batchName));
+      return false;
     }
   };
 
@@ -44,24 +100,24 @@ const BatchPage = ({ lang = 'en' }) => {
     setProcessingBatches((prev) => prev.filter((x) => x !== String(id)));
   };
 
-  const onExport = async (batchId, type) => {
+  const onExport = async (batchId, type, batchName, section) => {
     try {
       // Prefer server-provided chat logs for the batch
       const chats = await BatchService.retrieveBatchChats(batchId, 1000);
       const fileName = `${batchId}.${type === 'excel' ? 'xlsx' : 'csv'}`;
       if (Array.isArray(chats) && chats.length > 0) {
         ExportService.export(chats, fileName);
-        setStatusMessage({ text: t('batch.list.actions.exportSuccess'), isError: false });
+        announceSuccess(t('batch.list.actions.exportSuccess'), section);
         return;
       }
-      setStatusMessage({ text: t('batch.list.actions.exportEmpty'), isError: true });
+      setError(section, namedOrGeneric('batch.list.actions.exportEmptyNamed', 'batch.list.actions.exportEmpty', batchName));
     } catch (err) {
       console.error('Failed to fetch chats from BatchService.retrieveBatchChats, falling back to batch retrieve:', err);
-      setStatusMessage({ text: t('batch.list.actions.exportError'), isError: true });
+      setError(section, namedOrGeneric('batch.list.actions.exportErrorNamed', 'batch.list.actions.exportError', batchName));
     }
   };
 
-  const onProcess = async (batchId, provider, workflowParam) => {
+  const onProcess = async (batchId, provider, workflowParam, batchName, section) => {
     // Mark locally so the UI immediately hides the Process button
     markProcessing(batchId);
 
@@ -109,29 +165,29 @@ const BatchPage = ({ lang = 'en' }) => {
         }
         // Clear local processing marker when the run completes
         unmarkProcessing(batchId);
-        setStatusMessage({ text: t('batch.list.actions.processSuccess'), isError: false });
+        announceSuccess(t('batch.list.actions.processSuccess'), section);
       }).catch((err) => {
         console.error('Batch run failed:', err);
         unmarkProcessing(batchId);
-        setStatusMessage({ text: t('batch.list.actions.processError'), isError: true });
+        setError(section, namedOrGeneric('batch.list.actions.processErrorNamed', 'batch.list.actions.processError', batchName));
       });
     } catch (err) {
       console.error('Error starting process:', err);
       unmarkProcessing(batchId);
-      setStatusMessage({ text: t('batch.list.actions.processError'), isError: true });
+      setError(section, namedOrGeneric('batch.list.actions.processErrorNamed', 'batch.list.actions.processError', batchName));
     }
   };
 
-  const onCancel = async (batchId, provider) => {
+  const onCancel = async (batchId, provider, batchName, section) => {
     try {
       // Use cancelBatch which aborts client-side processing (provider is ignored)
       await BatchService.cancelBatch(batchId, provider);
       // Clear local processing marker
       unmarkProcessing(batchId);
-      setStatusMessage({ text: t('batch.list.actions.cancelSuccess'), isError: false });
+      announceSuccess(t('batch.list.actions.cancelSuccess'), section);
     } catch (err) {
       console.error('Cancel failed:', err);
-      setStatusMessage({ text: t('batch.list.actions.cancelError'), isError: true });
+      setError(section, namedOrGeneric('batch.list.actions.cancelErrorNamed', 'batch.list.actions.cancelError', batchName));
     }
   };
 
@@ -148,20 +204,34 @@ const BatchPage = ({ lang = 'en' }) => {
         </GcdsLink>
       </nav>
 
-      <StatusMessage variant={statusMessage ? (statusMessage.isError ? 'error' : 'success') : undefined} message={statusMessage?.text} />
+      <StatusMessage
+        persistent
+        nonce={successNonce}
+        message={successAnnouncement || undefined}
+        className="sr-only"
+      />
 
       <section id="evaluator" className="mb-200">
         <h2 className="mt-400 mb-400">{t('batch.sections.evaluator.title')}</h2>
         <BatchUpload lang={lang} onBatchSaved={triggerRefresh} />
       </section>
 
-      <section id="running-evaluation" className="mb-600 focus-target" tabIndex={-1}>
+      <section className="mb-600">
         <h2 className="mt-400 mb-400">{t('batch.sections.running.title')}</h2>
+        {/* Scoped to this table specifically - delete/process/cancel/export
+            failures from a row here shouldn't render above the *other*
+            table instead. */}
+        <StatusMessage
+          variant={errors.running ? 'error' : undefined}
+          message={errors.running?.text}
+          nonce={errorNonces.running}
+          className="mb-400"
+        />
         <BatchList
-          onProcess={onProcess}
-          onCancel={onCancel}
-          onDelete={onDelete}
-          onExport={onExport}
+          onProcess={(id, provider, workflow, name) => onProcess(id, provider, workflow, name, 'running')}
+          onCancel={(id, provider, name) => onCancel(id, provider, name, 'running')}
+          onDelete={(id, name) => onDelete(id, name, 'running')}
+          onExport={(id, type, name) => onExport(id, type, name, 'running')}
           // Include 'uploaded' so freshly created batches appear in the running list
           batchStatus="uploaded,validating,failed,in_progress,finalizing,completed,expired"
           key={`running-${refreshKey}`}
@@ -174,16 +244,23 @@ const BatchPage = ({ lang = 'en' }) => {
       <section id="processed-evaluation" className="mb-600">
         <h2 className="mt-400 mb-400">{t('batch.sections.processed.title')}</h2>
         <p className="mb-400">{t('batch.sections.processed.description')}</p>
+        <StatusMessage
+          variant={errors.processed ? 'error' : undefined}
+          message={errors.processed?.text}
+          nonce={errorNonces.processed}
+          className="mb-400"
+        />
         <BatchList
-          onProcess={onProcess}
-          onCancel={onCancel}
-          onDelete={onDelete}
-          onExport={onExport}
+          onProcess={(id, provider, workflow, name) => onProcess(id, provider, workflow, name, 'processed')}
+          onCancel={(id, provider, name) => onCancel(id, provider, name, 'processed')}
+          onDelete={(id, name) => onDelete(id, name, 'processed')}
+          onExport={(id, type, name) => onExport(id, type, name, 'processed')}
           batchStatus="processed"
           key={`processed-${refreshKey}`}
           processingBatches={processingBatches}
           unmarkProcessing={unmarkProcessing}
           lang={lang}
+          announceCompletions
         />
       </section>
     </GcdsContainer>

--- a/src/pages/__tests__/BatchPage.test.js
+++ b/src/pages/__tests__/BatchPage.test.js
@@ -27,8 +27,15 @@ vi.mock('../../services/ExportService.js', () => ({ default: { export: vi.fn() }
 vi.mock('../../components/batch/BatchUpload.js', () => ({ default: () => null }));
 // Expose onDelete directly as a clickable button so the test can trigger the
 // real BatchPage.onDelete handler without needing BatchList's own DataTable.
+// batchStatus distinguishes the "running" instance from the "processed" one
+// (BatchPage.js passes a different batchStatus filter to each) - labeled
+// per-section so tests can trigger a failure in one specific section
+// without also triggering the other.
 vi.mock('../../components/batch/BatchList.js', () => ({
-  default: ({ onDelete }) => <button onClick={() => onDelete('batch-1')}>trigger-delete</button>,
+  default: ({ onDelete, batchStatus }) => {
+    const section = batchStatus === 'processed' ? 'processed' : 'running';
+    return <button onClick={() => onDelete('batch-1')}>trigger-delete-{section}</button>;
+  },
 }));
 
 vi.mock('@gcds-core/components-react', () => ({
@@ -47,22 +54,77 @@ describe('BatchPage StatusMessage roles', () => {
     mockDeleteBatch.mockRejectedValue(new Error('delete failed'));
 
     renderWithRouter(<BatchPage lang="en" />);
-    fireEvent.click(screen.getAllByText('trigger-delete')[0]);
+    fireEvent.click(screen.getByText('trigger-delete-running'));
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toContain('batch.list.actions.deleteError');
   });
 
-  it('announces a successful delete as role="status"', async () => {
+  it('announces a successful delete as an sr-only role="status" region, not a visible box', async () => {
     mockDeleteBatch.mockResolvedValue({});
 
     renderWithRouter(<BatchPage lang="en" />);
-    fireEvent.click(screen.getAllByText('trigger-delete')[0]);
+    fireEvent.click(screen.getByText('trigger-delete-running'));
 
     await waitFor(() => {
       expect(screen.getByText('batch.list.actions.deleteSuccess')).toBeTruthy();
     });
-    expect(screen.getByText('batch.list.actions.deleteSuccess').closest('[role="status"]')).toBeTruthy();
+    const region = screen.getByText('batch.list.actions.deleteSuccess').closest('[role="status"]');
+    expect(region).toBeTruthy();
+    // Success is sr-only, not a visible box - the table itself already shows
+    // the outcome to a sighted user (the row disappears), so this shouldn't
+    // render as a status-message--success-box the way an error does.
+    expect(region.className).toContain('sr-only');
+    expect(region.className).not.toContain('status-message--success-box');
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it("does not remount/re-announce the processed section's error box when a later, unrelated error fires in the running section", async () => {
+    mockDeleteBatch.mockRejectedValue(new Error('delete failed'));
+
+    renderWithRouter(<BatchPage lang="en" />);
+
+    // Establish a real, non-null error in "processed" first - the shared-
+    // nonce bug only manifests once a section already has content to
+    // preserve (an untouched section renders null regardless of nonce, see
+    // StatusMessage.js's own early-return branch).
+    fireEvent.click(screen.getByText('trigger-delete-processed'));
+    const processedAlert = await screen.findAllByRole('alert');
+    // Both sections' boxes share role="alert" text/classing, so identify
+    // "processed"'s specifically by DOM position relative to its own
+    // trigger button, then capture its node identity to compare later.
+    const processedNode = screen.getByText('trigger-delete-processed').closest('section').querySelector('[role="alert"]');
+    expect(processedNode).toBeTruthy();
+
+    // Now fire a second, unrelated error in "running" only.
+    fireEvent.click(screen.getByText('trigger-delete-running'));
+    await waitFor(() => {
+      const runningNode = screen.getByText('trigger-delete-running').closest('section').querySelector('[role="alert"]');
+      expect(runningNode).toBeTruthy();
+    });
+
+    // "processed"'s own error box must be the exact same DOM node as
+    // before - a shared nonce would have forced it to remount (a fresh
+    // node, its stale text freshly inserted) purely because "running"
+    // changed, even though errors.processed itself never did.
+    const processedNodeAfter = screen.getByText('trigger-delete-processed').closest('section').querySelector('[role="alert"]');
+    expect(processedNodeAfter).toBe(processedNode);
+  });
+
+  it('clears a section\'s visible error box once a later action in that same section succeeds', async () => {
+    mockDeleteBatch.mockRejectedValueOnce(new Error('delete failed'));
+
+    renderWithRouter(<BatchPage lang="en" />);
+    fireEvent.click(screen.getByText('trigger-delete-running'));
+    await screen.findByRole('alert');
+
+    // Retry, this time succeeding - the earlier error box shouldn't just
+    // sit there forever contradicting what actually happened.
+    mockDeleteBatch.mockResolvedValueOnce({});
+    fireEvent.click(screen.getByText('trigger-delete-running'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
   });
 });

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -812,6 +812,23 @@
   margin-block-start: var(--gcds-spacing-200);
   padding: var(--gcds-spacing-200);
 }
+/* overflow-x: auto above makes this a scrollable region, which browsers
+   treat as implicitly keyboard-focusable (so arrow keys can scroll it when
+   the table is wider than the viewport lets it show, e.g. BatchList.js's 9
+   columns) - that's correct and shouldn't be removed (SC 2.1.1). Left
+   unstyled, focusing it drew the browser's raw default outline around the
+   whole 90vw breakout box - at that width, and outset (the default outline
+   position, outside the box) against this container's own negative
+   centering margins above, it reads as a huge, misplaced rectangle rather
+   than a focus ring on anything in particular. Same GC DS focus token as
+   the rest of this file, drawn inset (negative offset) instead of outset so
+   it hugs the container's own visible edge - still clearly visible, just
+   contained to the box it's actually indicating instead of floating past
+   it. */
+.dashboard-table-container:focus-visible {
+  outline: var(--gcds-input-outline-width) solid var(--gcds-input-focus-border);
+  outline-offset: calc(-1 * var(--gcds-input-outline-width));
+}
 /* Chat and Eval Dashboard only, so far (this container class itself is
    shared with AutoEval Dashboard too, hence the --grouped-scoped override
    rather than editing the base rule above): the gap between FilterPanel's
@@ -1015,6 +1032,27 @@ table.dataTable.dashboard-table.dashboard-table--grouped > tbody > tr.chat-group
 table.dataTable.dashboard-table.dashboard-table--grouped > tbody > tr > .sorting_1,
 table.dataTable.dashboard-table.dashboard-table--grouped > tbody > tr > .sorting_2,
 table.dataTable.dashboard-table.dashboard-table--grouped > tbody > tr > .sorting_3 {
+  box-shadow: inset 0 0 0 9999px rgba(235, 242, 250, 1);
+}
+/* Same blue highlight, for plain (non-grouped) .dashboard-table instances -
+   BatchList.js currently, the only other .dashboard-table consumer, and
+   deliberately without --grouped (no rowspan grouping to conflict with, see
+   this class's own comment in BatchList.js). This table doesn't have the
+   chat-group-a/b box-shadow conflict the rule above exists to work around,
+   so it doesn't need that rule's specificity/source-order reasoning either
+   - just the same solid pale-blue tint. This was the actual reason the
+   sorted-column highlight never showed up here: DataTables' own native
+   .sorting_1/2/3 (targeted correctly, confirmed by a direct test) resolves
+   to a near-invisible ~2% black tint by design, same as the --grouped
+   comment above already explains - there was simply no rule giving a plain
+   .dashboard-table the same real colour the grouped one gets. :not(),
+   not just a second identical-looking rule, so a table can't ever match
+   both this and the --grouped rule above at once (it only ever carries one
+   of the two class combinations, but this keeps that explicit rather than
+   relying on it staying true). */
+table.dataTable.dashboard-table:not(.dashboard-table--grouped) > tbody > tr > .sorting_1,
+table.dataTable.dashboard-table:not(.dashboard-table--grouped) > tbody > tr > .sorting_2,
+table.dataTable.dashboard-table:not(.dashboard-table--grouped) > tbody > tr > .sorting_3 {
   box-shadow: inset 0 0 0 9999px rgba(235, 242, 250, 1);
 }
 /* Chat ID/Department/Service(-or-Program)/Referring URL cells collapsed via
@@ -1456,6 +1494,11 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
   border-radius: 999px;
   font-size: 14px;
   font-weight: 500;
+  /* inline-block still wraps text by default once its column narrows -
+     a pill breaking onto two lines loses its rounded-pill shape entirely
+     and just looks broken. Pills are always short status/eval words, never
+     long-form content, so nowrap is safe everywhere this class is used. */
+  white-space: nowrap;
 }
 
 .label + .label {
@@ -1500,9 +1543,12 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
 }
 
 /* User type labels — shared with DatabasePage.js's .label.building
-   ("building" has no neutral tier of its own below). */
+   ("building" has no neutral tier of its own below), and BatchList.js's
+   in_progress status pill below (same "actively working" meaning as
+   building's blue tier). */
 .label.public,
-.label.building {
+.label.building,
+.label.in_progress {
   background-color: var(--gcds-color-blue-100);
   color: var(--gcds-color-blue-650);
 }
@@ -1517,8 +1563,10 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
   color: #00695C;
 }
 
-/* Answer type labels */
-.label.normal {
+/* Answer type labels, also shared by BatchList.js's "uploaded" status pill -
+   the batch's default, not-yet-started state. */
+.label.normal,
+.label.uploaded {
   background-color: var(--gcds-color-grayscale-50);
   color: var(--gcds-color-grayscale-700);
 }
@@ -1536,9 +1584,11 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
 /* Evaluation labels + DatabasePage.js index-build status share one
    good/caution/error tier. SuiteGridTable.js's pass/mixed/error verdict
    cells reuse these same classes below — only its flagged/missing cells
-   are their own thing, see that file. */
+   are their own thing, see that file. BatchList.js's processed status pill
+   joins the same green tier — same "done, no issues" meaning. */
 .label.correct,
 .label.complete,
+.label.processed,
 .verdict-cell--pass {
   background-color: #d8eeca;
   color: #1d4d27;
@@ -1547,7 +1597,8 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
 .label.needsImprovement,
 .label.incomplete,
 .verdict-cell--mixed,
-.label.partial {
+.label.partial,
+.label.unknown {
   background-color: var(--gcds-color-yellow-100);
   color: #7a5a00;
 }
@@ -2939,4 +2990,127 @@ table.dataTable.dashboard-table thead th[data-tooltip]::after {
 
 .admin-notifications-action::after {
   content: "→";
+}
+
+/* BatchUpload.js's step-2 form card. Deliberately its own class, not built
+   on chat.css's .feedback-reason-card (which PublicFeedbackComponent.js/
+   ExpertFeedbackComponent.js also use) — an earlier version of this class
+   shared the base rule and overrode just the border with a modifier, but
+   that still meant an edit to the shared class's background/padding would
+   silently reach this card too, with nothing here signalling that to
+   whoever made it. Full duplication instead: no border (unlike the chat
+   version), everything else copied rather than inherited, so this card's
+   own look is genuinely independent of the chat feedback cards' — change
+   one without the other changing underneath it. */
+.batch-upload-card {
+  background-color: var(--gcds-bg-white);
+}
+
+/* .zebra-stable-on-hover - general-purpose utility for any `display`-class
+   DataTable (dataTables.dataTables.css) that wants its zebra stripe to look
+   identical whether or not the pointer is over the row, not specific to
+   BatchList.js (its first consumer) - add the class to any other table that
+   wants the same thing. DataTables' `display` class ships a row-hover
+   shading effect layered *on top of* the zebra striping below
+   (`table.dataTable.display > tbody > tr:hover > *`, an inset box-shadow).
+   Neutralizing only the box-shadow (not background-color)
+   is deliberate: the zebra stripe itself is a separate, unconditional
+   background-color rule below on tr:nth-child(odd), so removing just the
+   shadow leaves a striped row's own colour untouched on hover instead of
+   flashing it to transparent - "no hover effect" means the row looks
+   exactly the same whether or not the pointer is over it, stripe included.
+   One extra class was meant to raise specificity above DataTables' own
+   selector, same reasoning as the border override above - except DataTables
+   also has a *more specific* hover rule for whichever column is currently
+   sorted (tr:hover > .sorting_1/2/3, its own extra class from the sort
+   state) that ties this rule's specificity exactly, so which one wins on
+   that column depends on the two stylesheets' load order rather than
+   losing outright - not reliable either way. !important sidesteps the tie
+   instead of trying to out-specify a selector that can always add one more
+   class. Doesn't touch the *separate*, non-:hover rule that gives the
+   sorted column its persistent tint at rest (table.dataTable.display >
+   tbody tr > .sorting_1, no :hover in that selector) - that one's supposed
+   to stay exactly as-is; only the extra boost DataTables adds on top of it
+   while hovering is what this removes.
+
+   `none` outright (what this rule used to say) was wrong for striped (odd)
+   rows specifically: DataTables' own zebra stripe is ALSO box-shadow
+   (table.dataTable.display > tbody > tr:nth-child(odd) > *, a faint
+   --dt-row-stripe tint) - box-shadow doesn't stack across separate rules,
+   whichever one wins applies its whole value, so blanking it to `none` on
+   hover erased the stripe's own tint too, not just the extra hover
+   darkening layered on top of it - a striped row visibly flashed to plain
+   white the instant the pointer crossed it. Restoring each row's own
+   *non-hover* shadow instead of removing it keeps the stripe intact while
+   still cancelling the hover-specific change - split by nth-child so odd
+   rows get their stripe's exact value back and even rows (no stripe to
+   begin with) get `none`, matching what each already looks like outside
+   :hover. */
+table.dataTable.display.zebra-stable-on-hover > tbody > tr:hover:nth-child(odd) > * {
+  box-shadow: inset 0 0 0 9999px rgba(var(--dt-row-stripe), var(--dt-row-stripe-alpha)) !important;
+}
+table.dataTable.display.zebra-stable-on-hover > tbody > tr:hover:nth-child(even) > * {
+  box-shadow: none !important;
+}
+/* Same "nothing changes on hover" intent as the two rules above, but the two
+   rules above didn't know about the sorted-column blue tint (further down
+   this file, table.dataTable.dashboard-table:not(.dashboard-table--grouped)
+   > tbody > tr > .sorting_1/2/3) when they were written - `> *` matches
+   every cell in the row indiscriminately, including a .sorting_1-classed
+   one, so hovering the sorted column was overwriting its blue with the
+   plain stripe/none value instead of leaving it alone. One more class
+   (.sorting_1/2/3) in the selector makes these win over the two rules
+   above for that specific cell; !important still needed for the same
+   reason as those two, to beat DataTables' own same-specificity hover+sort
+   rule rather than gamble on stylesheet load order. */
+table.dataTable.display.zebra-stable-on-hover > tbody > tr:hover > .sorting_1,
+table.dataTable.display.zebra-stable-on-hover > tbody > tr:hover > .sorting_2,
+table.dataTable.display.zebra-stable-on-hover > tbody > tr:hover > .sorting_3 {
+  box-shadow: inset 0 0 0 9999px rgba(235, 242, 250, 1) !important;
+}
+
+/* BatchList.js's visible "paused" design element - sits under the pause
+   button, above the table (in normal flow, not absolutely positioned over
+   any part of the table itself). aria-hidden in the markup: the real
+   announcement is the sr-only persistent StatusMessage rendered alongside
+   it, this is the sighted-user half only. Same neutral grayscale-50/200/700
+   triad as .status-message--loading elsewhere in this file, not any of
+   StatusMessage's own error/warning/info/success box tokens - deliberately
+   its own look ("paused" isn't one of those outcomes), not a StatusMessage
+   variant box reused for something StatusMessage itself only announces. */
+.dashboard-table-paused-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gcds-spacing-100);
+  /* inline-flex sits it on the same line as PauseToggleButton (a plain
+     <button>, inline-block by default) right before it - margin-left, not
+     padding, since padding would grow the pill's own box (and its border)
+     rather than just putting space between it and the button. */
+  margin-left: var(--gcds-spacing-200);
+  background-color: var(--gcds-color-grayscale-50);
+  border: 1px solid var(--gcds-color-grayscale-200);
+  color: var(--gcds-color-grayscale-700);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+}
+
+/* .table-row-actions - generic, reusable wrapper for a row of GcdsButtons
+   packed into one table cell (BatchList.js's Actions column is the first
+   consumer, meant for others too). GcdsButton's own "small" text size
+   (--gcds-button-small-font-desktop, 1.125rem/18px) reads large stacked
+   several-in-a-row inside a table cell; this drops it to 1rem/16px.
+   Overriding a CSS custom property on this wrapper - not a font-size rule
+   on the buttons themselves - is the only way to reach in: GcdsButton's own
+   `font: var(--gcds-button-small-font-desktop)` rule lives inside its
+   shadow DOM, invisible to an outside selector, but custom properties
+   (unlike regular CSS properties) inherit through shadow boundaries, so
+   redefining the same variable here on an ancestor light-DOM element
+   reaches the shadow-DOM rule that consumes it. Padding is untouched (a
+   separate, fixed token - 0.375rem/1rem - not derived from font-size), so
+   this only shrinks the glyphs, not the ~41px-tall tap target underneath
+   them, which stays clear of the 24px WCAG 2.5.8 minimum either way. */
+.table-row-actions {
+  --gcds-button-small-font-desktop: 400 1rem/155% "Noto Sans", sans-serif;
 }

--- a/src/utils/htmlEscape.js
+++ b/src/utils/htmlEscape.js
@@ -1,0 +1,16 @@
+// Escapes a value for safe interpolation into a hand-built HTML string.
+// DataTables `render` functions (and other hand-rolled markup builders)
+// return raw HTML rather than JSX, so nothing there gets React's automatic
+// escaping - anything dynamic/translated needs to go through this first.
+//
+// Single shared copy - reviewLink.js and labelPill.js both re-export this
+// rather than keeping their own, so there's exactly one place that owns
+// the escaping rules.
+export const escapeHtml = (value) => {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+};

--- a/src/utils/labelPill.js
+++ b/src/utils/labelPill.js
@@ -1,0 +1,16 @@
+import { escapeHtml } from './htmlEscape.js';
+
+// Re-exported so callers of labelPill.js (a pure CSS/presentation helper,
+// not a link builder) don't need to reach into htmlEscape.js separately -
+// see that file for the actual implementation, shared with reviewLink.js.
+export { escapeHtml };
+
+// Builds one `.label` pill (admin.css's shared colour-tier pills - see its
+// own comments for which classes map to which colour) as a raw HTML string,
+// for DataTables `render` functions. Purely presentational - not a link or
+// any other interactive element, so this has no dependency beyond the CSS
+// class itself. `className` is the tier-selecting class (e.g. 'processed',
+// 'failed', 'correct') - admin.css chains it onto the shared colour rule it
+// belongs to rather than giving every caller its own hex values.
+export const buildLabelPillHtml = (className, label) =>
+  `<span class="label ${escapeHtml(className)}">${escapeHtml(label)}</span>`;

--- a/src/utils/reviewLink.js
+++ b/src/utils/reviewLink.js
@@ -8,21 +8,19 @@
 // HTML string for DataTables render functions, which render raw HTML
 // rather than JSX.
 
+import { escapeHtml } from './htmlEscape.js';
+
 const buildInteractionHash = (interactionId) => {
   if (!interactionId) return '';
   return `#interaction=${encodeURIComponent(`interactionId${interactionId}`)}`;
 };
 
-// Escapes a value for safe interpolation into an HTML attribute/text
-// context. Also used by DataTables columns unrelated to this link.
-export const escapeHtmlAttribute = (value) => {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-};
+// Re-exported under this file's existing name so its consumers
+// (ChatDashboardPage.js, EvalDashboardPage.js, UsersPage.js) don't need to
+// change their imports - see htmlEscape.js for the actual implementation,
+// shared with labelPill.js. Not actually specific to links; kept here only
+// for import-compatibility with existing callers.
+export const escapeHtmlAttribute = escapeHtml;
 
 // For React <GcdsLink href={...}>.
 export const buildChatReviewHref = (chatId, lang, interactionId) =>


### PR DESCRIPTION
…ontrol)

 
  Accessibility pass on the batch evaluation page (`/admin/batches`) -
  `BatchPage.js` and `BatchList.js` - plus three bugs QA caught along the way.

  Screen-reader users had no reliable signal when a batch action
  (Process/Delete/Export/Cancel) succeeded or failed, no way to pause the
  table's 10s auto-refresh (SC 2.2.2), and focus was dropping to `<body>`
  after row-level actions caused the table to remount.

  ## Accessibility changes
  - **Per-section error announcements**: a failed action now shows its
    error next to the table it belongs to (Running vs. Processed), not in
    one shared box disconnected from both.
  - **sr-only success announcements**: successes stay screen-reader-only,
    since the table itself already shows the outcome visually (row moves/
    disappears, status updates) - a redundant visible box was noise.
  - **Focus restoration**: clicking a row action (Process/Delete/Cancel)
    and having the table remount underneath it no longer drops focus to
    `<body>`. Restoration targets the *specific* button clicked (not just
    "whatever's first"), and falls back to the pause button for a
    successful delete, where the row is gone and there's nothing left to
    refocus.
  - **Pause control**: the 10s poll can now be paused/resumed, with both a
    visual indicator and an sr-only announcement.
  - **Batch completion/failure announcements**: surfaced via a shared
    sr-only live region so admins don't have to notice a status badge
    change on their own.

  ## Bugs found and fixed during QA
  Ran this through `/code-review` and the `accessibility-review` skill
  before merging. Two real bugs turned up, both fixed:
  1. A section's visible error box wasn't cleared by a later success in
     that section - a stale "failed" banner could sit on screen after a
     successful retry.
  2. A "batch failed" sr-only announcement branch was dead code -
     `BatchService.getBatchStatuses` can never actually produce a
     `'failed'` status, so it never fired. Removed the branch and its
     now-unused locale key.

  Also added a missing `catch` on an async fire-and-forget delete path
  (latent, low severity).

  ## Testing
  - New `BatchList` test suite (11 tests): focus restoration/fallback,
    pause-gating across both list instances, sort-column highlighting.
  - `BatchPage` tests updated for the per-section error/success flow,
    including a regression test for the shared-nonce bug class (one
    section's error box must not remount/re-announce when a different
    section's error changes).
  - `node scripts/find-dead-locale-keys.cjs`: 0 parity gaps.
