### PR TITLE
fix: remove un-pausable auto-redirects, only navigate to admin when a…

### DIFF
--- a/src/components/admin/StatusMessage.js
+++ b/src/components/admin/StatusMessage.js
@@ -39,6 +39,16 @@ import { GcdsIcon } from '@gcds-core/components-react';
 // comment for why that shipped 5 icon-less error boxes before this fixed
 // it at the root.)
 //
+// TODO (design review): the four variant boxes lay out icon + content as
+// plain inline flow (unlike .status-message--loading, which is already
+// display:flex) — fine for a one-line `message` string, but `children` with
+// a block element (e.g. RegisterPage.js's two-<p> pending-approval message)
+// forces a line break right after the icon, stranding it above the text
+// instead of beside it. Needs a content wrapper (icon + wrapper as two flex
+// items, wrapper holding however many paragraphs) to fix properly, not a
+// CSS-only patch — bundling into the design pass below rather than doing
+// it ad hoc.
+//
 // TODO (design review): none of this component's CSS — the four variant
 // boxes, the loading box, the plain isError/tag styling — has had an actual
 // design pass; it was built engineering-led to close a11y gaps. Treat every

--- a/src/hooks/auth/useAuthOutcomeMessages.js
+++ b/src/hooks/auth/useAuthOutcomeMessages.js
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+// Centralizes the success/system-error message pair shared across the
+// sign-in/account pages (RegisterPage, ResetRequestPage, ResetCompletePage)
+// — success is a completed action outcome (StatusMessage variant="success"),
+// systemError is an outcome the user can't fix by editing a field
+// (StatusMessage variant="error"). Field-tied errors stay on the separate
+// useAuthFormValidation/AnnouncedError pair; this hook only covers the two
+// StatusMessage-rendered outcomes.
+//
+// Extracted after the three pages independently hand-rolled this same pair
+// and drifted once as a result — RegisterPage's "Sign in" link ended up
+// conditional on successMessage while the other two pages' didn't, purely
+// because each page's version was written separately. Sharing the state
+// shape doesn't prevent every kind of drift on its own, but removes one
+// source of it.
+export const useAuthOutcomeMessages = () => {
+  const [successMessage, setSuccessMessage] = useState('');
+  const [systemError, setSystemError] = useState('');
+
+  const clearMessages = () => {
+    setSuccessMessage('');
+    setSystemError('');
+  };
+
+  return { successMessage, setSuccessMessage, systemError, setSystemError, clearMessages };
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1024,7 +1024,8 @@
     "passwordTooShort": "Password must be at least 8 characters.",
     "errorOccurred": "An error occurred creating your account.",
     "submitting": "Creating account...",
-    "pending": "We've received your account request. An administrator must activate it before you can sign in."
+    "pendingReceived": "We've received your account request.",
+    "pendingActivation": "An administrator will contact you once your account is activated and you can sign in."
   },
   "users": {
     "title": "Manage user accounts",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1005,7 +1005,7 @@
       "confirm": "Confirm new password",
       "submit": "Set password",
       "submitting": "Submitting...",
-      "success": "Password updated. Redirecting to sign in...",
+      "success": "We've updated your password.",
       "error": "Failed to reset password.",
       "invalid": "Invalid reset link.",
       "passwordTooShort": "Password must be at least 8 characters.",
@@ -1023,7 +1023,8 @@
     "passwordMismatch": "Passwords do not match.",
     "passwordTooShort": "Password must be at least 8 characters.",
     "errorOccurred": "An error occurred creating your account.",
-    "submitting": "Creating account...wait for approval"
+    "submitting": "Creating account...",
+    "pending": "We've received your account request. An administrator must activate it before you can sign in."
   },
   "users": {
     "title": "Manage user accounts",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -952,7 +952,8 @@
     "passwordMismatch": "Les mots de passe ne correspondent pas.",
     "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
     "errorOccurred": "Une erreur est survenue lors de l'inscription.",
-    "submitting": "Création du compte...en attente d'approbation"
+    "submitting": "Création du compte...",
+    "pending": "Nous avons reçu votre demande de compte. Un administrateur doit l'activer avant que vous puissiez vous connecter."
   },
   "login": {
     "title": "Se connecter à l'administration de Réponses IA",
@@ -1016,7 +1017,7 @@
       "confirm": "Confirmer le nouveau mot de passe",
       "submit": "Définir le mot de passe",
       "submitting": "Envoi...",
-      "success": "Mot de passe mis à jour. Redirection vers la page de connexion...",
+      "success": "Nous avons mis à jour votre mot de passe.",
       "error": "Échec de la réinitialisation du mot de passe.",
       "invalid": "Lien de réinitialisation invalide.",
       "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -953,7 +953,8 @@
     "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
     "errorOccurred": "Une erreur est survenue lors de l'inscription.",
     "submitting": "Création du compte...",
-    "pending": "Nous avons reçu votre demande de compte. Un administrateur doit l'activer avant que vous puissiez vous connecter."
+    "pendingReceived": "Nous avons reçu votre demande de compte.",
+    "pendingActivation": "Un administrateur communiquera avec vous une fois votre compte activé et vous pourrez vous connecter."
   },
   "login": {
     "title": "Se connecter à l'administration de Réponses IA",

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -46,7 +46,10 @@ const RegisterPage = ({ lang = 'en' }) => {
       if (data.user?.active) {
         navigate(getPath('admin', lang));
       } else {
-        setSuccessMessage(t('signup.pending'));
+        // Just a truthy flag here, not display text - the two sentences
+        // below are rendered as separate <p>s via StatusMessage's
+        // `children` escape hatch (one string can't become two paragraphs).
+        setSuccessMessage(true);
       }
     } catch {
       setSystemError(t('signup.errorOccurred'));
@@ -58,7 +61,14 @@ const RegisterPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-signup-container">
       <h1>{t('signup.title')}</h1>
-      <StatusMessage variant="success" message={successMessage} />
+      <StatusMessage variant="success">
+        {successMessage && (
+          <>
+            <p>{t('signup.pendingReceived')}</p>
+            <p>{t('signup.pendingActivation')}</p>
+          </>
+        )}
+      </StatusMessage>
       <StatusMessage variant="error" message={systemError} />
       {error && (
         <AnnouncedError id="signup-error" message={error} errorCount={errorCount} inputRef={errorRef} />
@@ -113,9 +123,16 @@ const RegisterPage = ({ lang = 'en' }) => {
           </button>
         </form>
       )}
-      <div className="auth-links">
-        <Link to={getPath('signin', lang)}>{t('login.form.signinLink')}</Link>
-      </div>
+      {/* Only useful before submit (someone who landed here by mistake and
+          already has an account). Once signup succeeds, the account is
+          pending approval - there's nothing to sign into yet, an email is
+          what tells them when that changes - so the link would just be a
+          dead end here. */}
+      {!successMessage && (
+        <div className="auth-links">
+          <Link to={getPath('signin', lang)}>{t('login.form.signinLink')}</Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import AuthService from '../services/AuthService.js';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
+import StatusMessage from '../components/admin/StatusMessage.js';
 import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { useAuthOutcomeMessages } from '../hooks/auth/useAuthOutcomeMessages.js';
 import { normalizeEmail } from '../utils/auth/validateEmail.js';
 
 const RegisterPage = ({ lang = 'en' }) => {
@@ -14,11 +16,13 @@ const RegisterPage = ({ lang = 'en' }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const { successMessage, setSuccessMessage, systemError, setSystemError, clearMessages } = useAuthOutcomeMessages();
   const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    clearMessages();
     clearError();
 
     const trimmedEmail = normalizeEmail(email);
@@ -38,10 +42,14 @@ const RegisterPage = ({ lang = 'en' }) => {
 
     setIsLoading(true);
     try {
-      await AuthService.signup(trimmedEmail, password);
-      navigate(getPath('admin', lang));
-    } catch (err) {
-      setError(err.message || t('signup.errorOccurred'));
+      const data = await AuthService.signup(trimmedEmail, password);
+      if (data.user?.active) {
+        navigate(getPath('admin', lang));
+      } else {
+        setSuccessMessage(t('signup.pending'));
+      }
+    } catch {
+      setSystemError(t('signup.errorOccurred'));
     } finally {
       setIsLoading(false);
     }
@@ -50,57 +58,64 @@ const RegisterPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-signup-container">
       <h1>{t('signup.title')}</h1>
+      <StatusMessage variant="success" message={successMessage} />
+      <StatusMessage variant="error" message={systemError} />
       {error && (
         <AnnouncedError id="signup-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={handleSubmit} noValidate>
-        <div className="auth-form-group">
-          <label htmlFor="email">{t('signup.email')}</label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            title={t('signup.email')}
-            autoComplete="email"
-            onChange={(e) => setEmail(e.target.value)}
+      {!successMessage && (
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="auth-form-group">
+            <label htmlFor="email">{t('signup.email')}</label>
+            <input
+              type="email"
+              id="email"
+              value={email}
+              title={t('signup.email')}
+              autoComplete="email"
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isLoading}
+              aria-describedby={error ? 'signup-error' : undefined}
+              aria-invalid={isFieldInvalid('email')}
+            />
+          </div>
+          <PasswordInput
+            id="password"
+            name="password"
+            label={t('signup.password')}
+            value={password}
+            title={t('signup.password')}
+            onChange={(e) => setPassword(e.target.value)}
             required
             disabled={isLoading}
-            aria-describedby={error ? 'signup-error' : undefined}
-            aria-invalid={isFieldInvalid('email')}
+            autoComplete="new-password"
+            ariaDescribedBy={error ? 'signup-error' : undefined}
+            ariaInvalid={isFieldInvalid('password')}
+            lang={lang}
           />
-        </div>
-        <PasswordInput
-          id="password"
-          name="password"
-          label={t('signup.password')}
-          value={password}
-          title={t('signup.password')}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          disabled={isLoading}
-          autoComplete="new-password"
-          ariaDescribedBy={error ? 'signup-error' : undefined}
-          ariaInvalid={isFieldInvalid('password')}
-          lang={lang}
-        />
-        <PasswordInput
-          id="confirmPassword"
-          name="confirmPassword"
-          label={t('signup.confirmPassword')}
-          value={confirmPassword}
-          title={t('signup.confirmPassword')}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          required
-          disabled={isLoading}
-          autoComplete="new-password"
-          ariaDescribedBy={error ? 'signup-error' : undefined}
-          ariaInvalid={isFieldInvalid('confirmPassword')}
-          lang={lang}
-        />
-        <button type="submit" disabled={isLoading} className="btn-primary-sm auth-submit-button">
-          {isLoading ? t('signup.submitting') : t('signup.submit')}
-        </button>
-      </form>
+          <PasswordInput
+            id="confirmPassword"
+            name="confirmPassword"
+            label={t('signup.confirmPassword')}
+            value={confirmPassword}
+            title={t('signup.confirmPassword')}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            disabled={isLoading}
+            autoComplete="new-password"
+            ariaDescribedBy={error ? 'signup-error' : undefined}
+            ariaInvalid={isFieldInvalid('confirmPassword')}
+            lang={lang}
+          />
+          <button type="submit" disabled={isLoading} className="btn-primary-sm auth-submit-button">
+            {isLoading ? t('signup.submitting') : t('signup.submit')}
+          </button>
+        </form>
+      )}
+      <div className="auth-links">
+        <Link to={getPath('signin', lang)}>{t('login.form.signinLink')}</Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useSearchParams, useNavigate, Link } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import { useTranslations } from '../hooks/useTranslations.js';
 import AuthService from '../services/AuthService.js';
 import { getPath } from '../utils/routes.js';
 import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
+import StatusMessage from '../components/admin/StatusMessage.js';
 import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { useAuthOutcomeMessages } from '../hooks/auth/useAuthOutcomeMessages.js';
+import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
 
 const ResetCompletePage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
@@ -14,20 +17,32 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   const email = searchParams.get('email');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
-  const [successMessage, setSuccessMessage] = useState('');
+  const { successMessage, setSuccessMessage, systemError, setSystemError, clearMessages } = useAuthOutcomeMessages();
   const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
-  const navigate = useNavigate();
+
+  // The invalid-link check fires once, on mount, before the user has done
+  // anything — unlike the submit-driven system errors below (which sit right
+  // next to the button the user just clicked), there's nothing nearby to
+  // anchor a sighted or keyboard user's attention, and no interaction to
+  // signal a screen reader was already paying attention to this part of the
+  // page. So this one case gets an explicit focus-move, same mechanism
+  // AnnouncedError uses (useFocusOnChange), just pointed at this
+  // StatusMessage instead — a dedicated counter keeps it from also firing
+  // for the unrelated submit-time errors sharing the same systemError state.
+  const [invalidLinkCount, setInvalidLinkCount] = useState(0);
+  const invalidLinkRef = useFocusOnChange(invalidLinkCount);
 
   useEffect(() => {
     if (!code || !email) {
-      setError(t('reset.complete.invalid'));
+      setSystemError(t('reset.complete.invalid'));
+      setInvalidLinkCount((n) => n + 1);
     }
   }, [code, email, t]);
 
   const submit = async (e) => {
     e && e.preventDefault();
-    setSuccessMessage('');
+    clearMessages();
     clearError();
     if (!validate({ password, confirm }, t)) {
       return;
@@ -45,14 +60,16 @@ const ResetCompletePage = ({ lang = 'en' }) => {
       // TOTP-based password reset
       await AuthService.resetPassword({ email, code, password });
       setSuccessMessage(t('reset.complete.success'));
-      setTimeout(() => navigate(getPath('signin', lang)), 2500);
     } catch (err) {
+      // Rate-limiting and an invalid/expired reset link aren't things the
+      // user can fix by editing password/confirm — system-level outcomes,
+      // not field errors, so they go through StatusMessage, not AnnouncedError.
       const errorKeys = {
         RESET_LOCKED_OUT: 'reset.complete.lockedOut',
         RESET_INVALID_CODE: 'reset.complete.invalidCode',
       };
       const key = err.code && errorKeys[err.code];
-      setError(key ? t(key) : t('reset.complete.error'));
+      setSystemError(key ? t(key) : t('reset.complete.error'));
     } finally {
       setIsLoading(false);
     }
@@ -61,46 +78,44 @@ const ResetCompletePage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.complete.title')}</h1>
-      {successMessage && (
-        <p className="thank-you" role="status" aria-live="polite">
-          <span className="gcds-icon fa fa-solid fa-check-circle" aria-hidden="true"></span>
-          {successMessage}
-        </p>
-      )}
+      <StatusMessage variant="success" message={successMessage} />
+      <StatusMessage variant="error" message={systemError} ref={invalidLinkRef} tabIndex={-1} />
       {error && (
         <AnnouncedError id="reset-complete-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={submit} noValidate>
-        {/* No code/OTP field — link verification is sufficient to set a new password */}
-        <PasswordInput
-          id="password"
-          name="password"
-          label={t('reset.complete.password')}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          disabled={isLoading}
-          autoComplete="new-password"
-          ariaDescribedBy={error ? 'reset-complete-error' : undefined}
-          ariaInvalid={isFieldInvalid('password')}
-          lang={lang}
-        />
-        <PasswordInput
-          id="confirm"
-          name="confirm"
-          label={t('reset.complete.confirm')}
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          required
-          disabled={isLoading}
-          autoComplete="new-password"
-          ariaDescribedBy={error ? 'reset-complete-error' : undefined}
-          ariaInvalid={isFieldInvalid('confirm')}
-          lang={lang}
-        />
+      {code && email && !successMessage && (
+        <form onSubmit={submit} noValidate>
+          {/* No code/OTP field — link verification is sufficient to set a new password */}
+          <PasswordInput
+            id="password"
+            name="password"
+            label={t('reset.complete.password')}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            disabled={isLoading}
+            autoComplete="new-password"
+            ariaDescribedBy={error ? 'reset-complete-error' : undefined}
+            ariaInvalid={isFieldInvalid('password')}
+            lang={lang}
+          />
+          <PasswordInput
+            id="confirm"
+            name="confirm"
+            label={t('reset.complete.confirm')}
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+            disabled={isLoading}
+            autoComplete="new-password"
+            ariaDescribedBy={error ? 'reset-complete-error' : undefined}
+            ariaInvalid={isFieldInvalid('confirm')}
+            lang={lang}
+          />
 
-        <button type="submit" className="btn-primary-sm auth-submit-button" disabled={isLoading || !code || !email}>{isLoading ? t('reset.request.sending') : t('reset.complete.submit')}</button>
-      </form>
+          <button type="submit" className="btn-primary-sm auth-submit-button" disabled={isLoading}>{isLoading ? t('reset.request.sending') : t('reset.complete.submit')}</button>
+        </form>
+      )}
       <div className="auth-links">
         <Link to={getPath('signin', lang)}>{t('login.form.signinLink')}</Link>
       </div>

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -1,23 +1,24 @@
 import React, { useState } from 'react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import AuthService from '../services/AuthService.js';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { getPath } from '../utils/routes.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
+import StatusMessage from '../components/admin/StatusMessage.js';
 import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { useAuthOutcomeMessages } from '../hooks/auth/useAuthOutcomeMessages.js';
 import { normalizeEmail } from '../utils/auth/validateEmail.js';
 
 const ResetRequestPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const [email, setEmail] = useState('');
-  const [successMessage, setSuccessMessage] = useState('');
+  const { successMessage, setSuccessMessage, systemError, setSystemError, clearMessages } = useAuthOutcomeMessages();
   const { error, errorCount, errorRef, setError, clearError, validate, isFieldInvalid } = useAuthFormValidation();
   const [isLoading, setIsLoading] = useState(false);
-  const navigate = useNavigate();
 
   const submit = async (e) => {
     e && e.preventDefault();
-    setSuccessMessage('');
+    clearMessages();
     clearError();
     const trimmedEmail = normalizeEmail(email);
     if (!validate({ email: trimmedEmail }, t)) {
@@ -27,10 +28,8 @@ const ResetRequestPage = ({ lang = 'en' }) => {
     try {
       await AuthService.sendReset(trimmedEmail, lang);
       setSuccessMessage(t('reset.request.sent'));
-      // Optionally redirect to signin after a short delay
-      setTimeout(() => navigate(getPath('signin', lang)), 3000);
-    } catch (err) {
-      setError(t('reset.request.error'));
+    } catch {
+      setSystemError(t('reset.request.error'));
     } finally {
       setIsLoading(false);
     }
@@ -39,33 +38,31 @@ const ResetRequestPage = ({ lang = 'en' }) => {
   return (
     <div className="auth-login-container">
       <h1>{t('reset.request.title')}</h1>
-      {successMessage && (
-        <p className="thank-you" role="status" aria-live="polite">
-          <span className="gcds-icon fa fa-solid fa-check-circle" aria-hidden="true"></span>
-          {successMessage}
-        </p>
-      )}
+      <StatusMessage variant="success" message={successMessage} />
+      <StatusMessage variant="error" message={systemError} />
       {error && (
         <AnnouncedError id="reset-request-error" message={error} errorCount={errorCount} inputRef={errorRef} />
       )}
-      <form onSubmit={submit} noValidate>
-        <div className="auth-form-group">
-          <label htmlFor="email">{t('login.email')}</label>
-          <input
-            id="email"
-            type="email"
-            value={email}
-            title={t('login.email')}
-            autoComplete="email"
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            disabled={isLoading}
-            aria-describedby={error ? 'reset-request-error' : undefined}
-            aria-invalid={isFieldInvalid('email')}
-          />
-        </div>
-        <button type="submit" className="btn-primary-sm auth-submit-button" disabled={isLoading}>{isLoading ? t('reset.request.sending') : t('reset.request.send')}</button>
-      </form>
+      {!successMessage && (
+        <form onSubmit={submit} noValidate>
+          <div className="auth-form-group">
+            <label htmlFor="email">{t('login.email')}</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              title={t('login.email')}
+              autoComplete="email"
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isLoading}
+              aria-describedby={error ? 'reset-request-error' : undefined}
+              aria-invalid={isFieldInvalid('email')}
+            />
+          </div>
+          <button type="submit" className="btn-primary-sm auth-submit-button" disabled={isLoading}>{isLoading ? t('reset.request.sending') : t('reset.request.send')}</button>
+        </form>
+      )}
       <div className="auth-links">
         <Link to={getPath('signin', lang)}>{t('login.form.signinLink')}</Link>
       </div>


### PR DESCRIPTION
### Redirect behaviour

- **`ResetRequestPage.js` / `ResetCompletePage.js`** — dropped the fixed `setTimeout` redirect to sign-in after success. It fails [WCAG 2.2.1 Timing Adjustable](https://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable.html): no way to pause, extend, or cancel it. The existing "Sign in" link is the standard model for a consequential-action success screen, so no redirect is needed.

- **`RegisterPage.js`** — now only auto-navigates to `/admin` when the signup response reports the account as active (i.e. the bootstrap first user). Every other new signup is created inactive pending admin approval, so it was being routed into a gated area it couldn't use yet. Those users now get a pending-activation message instead: an administrator will contact them once the account is activated. No sign-in link is shown, since there's nothing to sign into yet.

### Success messaging

- **All three pages** — migrated the hand-rolled `<p className="thank-you">` success message to the shared `StatusMessage` component (`variant="success"`), matching the convention used elsewhere in the app.

### Error handling

- **All three pages** — split error handling by kind instead of routing everything through `AnnouncedError`:
  - **Field-fixable errors** (password mismatch, password too short, required-field validation) stay on `AnnouncedError`.
  - **System-level outcomes the user can't fix by editing the form** — network/server failures, rate limiting, and an invalid or missing reset link on `ResetCompletePage` — now render via `StatusMessage variant="error"`. The invalid-link case gets its own explicit focus move on mount, since there's no nearby trigger to anchor attention the way a submit-driven error has.

- **`RegisterPage.js`** — stopped showing raw `err.message` on signup failure. It was surfacing untranslated, always-English browser/fetch text (e.g. `Failed to fetch`), which is an OL violation for French users and irrelevant besides. It now always shows the translated `signup.errorOccurred` message, matching the existing pattern in Login and Reset\*. Deliberately kept generic rather than distinguishing "email already exists" from other failures, to avoid an account-enumeration oracle.

### Strings

- **`en.json` / `fr.json`** — added `signup.pendingReceived` and `signup.pendingActivation` (split into two sentences so the pending-approval message renders as two paragraphs), reworded `reset.complete.success` so it no longer promises a redirect, and simplified `signup.submitting`.