### PR TITLE
fix: bump warning-box text to yellow-750 for AA contrast

### DIFF
--- a/docs/coding-agent-docs/design-system.md
+++ b/docs/coding-agent-docs/design-system.md
@@ -139,7 +139,7 @@ Greys and borders used only for structural layout (not data encoding) may stay l
 |---|---|---|---|---|---|
 | Loading | `<StatusMessage loading message={...} />` | `status-message--loading` | `--gcds-color-grayscale-50/200/700` | `.loading-animation` pulsing-bars spinner (shared with `.section-loading-indicator`, `prefers-reduced-motion`-aware) | In-progress state, not a completed result |
 | Error | `<StatusMessage variant="error" message={...} />` | `status-message--error-box` | `--gcds-color-red-100/500/700` | `GcdsIcon warning-triangle` | Failures |
-| Warning | `<StatusMessage variant="warning" message={...} />` | `status-message--warning-box` | `--gcds-color-yellow-100/500/700` | `GcdsIcon warning-triangle` | Cautions (e.g. unsaved changes) |
+| Warning | `<StatusMessage variant="warning" message={...} />` | `status-message--warning-box` | `--gcds-color-yellow-100/500/750` | `GcdsIcon warning-triangle` | Cautions (e.g. unsaved changes) |
 | Info | `<StatusMessage variant="info" message={...} />` | `status-message--info-box` | `--gcds-color-blue-100/500/700` | `GcdsIcon info-circle` | Neutral confirmations |
 | Success | `<StatusMessage variant="success" message={...} />` | `status-message--success-box` | `--gcds-color-green-100/500/700` | raw `fa-solid fa-check-circle` span (GC DS's icon font has no checkmark glyph, matching the existing precedent in `BatchUpload.js`) | Completed saves |
 

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1858,11 +1858,16 @@ table.dataTable.dashboard-table thead th[data-tooltip]:has(.dt-column-order:focu
 /* Same box treatment as .status-message--error-box, for a caution rather than a
    failure (SettingsPage's page-level "Unsaved changes" banner) — GC DS has
    no orange token family, so this uses the yellow/gold triad instead,
-   same red-100/500/700 pairing shape .status-message--error-box uses. */
+   same 100/500 background/border pairing shape .status-message--error-box
+   uses. Text is yellow-750, not yellow-700 (unlike the red/blue/green
+   triads): yellow-700 on yellow-100 only reaches 4.39:1, short of the
+   4.5:1 minimum for normal-size text (SC 1.4.3); yellow-750 reaches ~5.79:1
+   — enough margin above the minimum without overshooting to yellow-800's
+   ~7.8:1, which reads noticeably darker than the other three triads. */
 .status-message--warning-box {
   background: var(--gcds-color-yellow-100);
   border: 1px solid var(--gcds-color-yellow-500);
-  color: var(--gcds-color-yellow-700);
+  color: var(--gcds-color-yellow-750);
 }
 
 /* Same box treatment as .status-message--error-box/.status-message--warning-box, for a
@@ -2853,7 +2858,7 @@ table.dataTable.dashboard-table thead th[data-tooltip]::after {
    from its own AdminNotifications.css so all admin styling lives in this one
    stylesheet, consistent with the rest of the admin section.
    TODO: this panel predates StatusMessage's variant box treatment
-   (.status-message--warning-box etc., using --gcds-color-yellow-100/500/700 —
+   (.status-message--warning-box etc., using --gcds-color-yellow-100/500/750 —
    see above) and still hand-rolls its own yellow/amber palette and
    gradient background instead of it. Worth reviewing whether this can be
    consolidated onto that shared warning styling rather than keeping a
@@ -2905,8 +2910,8 @@ table.dataTable.dashboard-table thead th[data-tooltip]::after {
 
 .admin-notifications-item--warning .admin-notifications-count {
   /* #d97706 was ~3.19:1 against the white badge text, below the 4.5:1
-     minimum for normal-size text (SC 1.4.3). --gcds-color-yellow-700 (also
-     used by .status-message--warning-box above) reaches ~5:1. */
+     minimum for normal-size text (SC 1.4.3). --gcds-color-yellow-700
+     reaches ~5:1. */
   background: var(--gcds-color-yellow-700);
   color: white;
 }


### PR DESCRIPTION
  --gcds-color-yellow-700 on yellow-100 only reaches 4.39:1, short of the
  4.5:1 minimum for normal-size text (SC 1.4.3). Use yellow-750 (~5.79:1)
  instead of yellow-800 (~7.8:1), which overshoots and reads darker than
  the other status-message triads. Updates the CSS and the design-system
  doc table, which had also drifted out of sync.