### PR TITLE
fix: raw untranslated err.message to text except true developer strings 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,35 @@ French slugs must be real translations — not copied English slugs. Once regist
 
 Read [docs/coding-agent-docs/status-and-error-messaging.md](docs/coding-agent-docs/status-and-error-messaging.md) before rendering any save/delete/import/export/test-run/upload outcome, autosave failure, loading state, sr-only announcement, or form validation error. The short version: use `src/components/admin/StatusMessage.js` for page/section-level outcomes with no single input they belong to, and the form-error family (`AnnouncedError.js`/`FeedbackInlineError.js`/`ExplanationErrorSummary.js`) for anything tied to a specific field — don't hand-roll a plain `<div>`/`<p>`/`alert()` for either. Never show a raw `err.message`/`error.message` directly to the user; the doc covers why and the two established alternatives.
 
+**Never show a raw `err.message`/`error.message` directly to the user.** It's the literal,
+untranslated text a JS `Error` or `fetch()` rejection happened to carry (`"Failed to fetch"`,
+a driver's internal message, etc.) — always English regardless of the user's language, and
+often irrelevant or confusing to show verbatim. `err.message || t('some.fallback')` doesn't
+protect against this: `.message` is essentially always truthy on a real `Error`, so the
+translated fallback can never actually fire. Two established alternatives, depending on
+whether the raw detail is worth keeping:
+
+1. **A stable backend `code`, not free text.** Have the backend return a small, fixed `code`
+   field and map that through a local object to a `t()` key client-side — use the shared
+   `resolveErrorMessage()` helper (`src/utils/errorCodeMessage.js`) rather than hand-rolling
+   the map/lookup per call site (see `ResetCompletePage.js`).
+2. **Wrap the raw detail in `<code lang="en">`.** If the raw detail itself is genuinely useful
+   to show (admin/diagnostic tooling especially — a fetch failure, an export error), split the
+   translated template around the placeholder and wrap only that portion, e.g.
+   `<>{prefix}<code lang="en">{error.message}</code>{suffix}</>` — see `DeleteChatSection.js`'s
+   `resolveLook()`. `<code>` (not `<span>`) both gets the correct `lang="en"` pronunciation for
+   AT *and* the existing global `code { font-family: monospace... }` style for sighted users,
+   so raw/technical output reads as visually distinct from prose — free, no new CSS. On a page
+   with several of these (e.g. `DatabasePage.js`'s ~13 operations), pull the split/wrap and the
+   render into two small local helpers instead of repeating the shape per state — see
+   `DatabasePage.js`'s `buildErrorStatus`/`renderStatusMessage`.
+
+A `t()` string with a `{placeholder}` substituted via `.replace()`/interpolation (the pattern
+just above) is *not* equivalent to option 2: `t()` returns a plain string, which can't embed
+an HTML element, so the substituted text has no way to get `lang="en"` — and no code styling
+either — and stays unmarked regardless of how carefully the `.replace()` call itself is
+written.
+
 ## Admin page nav landmark
 
 Every admin/partner page's "back to admin" `<nav>` needs an `aria-label`, or screen-reader users navigating by landmark get an unlabeled region (and, on pages with more than one `<nav>`, indistinguishable ones):

--- a/docs/coding-agent-docs/status-and-error-messaging.md
+++ b/docs/coding-agent-docs/status-and-error-messaging.md
@@ -166,10 +166,25 @@ protect against this: `.message` is essentially always truthy on a real `Error`,
 translated fallback can never actually fire. Two established alternatives, depending on
 whether the raw detail is worth keeping: (1) have the backend return a small, stable `code`
 field (not free text) and map that through a local object to a `t()` key client-side — see
-`ResetCompletePage.js`'s `errorKeys` map; or (2) if the raw detail itself is genuinely useful
-to show, wrap only that portion in `<span lang="en">` inside an otherwise-translated
+`resolveErrorMessage` in `src/utils/errorCodeMessage.js` (`ResetCompletePage.js`'s own use of
+it is the reference call site); or (2) if the raw detail itself is genuinely useful
+to show, wrap only that portion in `<code lang="en">` inside an otherwise-translated
 template, so AT pronounces it as English rather than mangling it with the page's own
-language rules — see `DeleteChatSection.js`'s `resolveLook()`. A `t()` string with a
+language rules (`<code>` over a plain `<span>` — same `lang` behaviour, plus free monospace
+styling from `global.css`'s bare `code {}` rule, and it's more semantically correct for a raw
+technical detail) — see `DeleteChatSection.js`'s `resolveLook()`. A `t()` string with a
 `{placeholder}` substituted via `.replace()`/interpolation is *not* equivalent to option 2:
 `t()` returns a plain string, which can't embed an HTML element, so the substituted text has
 no way to get `lang="en"` and stays unmarked either way.
+
+**`{ prefix, suffix, detail, isError }` shape, specifically: use `useErrorStatus`, not a third
+hand-rolled copy.** `DatabasePage.js` (~13 call sites) and `SettingsPage.js` independently
+built the same combination of option 2 above with a translated template split around
+`{error}` — extracted into `src/hooks/useErrorStatus.js` after the duplication was flagged in
+review. `const { buildErrorStatus, renderStatusMessage } = useErrorStatus(t);` once per page;
+`buildErrorStatus(key, error, otherPlaceholders)` takes the *raw* error object (not
+`error.message`) so the `error.message || String(error)` fallback lives in one place, and
+`renderStatusMessage(status, successVariant)` renders it (`successVariant` defaults to
+`'success'`; pass `'info'` for an outcome that's a neutral confirmation rather than a
+completed mutation — see `SettingsPage.js`'s cache-refresh use). Reach for this whenever a
+page needs the prefix/suffix/detail shape; don't rebuild it inline again.

--- a/src/components/DeleteExpertEval.js
+++ b/src/components/DeleteExpertEval.js
@@ -50,7 +50,7 @@ const DeleteExpertEval = ({ lang = 'en' }) => {
       // (network drop, unexpected 500). Not done: touches both layers plus
       // a test rewrite, not just this file — see PR discussion.
       const [prefix, suffix] = t('admin.deleteExpertEval.error').split('{message}');
-      return { isError: true, prefix, detail: <span lang="en">{err.message || String(err)}</span>, suffix };
+      return { isError: true, prefix, detail: <code lang="en">{err.message || String(err)}</code>, suffix };
     }
   };
 

--- a/src/components/__tests__/DeleteExpertEval.test.js
+++ b/src/components/__tests__/DeleteExpertEval.test.js
@@ -122,10 +122,10 @@ describe('DeleteExpertEval error/success announcements', () => {
     expect(alert.textContent).toBe('Failed to delete expert evaluation: Not evaluated.');
     // "Not evaluated" is a known translated reason, not raw exception text —
     // shouldn't get the lang="en" pronunciation wrapper.
-    expect(alert.querySelector('span[lang="en"]')).toBeNull();
+    expect(alert.querySelector('code[lang="en"]')).toBeNull();
   });
 
-  it('announces a chat deleted between the existence check and the delete call (server-side 404 race) in a lang="en" span, inside role="alert"', async () => {
+  it('announces a chat deleted between the existence check and the delete call (server-side 404 race) in a lang="en" code element, inside role="alert"', async () => {
     // The existence pre-check found it, but the actual delete call still
     // fails server-side (e.g. the chat was removed in the gap between the
     // two requests) — EvaluationService.deleteExpertEval throws for the
@@ -142,12 +142,12 @@ describe('DeleteExpertEval error/success announcements', () => {
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toBe('Failed to delete expert evaluation: Chat not found');
 
-    const enSpan = alert.querySelector('span[lang="en"]');
+    const enSpan = alert.querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('Chat not found');
   });
 
-  it('wraps a generic network/server error in a lang="en" span too', async () => {
+  it('wraps a generic network/server error in a lang="en" code element too', async () => {
     chatExists();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockDeleteExpertEval.mockRejectedValue(new Error('Failed to fetch'));
@@ -157,7 +157,7 @@ describe('DeleteExpertEval error/success announcements', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toBe('Failed to delete expert evaluation: Failed to fetch');
-    expect(alert.querySelector('span[lang="en"]')).toBeTruthy();
+    expect(alert.querySelector('code[lang="en"]')).toBeTruthy();
   });
 
   it('clears a stale result message as soon as the admin edits the chat ID again', async () => {

--- a/src/components/admin/ChatLogsDashboard.js
+++ b/src/components/admin/ChatLogsDashboard.js
@@ -128,7 +128,7 @@ const ChatLogsDashboard = ({ lang = 'en' }) => {
 
       {exportError && (
         <StatusMessage variant="error">
-          {exportError.prefix}<span lang="en">{exportError.detail}</span>{exportError.suffix}
+          {exportError.prefix}<code lang="en">{exportError.detail}</code>{exportError.suffix}
         </StatusMessage>
       )}
 

--- a/src/components/admin/DeleteByChatIdSection.js
+++ b/src/components/admin/DeleteByChatIdSection.js
@@ -121,7 +121,7 @@ const DeleteByChatIdSection = ({
           // children shape the isError branch below needs.
           <StatusMessage variant="error" message={status.text} persistent />
         ) : status?.isError ? (
-          // variant="error" + children (not `message`): the <span lang="en">
+          // variant="error" + children (not `message`): the <code lang="en">
           // wrapper a raw exception detail needs (see onDelete's own
           // comment) can't go inside a plain message string. StatusMessage
           // adds its own icon automatically either way (see its own

--- a/src/components/admin/DeleteChatSection.js
+++ b/src/components/admin/DeleteChatSection.js
@@ -38,7 +38,7 @@ const DeleteChatSection = ({ lang = 'en' }) => {
       // that's worth doing — touches both layers plus a test rewrite, not
       // just this file.
       const [prefix, suffix] = t('admin.deleteChat.error').split('{message}');
-      return { isError: true, prefix, detail: <span lang="en">{error.message || String(error)}</span>, suffix };
+      return { isError: true, prefix, detail: <code lang="en">{error.message || String(error)}</code>, suffix };
     }
   };
 

--- a/src/components/admin/MetricsDashboard.js
+++ b/src/components/admin/MetricsDashboard.js
@@ -246,7 +246,7 @@ const MetricsDashboard = ({ lang = 'en' }) => {
         )}
         {error && !isLoading && (
           <StatusMessage variant="error">
-            {fetchErrorPrefix}<span lang="en">{error}</span>{fetchErrorSuffix}
+            {fetchErrorPrefix}<code lang="en">{error}</code>{fetchErrorSuffix}
           </StatusMessage>
         )}
         {/* No loading-dim/disable while a section refetches — removed rather

--- a/src/components/admin/ServerDataTable.js
+++ b/src/components/admin/ServerDataTable.js
@@ -42,7 +42,8 @@ const ServerDataTable = forwardRef(function ServerDataTable({
     ordering = true,
     pageLength = 10,
     lengthChange = true,
-    layout
+    layout,
+    onError
 }, ref) {
     const initialResultRef = useRef(initialResult);
     // The live DataTables API instance, captured via initComplete (the same
@@ -108,6 +109,7 @@ const ServerDataTable = forwardRef(function ServerDataTable({
                     ? result.recordsFiltered
                     : (Number.isFinite(result.pagination?.total) ? result.pagination.total : data.length);
 
+                onError?.(null);
                 callback({
                     draw: params.draw,
                     recordsTotal,
@@ -115,7 +117,16 @@ const ServerDataTable = forwardRef(function ServerDataTable({
                     data
                 });
             } catch (error) {
+                // Previously: swallowed into an empty result with only a
+                // console.error — a genuine fetch failure and "this table
+                // has zero rows" were indistinguishable to the admin, since
+                // both render emptyTableText. onError hands the raw error
+                // up so a caller can show it (see SettingsPage.js's audit
+                // history for the reference usage) instead of just logging
+                // it; onError?.(null) above clears a stale error once a
+                // later fetch (e.g. a retry) succeeds.
                 console.error('Failed to load table data:', error);
+                onError?.(error);
                 callback({ draw: params.draw, recordsTotal: 0, recordsFiltered: 0, data: [] });
             }
         },
@@ -130,7 +141,7 @@ const ServerDataTable = forwardRef(function ServerDataTable({
         initComplete: function () {
             tableApiRef.current = this.api();
         }
-    }), [autoWidth, emptyTableText, fetchData, lang, layout, lengthChange, order, ordering, pageLength, renderActions, tableColumns]);
+    }), [autoWidth, emptyTableText, fetchData, lang, layout, lengthChange, onError, order, ordering, pageLength, renderActions, tableColumns]);
 
     return (
         // tabIndex makes this reachable by keyboard when its content overflows

--- a/src/components/admin/SimilarChatsDashboard.js
+++ b/src/components/admin/SimilarChatsDashboard.js
@@ -58,13 +58,13 @@ const SimilarChatsDashboard = ({ lang = 'en' }) => {
         // can be wrapped in its own lang="en" span (mirrors
         // DeleteChatSection.js).
         const [prefix, suffix] = t('vector.fetchErrorDetail').split('{message}');
-        setFetchMessage({ prefix, suffix, detail: <span lang="en">{data.message}</span> });
+        setFetchMessage({ prefix, suffix, detail: <code lang="en">{data.message}</code> });
       } else {
         setFetchMessage({ prefix: t('vector.fetchError'), suffix: '', detail: null });
       }
     } catch (error) {
       const [prefix, suffix] = t('vector.fetchErrorDetail').split('{message}');
-      setFetchMessage({ prefix, suffix, detail: <span lang="en">{error.message || String(error)}</span> });
+      setFetchMessage({ prefix, suffix, detail: <code lang="en">{error.message || String(error)}</code> });
     }
     setLoading(false);
   };

--- a/src/components/admin/StatusMessage.js
+++ b/src/components/admin/StatusMessage.js
@@ -34,7 +34,7 @@ import { GcdsIcon } from '@gcds-core/components-react';
 // checkmark glyph. A caller that passes `children` alongside `variant` gets
 // the box/role treatment AND the same icon `message` would have gotten —
 // `children` is only an escape hatch for content richer than one string
-// (e.g. a raw exception detail that needs its own <span lang="en">), not a
+// (e.g. a raw exception detail that needs its own <code lang="en">), not a
 // way to opt out of the icon. (It used to be — see resolveLook's own
 // comment for why that shipped 5 icon-less error boxes before this fixed
 // it at the root.)
@@ -138,7 +138,7 @@ function resolveLook({ variant, loading, message, isError, children }) {
       className: variantConfig.className,
       // Icon is unconditional — every real `children` caller in this
       // codebase only reaches for `children` to wrap part of the text in
-      // e.g. <span lang="en">, never for a genuinely icon-less shape, and
+      // e.g. <code lang="en">, never for a genuinely icon-less shape, and
       // the old `children || (icon + message)` short-circuited the icon
       // out entirely whenever `children` was passed. That was the actual
       // cause behind 5 separate call sites shipping error boxes with no

--- a/src/components/admin/TechnicalMetricsDashboard.js
+++ b/src/components/admin/TechnicalMetricsDashboard.js
@@ -73,7 +73,7 @@ const TechnicalMetricsDashboard = ({ lang = 'en' }) => {
         )}
         {error && !isLoading && (
           <StatusMessage variant="error">
-            {fetchErrorPrefix}<span lang="en">{error}</span>{fetchErrorSuffix}
+            {fetchErrorPrefix}<code lang="en">{error}</code>{fetchErrorSuffix}
           </StatusMessage>
         )}
         {/* No loading-dim/disable while a section refetches — removed rather

--- a/src/components/admin/__tests__/DeleteChatSection.test.js
+++ b/src/components/admin/__tests__/DeleteChatSection.test.js
@@ -49,7 +49,7 @@ describe('DeleteChatSection error/success announcements', () => {
     vi.restoreAllMocks();
   });
 
-  it('wraps the untranslated error detail in a lang="en" span, inside role="alert"', async () => {
+  it('wraps the untranslated error detail in a lang="en" code element, inside role="alert"', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockGetChat.mockResolvedValue({ chat: { chatId: VALID_CHAT_ID } });
     mockDeleteChat.mockRejectedValue(new Error('Failed to fetch'));
@@ -62,7 +62,7 @@ describe('DeleteChatSection error/success announcements', () => {
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toBe('Failed to delete chat: Failed to fetch');
 
-    const enSpan = alert.querySelector('span[lang="en"]');
+    const enSpan = alert.querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('Failed to fetch');
   });

--- a/src/components/admin/__tests__/MetricsDashboard.statusMessage.test.js
+++ b/src/components/admin/__tests__/MetricsDashboard.statusMessage.test.js
@@ -72,7 +72,7 @@ describe('MetricsDashboard StatusMessage role', () => {
     expect(alerts.length).toBeGreaterThan(0);
     expect(alerts[0].textContent).toBe('Failed to load data: usage metrics failed');
 
-    const enSpan = alerts[0].querySelector('span[lang="en"]');
+    const enSpan = alerts[0].querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('usage metrics failed');
   });

--- a/src/components/admin/__tests__/SimilarChatsDashboard.test.js
+++ b/src/components/admin/__tests__/SimilarChatsDashboard.test.js
@@ -58,7 +58,7 @@ describe('SimilarChatsDashboard — was window.alert(), now StatusMessage/Feedba
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toBe('Failed to fetch similar chats: no embeddings found');
-    const enSpan = alert.querySelector('span[lang="en"]');
+    const enSpan = alert.querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('no embeddings found');
     expect(alertSpy).not.toHaveBeenCalled();
@@ -72,7 +72,7 @@ describe('SimilarChatsDashboard — was window.alert(), now StatusMessage/Feedba
     fireEvent.click(screen.getByText('vector.getSimilarChats'));
 
     const alert = await screen.findByRole('alert');
-    const enSpan = alert.querySelector('span[lang="en"]');
+    const enSpan = alert.querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('Failed to fetch');
   });

--- a/src/components/admin/__tests__/TechnicalMetricsDashboard.statusMessage.test.js
+++ b/src/components/admin/__tests__/TechnicalMetricsDashboard.statusMessage.test.js
@@ -64,7 +64,7 @@ describe('TechnicalMetricsDashboard StatusMessage role', () => {
     expect(alerts.length).toBeGreaterThan(0);
     expect(alerts[0].textContent).toBe('Failed to load data: boom');
 
-    const enSpan = alerts[0].querySelector('span[lang="en"]');
+    const enSpan = alerts[0].querySelector('code[lang="en"]');
     expect(enSpan).toBeTruthy();
     expect(enSpan.textContent).toBe('boom');
   });

--- a/src/components/batch/BatchUpload.js
+++ b/src/components/batch/BatchUpload.js
@@ -4,6 +4,7 @@ import { useTranslations } from '../../hooks/useTranslations.js';
 import { GcdsContainer, GcdsFileUploader, GcdsFieldset, GcdsStepper, GcdsInput, GcdsSelect } from '@gcds-core/components-react';
 import BatchService from '../../services/BatchService.js';
 import DataStoreService from '../../services/DataStoreService.js';
+import { resolveErrorMessage } from '../../utils/errorCodeMessage.js';
 import { WORKFLOWS, AVAILABLE_MODELS } from '../../config/workflows.js';
 import { parseBatchCsv } from '../../utils/spreadsheets/csv.js';
 import { MAX_BATCH_ITEMS } from '../../config/batch.js';
@@ -195,18 +196,24 @@ const BatchUpload = ({ lang, onBatchSaved }) => {
           setFileUploaderKey((k) => k + 1);
         } catch (persistErr) {
           console.error('Failed to persist batch:', persistErr);
-          setError(persistErr?.message || t('batch.upload.error.saveFailed'));
+          setError(persistErr?.message
+            ? <>{t('batch.upload.error.saveFailed')} <code lang="en">{persistErr.message}</code></>
+            : t('batch.upload.error.saveFailed'));
           // Re-show the upload button so the user can retry
           setFileUploaded(false);
           setProcessing(false);
         }
       } catch (err) {
         // Surface the actual parse error (e.g. missing column, empty file)
-        // so the admin can see what's wrong with the CSV.
-        const detail = {
-          EMPTY_CSV: t('batch.upload.error.invalidCsv'),
-          MISSING_QUESTION_COLUMN: t('batch.upload.error.missingQuestionColumn'),
-        }[err?.code] || err?.message || t('batch.upload.error.readFailed');
+        // so the admin can see what's wrong with the CSV. This feeds
+        // GcdsFileUploader's errorMessage prop, a plain-string web-component
+        // attribute — no way to wrap a raw err.message in <code lang="en">
+        // here, so unlike other error sites, an unrecognized err.code falls
+        // back to the translated generic message rather than raw text.
+        const detail = resolveErrorMessage(err?.code, {
+          EMPTY_CSV: 'batch.upload.error.invalidCsv',
+          MISSING_QUESTION_COLUMN: 'batch.upload.error.missingQuestionColumn',
+        }, 'batch.upload.error.readFailed', t);
         announceFileError(detail);
         fileUploaderRef.current?.focus?.();
         console.error('Error reading file:', err);

--- a/src/components/chat/review/EvalPanel.js
+++ b/src/components/chat/review/EvalPanel.js
@@ -197,7 +197,7 @@ const EvalPanel = ({ message, t, lang = 'en', answerNumber }) => {
           </GcdsButton>
         </div>
         {loading && <div>{t('common.loading', 'Loading...')}</div>}
-        {error && <div className="error">{t('common.error', 'Error')}: {error}</div>}
+        {error && <div className="error">{t('common.error', 'Error')}: <code lang="en">{error}</code></div>}
 
         {evalObj ? (
           <>

--- a/src/components/chat/review/ExpertFeedbackPanel.js
+++ b/src/components/chat/review/ExpertFeedbackPanel.js
@@ -251,7 +251,7 @@ const ExpertFeedbackPanel = ({ message, extractSentences, t, lang = 'en', answer
             </summary>
             <div className="review-panel expert-feedback-panel">
                 {loading && <div>{t('common.loading') || 'Loading...'}</div>}
-                {error && <div className="error">{t('common.error') || 'Error'}: {error}</div>}
+                {error && <div className="error">{t('common.error') || 'Error'}: <code lang="en">{error}</code></div>}
                 {/* Summary: citation and total score */}
                 <div className="expert-feedback-summary">
                     {(() => {

--- a/src/components/chat/review/PublicFeedbackPanel.js
+++ b/src/components/chat/review/PublicFeedbackPanel.js
@@ -86,7 +86,7 @@ const PublicFeedbackPanel = ({ message, t, answerNumber }) => {
             </summary>
             <div className="review-panel public-feedback-panel">
                 {loading && <div>{t('common.loading', 'Loading...')}</div>}
-                {error && <div className="error">{t('common.error', 'Error')}: {error}</div>}
+                {error && <div className="error">{t('common.error', 'Error')}: <code lang="en">{error}</code></div>}
                 <div className="public-feedback-summary">
                     <div>{t('reviewPanels.score', 'Score')}: {(publicFeedback && typeof publicFeedback.publicFeedbackScore !== 'undefined' && publicFeedback.publicFeedbackScore !== null) ? publicFeedback.publicFeedbackScore : t('reviewPanels.notAvailable', 'N/A')}</div>
                     <div>{t('reviewPanels.reason', 'Reason')}: {(() => {

--- a/src/hooks/__tests__/useErrorStatus.test.js
+++ b/src/hooks/__tests__/useErrorStatus.test.js
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { useErrorStatus } from '../useErrorStatus.js';
+
+const TRANSLATIONS = {
+  'admin.database.exportError': 'Export failed: {error}.',
+  'admin.database.checkFailed': 'Check {check} failed: {error}.',
+  'settings.refreshCache.success': 'Settings cache refreshed.',
+};
+const t = (key) => TRANSLATIONS[key] || key;
+
+// Tiny host component — buildErrorStatus/renderStatusMessage are plain
+// functions returned from the hook, not components themselves, so a host
+// is needed to actually mount what renderStatusMessage returns and assert
+// on real DOM (role, class, <code lang="en">), the same way
+// MetricsDashboard.statusMessage.test.js asserts on StatusMessage's output
+// rather than inspecting the returned React element in isolation.
+const Host = ({ status, successVariant }) => {
+  const { renderStatusMessage } = useErrorStatus(t);
+  return renderStatusMessage(status, successVariant);
+};
+
+describe('useErrorStatus', () => {
+  afterEach(cleanup);
+
+  describe('buildErrorStatus', () => {
+    it('splits the template on {error} and sets detail/isError from the error object', () => {
+      const { buildErrorStatus } = useErrorStatusForTest();
+      const status = buildErrorStatus('admin.database.exportError', new Error('disk full'));
+
+      expect(status).toEqual({
+        prefix: 'Export failed: ',
+        suffix: '.',
+        detail: 'disk full',
+        isError: true,
+      });
+    });
+
+    it('substitutes otherPlaceholders before splitting on {error} (DatabasePage.js checkFailed case)', () => {
+      const { buildErrorStatus } = useErrorStatusForTest();
+      const status = buildErrorStatus('admin.database.checkFailed', new Error('timeout'), { check: 'duplicateKeys' });
+
+      expect(status.prefix).toBe('Check duplicateKeys failed: ');
+      expect(status.suffix).toBe('.');
+      expect(status.detail).toBe('timeout');
+    });
+
+    it('falls back to String(error) when the thrown value has no usable .message', () => {
+      const { buildErrorStatus } = useErrorStatusForTest();
+
+      // A non-Error thrown value (e.g. a rejected fetch with a plain string,
+      // or code that does `throw 'oops'`) has no .message at all — detail
+      // must still resolve to something renderable, not undefined. An
+      // undefined detail would make renderStatusMessage's
+      // `detail !== undefined` check fall through to the .text branch,
+      // silently dropping the error entirely (see the hook's own comment).
+      const status = buildErrorStatus('admin.database.exportError', 'raw string failure');
+      expect(status.detail).toBe('raw string failure');
+
+      // An Error whose .message is itself an empty string is falsy, so the
+      // `error?.message || String(error)` fallback must not skip past it as
+      // if .message were missing entirely.
+      const emptyMessageStatus = buildErrorStatus('admin.database.exportError', new Error(''));
+      expect(emptyMessageStatus.detail).toBe('Error');
+    });
+  });
+
+  describe('renderStatusMessage', () => {
+    it('renders a null status as nothing', () => {
+      render(<Host status={null} />);
+      expect(screen.queryByRole('status')).toBeNull();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    it('renders a {text, isError:false} status as plain text with the default success variant', () => {
+      render(<Host status={{ text: 'Done.', isError: false }} />);
+
+      const el = screen.getByRole('status');
+      expect(el.className).toContain('status-message--success-box');
+      expect(el.textContent).toContain('Done.');
+    });
+
+    it('renders a successVariant override (e.g. "info") instead of success for a non-error status', () => {
+      // The exact "found by code review" case the hook's own comment flags:
+      // SettingsPage.js's cache-refresh success is a neutral confirmation,
+      // not a completed mutation, so it renders as 'info' via this param
+      // rather than the 'success' default every other caller gets.
+      render(<Host status={{ text: 'Settings cache refreshed.', isError: false }} successVariant="info" />);
+
+      const el = screen.getByRole('status');
+      expect(el.className).toContain('status-message--info-box');
+      expect(el.className).not.toContain('status-message--success-box');
+    });
+
+    it('renders a buildErrorStatus-shaped status as prefix + <code lang="en">{detail}</code> + suffix with the error variant', () => {
+      render(<Host status={{ prefix: 'Export failed: ', suffix: '.', detail: 'disk full', isError: true }} />);
+
+      const el = screen.getByRole('alert');
+      expect(el.className).toContain('status-message--error-box');
+      expect(el.textContent).toBe('Export failed: disk full.');
+
+      const raw = el.querySelector('code[lang="en"]');
+      expect(raw).toBeTruthy();
+      expect(raw.textContent).toBe('disk full');
+    });
+  });
+});
+
+// buildErrorStatus itself needs no React tree — it's a pure function — so
+// tests that only assert on its return value call the hook via a throwaway
+// component-free invocation instead of mounting a Host for each one.
+function useErrorStatusForTest() {
+  let captured;
+  function Capture() {
+    captured = useErrorStatus(t);
+    return null;
+  }
+  render(<Capture />);
+  return captured;
+}

--- a/src/hooks/useErrorStatus.js
+++ b/src/hooks/useErrorStatus.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import StatusMessage from '../components/admin/StatusMessage.js';
+
+// Shared { text } (success) | { prefix, suffix, detail, isError } (error)
+// status shape, and the two small helpers that build/render it — extracted
+// after DatabasePage.js (~13 call sites) and SettingsPage.js independently
+// hand-rolled the same pattern. buildErrorStatus splits the translated
+// template around {error} once; the raw detail (error.message) is never
+// shown untagged - see AGENTS.md's "Never show a raw err.message" rule.
+//
+// Takes the raw error object (not error.message) so the
+// `error.message || String(error)` fallback lives here once, not repeated
+// per call site - a caught non-Error value or an Error with no .message
+// would otherwise resolve detail to undefined, which renderStatusMessage's
+// `!== undefined` check reads as "render status.text instead" - but this
+// shape never sets .text, so StatusMessage's own empty-message guard would
+// return null and the whole error box would silently vanish. Found by code
+// review on DatabasePage.js, which was missing it; SettingsPage.js already
+// had it.
+//
+// `t` is taken once here rather than passed to each call, so callers don't
+// repeat useTranslations() plumbing through this - same shape as
+// useAuthOutcomeMessages taking its dependencies once at the top.
+export const useErrorStatus = (t) => {
+  const buildErrorStatus = (key, error, otherPlaceholders = {}) => {
+    let template = t(key);
+    for (const [name, value] of Object.entries(otherPlaceholders)) {
+      template = template.replace(`{${name}}`, () => value);
+    }
+    // split('{error}') assumes the placeholder appears exactly once — a
+    // locale string with {error} twice would split into >2 pieces and this
+    // destructure silently drops everything after the second occurrence.
+    // No current key repeats it; if a future one does, this needs a
+    // template.replace-based split instead.
+    const [prefix, suffix] = template.split('{error}');
+    const detail = error?.message || String(error);
+    return { prefix, suffix, detail, isError: true };
+  };
+
+  // successVariant: DatabasePage.js's operations are completed mutations
+  // ('success', the default); SettingsPage.js's cache refresh is a neutral
+  // confirmation, not a mutation ('info') - a real semantic difference
+  // between the two existing callers, not just inconsistency to paper over.
+  const renderStatusMessage = (status, successVariant = 'success') => (
+    <StatusMessage variant={status ? (status.isError ? 'error' : successVariant) : undefined}>
+      {status && (
+        status.detail !== undefined
+          ? <>{status.prefix}<code lang="en">{status.detail}</code>{status.suffix}</>
+          : status.text
+      )}
+    </StatusMessage>
+  );
+
+  return { buildErrorStatus, renderStatusMessage };
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -501,6 +501,10 @@
       "checkIndexStatusButton": "Check index status",
       "checkingLabel": "Checking...",
       "indexStatusError": "Index status check failed: {error}",
+      "indexStatusBuilding": "Some indexes are currently building.",
+      "indexStatusComplete": "All indexes are complete.",
+      "indexStatusIncomplete": "Some indexes may be incomplete.",
+      "countsError": "Table counts failed: {error}",
       "indexCreationFailed": "Index creation failed for the following collections:",
       "collectionColumn": "Collection",
       "currentColumn": "Current",
@@ -1075,6 +1079,9 @@
     "title": "Settings",
     "saveSuccessIn": "Changes to {section} saved.",
     "saveError": "Failed to save setting.",
+    "fieldError": {
+      "unexpected": "Unexpected error: {error}"
+    },
     "save": "Save",
     "saving": "Saving...",
     "unsavedChangesIn": "Unsaved changes in {sections}",
@@ -1142,6 +1149,7 @@
       "title": "Settings history",
       "description": "Review who changed settings and when.",
       "empty": "No settings changes have been recorded.",
+      "loadError": "Failed to load audit history: {error}",
       "user": "User",
       "action": "Action",
       "setting": "Setting",
@@ -1795,6 +1803,7 @@
     "loading": "Loading...",
     "fetchStats": "Fetch vector stats",
     "statsLoaded": "Vector stats loaded.",
+    "statsLoadError": "Failed to load vector stats: {error}",
     "createIndex": "Create vector index",
     "embeddingManagement": "Embedding management",
     "embeddingDescription": "Process interactions to generate embeddings.",
@@ -1934,6 +1943,7 @@
     "regenerateEmbeddingsFailed": "Failed to regenerate embeddings. Check the console for details.",
     "regenerateConfirm": "This will delete all existing embeddings and regenerate them from scratch. This operation cannot be undone. Are you sure you want to continue?",
     "indexCreatedSuccess": "Vector index created and vector service reinitialized successfully.",
+    "indexCreateError": "Failed to reinitialize vector service: {error}",
     "docdb8Capability": {
       "title": "DocumentDB 8 vector search capability test",
       "description": "Run aggregation probes against DocumentDB 8 to see whether filters can reduce the candidate set before vector search.",
@@ -1945,6 +1955,7 @@
       "yes": "Yes",
       "no": "No",
       "noError": "No error",
+      "errorDetail": "Test failed: {error}",
       "probeComplete": "{label}: {status}",
       "notAvailable": "Not available",
       "estimatedFeedbackSelectivity": "Estimated feedback selectivity",
@@ -2042,9 +2053,6 @@
       "step1": "Contact the AI Answers team at {email}, and include a copy of the edited text version in your email.",
       "step2": "The AI Answers team will review and then apply the changes into the live AI Answers product."
     },
-    "error": {
-      "fallback": "An error occurred while loading this page."
-    },
     "empty": {
       "never": "Never"
     }
@@ -2116,6 +2124,7 @@
       "creatingInstantAnswer": "Generating equivalent questions and creating dataset...",
       "goldenAnswerSuccess": "Golden answer dataset created successfully.",
       "goldenAnswerFailed": "Failed to create golden answer dataset.",
+      "goldenAnswerFailedDetail": "Failed to create golden answer dataset: {error}",
       "instantAnswerSuccess": "Instant answer test dataset created successfully.",
       "instantAnswerQueued": "Instant answer dataset creation has been queued. You can monitor its status on the datasets page.",
       "instantAnswerFailed": "Failed to create instant answer test dataset.",
@@ -2135,6 +2144,7 @@
       "errorLoadingRows": "Failed to load rows.",
       "confirmDelete": "Are you sure you want to delete this dataset? This action cannot be undone.",
       "inUse": "This dataset is in use by active batches and cannot be deleted.",
+      "deleteFailed": "Failed to delete dataset.",
       "nameLabel": "Dataset Name",
       "descLabel": "Description",
       "typeLabel": "Dataset Type",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -501,6 +501,10 @@
       "checkIndexStatusButton": "Vérifier l'état des index",
       "checkingLabel": "Vérification...",
       "indexStatusError": "Échec de la vérification de l'état des index : {error}",
+      "indexStatusBuilding": "Certains index sont en cours de création.",
+      "indexStatusComplete": "Tous les index sont complets.",
+      "indexStatusIncomplete": "Certains index pourraient être incomplets.",
+      "countsError": "Échec de la récupération des totaux de la table : {error}",
       "indexCreationFailed": "La création d'index a échoué pour les collections suivantes :",
       "collectionColumn": "Collection",
       "currentColumn": "Actuel",
@@ -1075,6 +1079,9 @@
     "title": "Paramètres",
     "saveSuccessIn": "Modifications de {section} enregistrées.",
     "saveError": "Échec de l'enregistrement du paramètre.",
+    "fieldError": {
+      "unexpected": "Erreur inattendue : {error}"
+    },
     "save": "Enregistrer",
     "saving": "Enregistrement...",
     "unsavedChangesIn": "Modifications non enregistrées dans {sections}",
@@ -1142,6 +1149,7 @@
       "title": "Historique des paramètres",
       "description": "Consultez qui a modifié les paramètres et à quel moment.",
       "empty": "Aucune modification des paramètres n’a été enregistrée.",
+      "loadError": "Échec du chargement de l'historique : {error}",
       "user": "Utilisateur",
       "action": "Action",
       "setting": "Paramètre",
@@ -1794,6 +1802,7 @@
     "loading": "Chargement...",
     "fetchStats": "Afficher les statistiques des vecteurs",
     "statsLoaded": "Statistiques des vecteurs chargées.",
+    "statsLoadError": "Échec du chargement des statistiques des vecteurs : {error}",
     "reinitializeIndex": "Réinitialiser l'index",
     "createIndex": "Créer un index de vecteurs",
     "embeddingManagement": "Gestion des embeddings",
@@ -1934,6 +1943,7 @@
     "regenerateEmbeddingsFailed": "Échec de la régénération des incorporations. Vérifiez la console pour plus de détails.",
     "regenerateConfirm": "Cela supprimera toutes les incorporations existantes et les régénérera depuis le début. Cette opération est irréversible. Êtes-vous sûr de vouloir continuer ?",
     "indexCreatedSuccess": "Index vectoriel créé et service vectoriel réinitialisé avec succès.",
+    "indexCreateError": "Échec de la réinitialisation du service vectoriel : {error}",
     "docdb8Capability": {
       "title": "Test des capacités de recherche vectorielle de DocumentDB 8",
       "description": "Exécutez des tests d'agrégation dans DocumentDB 8 pour vérifier si les filtres peuvent réduire l'ensemble des candidats avant la recherche vectorielle.",
@@ -1944,6 +1954,7 @@
       "yes": "Oui",
       "no": "Non",
       "noError": "Aucune erreur",
+      "errorDetail": "Échec du test : {error}",
       "probeComplete": "{label} : {status}",
       "notAvailable": "Non disponible",
       "estimatedFeedbackSelectivity": "Sélectivité estimée des rétroactions",
@@ -2042,9 +2053,6 @@
       "step1": "Communiquez avec l'équipe Réponses IA à {email}, et joignez une copie du texte modifié à votre courriel.",
       "step2": "L'équipe Réponses IA examinera les modifications, puis les appliquera dans le produit Réponses IA en direct."
     },
-    "error": {
-      "fallback": "Une erreur est survenue lors du chargement de cette page."
-    },
     "empty": {
       "never": "Jamais"
     }
@@ -2116,6 +2124,7 @@
       "creatingInstantAnswer": "Génération de questions équivalentes et création de l’ensemble de données...",
       "goldenAnswerSuccess": "L’ensemble de réponses de référence a été créé avec succès.",
       "goldenAnswerFailed": "Échec de la création de l’ensemble de réponses de référence.",
+      "goldenAnswerFailedDetail": "Échec de la création de l’ensemble de réponses de référence : {error}",
       "instantAnswerSuccess": "L’ensemble d’essai des réponses instantanées a été créé avec succès.",
       "instantAnswerQueued": "La création de l’ensemble de données de réponses instantanées a été mise en file d’attente. Vous pouvez suivre son état sur la page des ensembles de données.",
       "instantAnswerFailed": "Échec de la création de l’ensemble d’essai des réponses instantanées.",
@@ -2135,6 +2144,7 @@
       "errorLoadingRows": "Échec du chargement des données.",
       "confirmDelete": "Êtes-vous sûr de vouloir supprimer cet ensemble de données ? Cette action est irréversible.",
       "inUse": "Cet ensemble de données est utilisé par des lots actifs et ne peut pas être supprimé.",
+      "deleteFailed": "Échec de la suppression de l'ensemble de données.",
       "nameLabel": "Nom de l'ensemble de données",
       "descLabel": "Description",
       "typeLabel": "Type d'ensemble de données",

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -151,10 +151,9 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
         <LoadingOverlay message={t('admin.autoEvalDashboard.loading')} />
       )}
 
-      <StatusMessage
-        variant={error ? 'error' : undefined}
-        message={error ? `${t('admin.autoEvalDashboard.error')} ${String(error)}` : null}
-      />
+      <StatusMessage variant={error ? 'error' : undefined}>
+        {error && <>{t('admin.autoEvalDashboard.error')} <code lang="en">{String(error)}</code></>}
+      </StatusMessage>
 
       {hasAppliedFilters && !loading && !error && pageResultCount === 0 && (
         <StatusMessage variant="info" message={t('common.noDataForFilters')} nonce={zeroResultNonce} />

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -368,10 +368,9 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
         <LoadingOverlay message={t('admin.chatDashboard.loading')} />
       )}
 
-      <StatusMessage
-        variant={error ? 'error' : undefined}
-        message={error ? `${t('admin.chatDashboard.error')} ${String(error)}` : null}
-      />
+      <StatusMessage variant={error ? 'error' : undefined}>
+        {error && <>{t('admin.chatDashboard.error')} <code lang="en">{String(error)}</code></>}
+      </StatusMessage>
 
       {hasAppliedFilters && !loading && !error && recordsTotal === 0 && searchTerm && (
         <StatusMessage variant="info" message={t('admin.common.noSearchResults')} nonce={zeroResultNonce} />

--- a/src/pages/ConnectivityPage.js
+++ b/src/pages/ConnectivityPage.js
@@ -217,7 +217,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
             </section>
 
             <StatusMessage variant={error ? 'error' : undefined}>
-                {error && <><strong>{t('connectivity.error')}:</strong> {error}</>}
+                {error && <><strong>{t('connectivity.error')}:</strong> <code lang="en">{error}</code></>}
             </StatusMessage>
 
             {/* TODO: these counts should go through formatNumber(n, lang) per the

--- a/src/pages/DatabasePage.js
+++ b/src/pages/DatabasePage.js
@@ -10,6 +10,7 @@ import { formatNumber } from '../utils/numberFormat.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import FeedbackInlineError from '../components/chat/FeedbackInlineError.js';
 import { useInlineFormError } from '../hooks/useInlineFormError.js';
+import { useErrorStatus } from '../hooks/useErrorStatus.js';
 import {
   ALL_BUT_LOGS_AND_EMBEDDINGS_EXPORT,
   EXPERT_EVAL_CHATS_EXPORT,
@@ -19,6 +20,14 @@ import {
 
 const DatabasePage = ({ lang }) => {
   const { t } = useTranslations(lang);
+
+  // Every ...Message state below shares the same { text } (success) or
+  // { prefix, suffix, detail, isError } (error) shape — buildErrorStatus/
+  // renderStatusMessage build and render it, shared with SettingsPage.js's
+  // own single use of the same shape (useErrorStatus.js) rather than each
+  // hand-rolling it independently.
+  const { buildErrorStatus, renderStatusMessage } = useErrorStatus(t);
+
   const [isExporting, setIsExporting] = useState(false);
   const [collections, setCollections] = useState([]);
   const [selectedCollection, setSelectedCollection] = useState('All');
@@ -56,7 +65,7 @@ const DatabasePage = ({ lang }) => {
   const [endDate, setEndDate] = useState('');
   const [exportLimit, setExportLimit] = useState(10000); // New state for export limit
   const [tableCounts, setTableCounts] = useState(null);
-  const [countsError, setCountsError] = useState('');
+  const [countsError, setCountsError] = useState(null);
   // Import controls: chunk size in MB and optional throttle between chunk uploads (ms)
   const [importChunkMB, setImportChunkMB] = useState(90); // default 90 MB per file slice
   const [importThrottleMs, setImportThrottleMs] = useState(0); // default no extra delay between chunk POSTs
@@ -78,12 +87,15 @@ const DatabasePage = ({ lang }) => {
   useEffect(() => {
     let isMounted = true;
     async function fetchCountsAndCollections() {
-      setCountsError('');
+      setCountsError(null);
       try {
         const counts = await DataStoreService.getTableCounts();
         if (isMounted) setTableCounts(counts);
       } catch (e) {
-        if (isMounted) setCountsError(e.message);
+        // Was raw e.message, untranslated and unwrapped — same fix as the
+        // ~13 buildErrorStatus call sites below, just missed on this one
+        // since it predates them (fetched on mount, not from a button).
+        if (isMounted) setCountsError(buildErrorStatus('admin.database.countsError', e));
       }
       // Fetch collections for export dropdown
       try {
@@ -102,6 +114,22 @@ const DatabasePage = ({ lang }) => {
     return () => { isMounted = false; };
   }, []);
 
+  // TODO (pending review — open question, not yet a confirmed gap):
+  // SettingsPage.js's real convention (stageChange) is narrower than it
+  // first looks — editing a field clears only that *section's* own stale
+  // save message, never a sibling section's. Export/Import here already
+  // match that exactly (each clears its own message when its own fields
+  // change). The other ~10 operations (Drop indexes, Repair timestamps,
+  // Migrate public feedback, etc.) are single-button actions with no
+  // editable fields at all, so there's no field-edit event to hook a clear
+  // into the way Settings/Export/Import do — per that actual precedent,
+  // that may not be a gap. Open question for review: should an unrelated
+  // stale message (e.g. "Repair timestamps succeeded" sitting on screen
+  // while the admin then clicks "Drop indexes") get cleared by that
+  // unrelated click, or is per-operation persistence until its own button
+  // is re-clicked actually fine? Don't copy VectorPage.js's
+  // fetchVectorStats (clears a sibling message too) as precedent here —
+  // that pattern hasn't been reviewed yet.
   const handleExport = async () => {
     try {
       setIsExporting(true);
@@ -185,7 +213,7 @@ const DatabasePage = ({ lang }) => {
       await writer.close();
       setExportMessage({ text: t('admin.database.exportSuccess'), isError: false });
     } catch (error) {
-      setExportMessage({ text: t('admin.database.exportError').replace('{error}', () => error.message), isError: true });
+      setExportMessage(buildErrorStatus('admin.database.exportError', error));
       console.error('Export error:', error);
     } finally {
       setIsExporting(false);
@@ -382,7 +410,7 @@ const DatabasePage = ({ lang }) => {
         fileInputRef.current.value = ''; // Reset file input
       }
     } catch (error) {
-      setImportMessage({ text: t('admin.database.importError').replace('{error}', () => error.message), isError: true });
+      setImportMessage(buildErrorStatus('admin.database.importError', error));
       console.error('Import error:', error);
     } finally {
       setIsImporting(false);
@@ -410,7 +438,7 @@ const DatabasePage = ({ lang }) => {
       const result = await response.json();
       setDropIndexesMessage({ text: t('admin.database.dropIndexesSuccess').replace('{count}', result.results.success.length), isError: false });
     } catch (error) {
-      setDropIndexesMessage({ text: t('admin.database.dropIndexesError').replace('{error}', () => error.message), isError: true });
+      setDropIndexesMessage(buildErrorStatus('admin.database.dropIndexesError', error));
       console.error('Drop indexes error:', error);
     } finally {
       setIsDroppingIndexes(false);
@@ -429,7 +457,7 @@ const DatabasePage = ({ lang }) => {
       if (!response.ok) throw new Error(result.message || 'Failed to delete system logs');
       setDeleteSystemLogsMessage({ text: t('admin.database.deleteSystemLogsSuccess').replace('{count}', result.deletedCount), isError: false });
     } catch (error) {
-      setDeleteSystemLogsMessage({ text: t('admin.database.deleteSystemLogsError').replace('{error}', () => error.message), isError: true });
+      setDeleteSystemLogsMessage(buildErrorStatus('admin.database.deleteSystemLogsError', error));
     } finally {
       setIsDeletingSystemLogs(false);
     }
@@ -447,7 +475,7 @@ const DatabasePage = ({ lang }) => {
       const deletedBatchItems = (result && result.deletedBatchItems != null) ? result.deletedBatchItems : 0;
       setDeleteAllBatchesMessage({ text: t('admin.database.deleteAllBatchesSuccess').replace('{batches}', deletedBatches).replace('{batchItems}', deletedBatchItems), isError: false });
     } catch (error) {
-      setDeleteAllBatchesMessage({ text: t('admin.database.deleteAllBatchesError').replace('{error}', () => error.message), isError: true });
+      setDeleteAllBatchesMessage(buildErrorStatus('admin.database.deleteAllBatchesError', error));
       console.error('Delete all batches error:', error);
     } finally {
       setIsDeletingAllBatches(false);
@@ -464,7 +492,7 @@ const DatabasePage = ({ lang }) => {
       const result = await DataStoreService.repairTimestamps();
       setRepairTimestampsMessage({ text: t('admin.database.repairTimestampsSuccess').replace('{updated}', result.stats.tools.updated).replace('{total}', result.stats.tools.total), isError: false });
     } catch (error) {
-      setRepairTimestampsMessage({ text: t('admin.database.repairTimestampsError').replace('{error}', () => error.message), isError: true });
+      setRepairTimestampsMessage(buildErrorStatus('admin.database.repairTimestampsError', error));
     } finally {
       setIsRepairingTimestamps(false);
     }
@@ -480,7 +508,7 @@ const DatabasePage = ({ lang }) => {
       const result = await DataStoreService.repairExpertFeedback();
       setRepairExpertFeedbackMessage({ text: t('admin.database.repairExpertFeedbackSuccess').replace('{updated}', result.stats.expertFeedback.updated).replace('{total}', result.stats.expertFeedback.total).replace('{alreadyCorrect}', result.stats.expertFeedback.alreadyCorrect), isError: false });
     } catch (error) {
-      setRepairExpertFeedbackMessage({ text: t('admin.database.repairExpertFeedbackError').replace('{error}', () => error.message), isError: true });
+      setRepairExpertFeedbackMessage(buildErrorStatus('admin.database.repairExpertFeedbackError', error));
     } finally {
       setIsRepairingExpertFeedback(false);
     }
@@ -494,7 +522,7 @@ const DatabasePage = ({ lang }) => {
       const result = await DataStoreService.repairQaMatchScores();
       setRepairQaMatchScoresMessage({ text: t('admin.database.repairQaMatchScoresSuccess').replace('{updated}', result.stats.updated).replace('{matches}', result.stats.matches), isError: false });
     } catch (error) {
-      setRepairQaMatchScoresMessage({ text: t('admin.database.repairQaMatchScoresError').replace('{error}', () => error.message), isError: true });
+      setRepairQaMatchScoresMessage(buildErrorStatus('admin.database.repairQaMatchScoresError', error));
     } finally {
       setIsRepairingQaMatchScores(false);
     }
@@ -508,7 +536,7 @@ const DatabasePage = ({ lang }) => {
       const result = await DataStoreService.migratePublicFeedback();
       setMigratePublicFeedbackMessage({ text: t('admin.database.migratePublicFeedbackSuccess').replace('{migrated}', result.migrated || 0), isError: false });
     } catch (error) {
-      setMigratePublicFeedbackMessage({ text: t('admin.database.migratePublicFeedbackError').replace('{error}', () => error.message), isError: true });
+      setMigratePublicFeedbackMessage(buildErrorStatus('admin.database.migratePublicFeedbackError', error));
     } finally {
       setIsMigratingPublicFeedback(false);
     }
@@ -532,7 +560,7 @@ const DatabasePage = ({ lang }) => {
       setCreateIndexesMessage({ text: t('admin.database.createIndexesSuccess').replace('{successCount}', successCount).replace('{failCount}', failCount), isError: false });
     } catch (error) {
       setCreationDetails(null);
-      setCreateIndexesMessage({ text: t('admin.database.createIndexesError').replace('{error}', () => error.message), isError: true });
+      setCreateIndexesMessage(buildErrorStatus('admin.database.createIndexesError', error));
       console.error('Create indexes error:', error);
     } finally {
       setIsCreatingIndexes(false);
@@ -554,7 +582,7 @@ const DatabasePage = ({ lang }) => {
       {/* Table counts display */}
       <div style={{ marginBottom: 24 }}>
         <GcdsHeading tag="h2">{t('admin.database.tableRecordCounts')}</GcdsHeading>
-        <StatusMessage variant={countsError ? 'error' : undefined} message={countsError} />
+        {renderStatusMessage(countsError)}
         {tableCounts ? (
           <table style={{ margin: '12px 0', borderCollapse: 'collapse' }}>
             <thead>
@@ -620,7 +648,7 @@ const DatabasePage = ({ lang }) => {
         <GcdsButton onClick={handleExport} disabled={isExporting || collections.length === 0}>
           {isExporting ? t('admin.database.exporting') : t('admin.database.exportButton')}
         </GcdsButton>
-        <StatusMessage variant={exportMessage ? (exportMessage.isError ? 'error' : 'success') : undefined} message={exportMessage?.text} />
+        {renderStatusMessage(exportMessage)}
       </div>
       {/* Integrity checks: orphan and parent-invalid-child counts */}
       <div className="mb-400">
@@ -661,12 +689,11 @@ const DatabasePage = ({ lang }) => {
                     } catch (err) {
                       setChecksMessages(prev => ({
                         ...prev,
-                        [check.id]: {
-                          text: t('admin.database.checkFailed')
-                            .replace('{check}', check.id)
-                            .replace('{error}', () => err.message),
-                          isError: true,
-                        },
+                        [check.id]: buildErrorStatus(
+                          'admin.database.checkFailed',
+                          err,
+                          { check: check.id },
+                        ),
                       }));
                     } finally {
                       setChecksRunning(prev => ({ ...prev, [check.id]: false }));
@@ -677,10 +704,7 @@ const DatabasePage = ({ lang }) => {
                 >
                   {checksRunning[check.id] ? t('admin.database.runningLabel') : t('admin.database.runCheckButton')}
                 </GcdsButton>
-                <StatusMessage
-                  variant={checksMessages[check.id] ? (checksMessages[check.id].isError ? 'error' : 'success') : undefined}
-                  message={checksMessages[check.id]?.text}
-                />
+                {renderStatusMessage(checksMessages[check.id])}
                 <div style={{ minWidth: 220, textAlign: 'right' }}>
                   {checksResults[check.id] ? (
                     <div style={{ fontSize: 13 }}>
@@ -719,7 +743,7 @@ const DatabasePage = ({ lang }) => {
                         // Refresh the check results
                         setChecksResults(prev => ({ ...prev, duplicateKeys: null }));
                       } catch (err) {
-                        setRemoveDuplicatesMessage({ text: t('admin.database.removeDuplicatesError').replace('{error}', () => err.message), isError: true });
+                        setRemoveDuplicatesMessage(buildErrorStatus('admin.database.removeDuplicatesError', err));
                       } finally {
                         setIsRemovingDuplicates(false);
                       }
@@ -731,10 +755,7 @@ const DatabasePage = ({ lang }) => {
                   </GcdsButton>
                 )}
                 {check.id === 'duplicateKeys' && (
-                  <StatusMessage
-                    variant={removeDuplicatesMessage ? (removeDuplicatesMessage.isError ? 'error' : 'success') : undefined}
-                    message={removeDuplicatesMessage?.text}
-                  />
+                  renderStatusMessage(removeDuplicatesMessage)
                 )}
               </div>
             ))}
@@ -822,7 +843,7 @@ const DatabasePage = ({ lang }) => {
           {isImporting ? (
             <div role="status" aria-live="polite" className="status-message--progress">{importMessage?.text}</div>
           ) : (
-            <StatusMessage variant={importMessage ? (importMessage.isError ? 'error' : 'success') : undefined} message={importMessage?.text} />
+            renderStatusMessage(importMessage)
           )}
           {/* TODO: this is a raw <input type="file">, so the field-tied error
               below is FeedbackInlineError + aria-describedby (matching
@@ -873,7 +894,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isCreatingIndexes ? t('admin.database.creatingIndexesLabel') : t('admin.database.createIndexesButton')}
         </GcdsButton>
-        <StatusMessage variant={createIndexesMessage ? (createIndexesMessage.isError ? 'error' : 'success') : undefined} message={createIndexesMessage?.text} />
+        {renderStatusMessage(createIndexesMessage)}
         {creationDetails && creationDetails.failed && creationDetails.failed.length > 0 && (
           <div style={{ marginTop: 12, border: '1px solid #d93939', padding: 12, borderRadius: 4, backgroundColor: '#fff5f5' }}>
             <div style={{ fontWeight: 600, color: '#d93939', marginBottom: 8 }}>
@@ -905,7 +926,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isDroppingIndexes ? t('admin.database.droppingLabel') : t('admin.database.dropIndexesButton')}
         </GcdsButton>
-        <StatusMessage variant={dropIndexesMessage ? (dropIndexesMessage.isError ? 'error' : 'success') : undefined} message={dropIndexesMessage?.text} />
+        {renderStatusMessage(dropIndexesMessage)}
       </div>
 
       <div className="mb-400">
@@ -922,7 +943,7 @@ const DatabasePage = ({ lang }) => {
               const json = await DataStoreService.checkIndexStatus();
               setIndexStatus(json);
             } catch (err) {
-              setIndexStatusMessage({ text: t('admin.database.indexStatusError').replace('{error}', () => err.message), isError: true });
+              setIndexStatusMessage(buildErrorStatus('admin.database.indexStatusError', err));
             } finally {
               setIsCheckingIndexStatus(false);
             }
@@ -933,20 +954,27 @@ const DatabasePage = ({ lang }) => {
         >
           {isCheckingIndexStatus ? t('admin.database.checkingLabel') : t('admin.database.checkIndexStatusButton')}
         </GcdsButton>
-        <StatusMessage variant={indexStatusMessage ? (indexStatusMessage.isError ? 'error' : 'success') : undefined} message={indexStatusMessage?.text} />
+        {renderStatusMessage(indexStatusMessage)}
         {indexStatus && (
           <div style={{ marginTop: 12 }}>
-            <div
-              className={
-                indexStatus.anyBuilding
-                  ? 'text-status--neutral'
-                  : indexStatus.allComplete
-                    ? 'text-status--positive'
-                    : 'text-status--warning'
-              }
-              style={{ fontWeight: 600, marginBottom: 8 }}
-            >
-              {indexStatus.message}
+            {/* Was a hand-rolled colored <div> showing indexStatus.message
+                verbatim — raw, untranslated server text with no t() call at
+                all. The server's message is actually always one of these
+                same 3 fixed strings (see api/db/db-database-management.js),
+                picked from the exact same anyBuilding/allComplete booleans
+                already computed here — so the frontend translates its own
+                copy instead of echoing the server's English one. */}
+            <div style={{ marginBottom: 8 }}>
+              <StatusMessage
+                variant={indexStatus.anyBuilding ? 'info' : indexStatus.allComplete ? 'success' : 'warning'}
+                message={t(
+                  indexStatus.anyBuilding
+                    ? 'admin.database.indexStatusBuilding'
+                    : indexStatus.allComplete
+                      ? 'admin.database.indexStatusComplete'
+                      : 'admin.database.indexStatusIncomplete'
+                )}
+              />
             </div>
             <table style={{ borderCollapse: 'collapse', fontSize: 13 }}>
               <thead>
@@ -1003,7 +1031,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isDeletingSystemLogs ? t('admin.database.deletingLabel') : t('admin.database.deleteSystemLogsButton')}
         </GcdsButton>
-        <StatusMessage variant={deleteSystemLogsMessage ? (deleteSystemLogsMessage.isError ? 'error' : 'success') : undefined} message={deleteSystemLogsMessage?.text} />
+        {renderStatusMessage(deleteSystemLogsMessage)}
       </div>
 
       <div className="mb-400">
@@ -1019,7 +1047,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isRepairingTimestamps ? t('admin.database.repairingLabel') : t('admin.database.repairTimestampsButton')}
         </GcdsButton>
-        <StatusMessage variant={repairTimestampsMessage ? (repairTimestampsMessage.isError ? 'error' : 'success') : undefined} message={repairTimestampsMessage?.text} />
+        {renderStatusMessage(repairTimestampsMessage)}
       </div>
 
       <div className="mb-400">
@@ -1035,7 +1063,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isDeletingAllBatches ? t('admin.database.deletingLabel') : t('admin.database.deleteAllBatchesButton')}
         </GcdsButton>
-        <StatusMessage variant={deleteAllBatchesMessage ? (deleteAllBatchesMessage.isError ? 'error' : 'success') : undefined} message={deleteAllBatchesMessage?.text} />
+        {renderStatusMessage(deleteAllBatchesMessage)}
       </div>
 
       <div className="mb-400">
@@ -1051,7 +1079,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isRepairingExpertFeedback ? t('admin.database.repairingLabel') : t('admin.database.repairExpertFeedbackButton')}
         </GcdsButton>
-        <StatusMessage variant={repairExpertFeedbackMessage ? (repairExpertFeedbackMessage.isError ? 'error' : 'success') : undefined} message={repairExpertFeedbackMessage?.text} />
+        {renderStatusMessage(repairExpertFeedbackMessage)}
       </div>
 
       <div className="mb-400">
@@ -1067,7 +1095,7 @@ const DatabasePage = ({ lang }) => {
         >
           {isMigratingPublicFeedback ? t('admin.database.migratingLabel') : t('admin.database.migratePublicFeedbackButton')}
         </GcdsButton>
-        <StatusMessage variant={migratePublicFeedbackMessage ? (migratePublicFeedbackMessage.isError ? 'error' : 'success') : undefined} message={migratePublicFeedbackMessage?.text} />
+        {renderStatusMessage(migratePublicFeedbackMessage)}
       </div>
 
       <div className="mb-400">
@@ -1076,7 +1104,7 @@ const DatabasePage = ({ lang }) => {
         <GcdsButton onClick={handleRepairQaMatchScores} disabled={isRepairingQaMatchScores} buttonRole="secondary" className="mb-200">
           {isRepairingQaMatchScores ? t('admin.database.repairingLabel') : t('admin.database.repairQaMatchScoresButton')}
         </GcdsButton>
-        <StatusMessage variant={repairQaMatchScoresMessage ? (repairQaMatchScoresMessage.isError ? 'error' : 'success') : undefined} message={repairQaMatchScoresMessage?.text} />
+        {renderStatusMessage(repairQaMatchScoresMessage)}
       </div>
     </GcdsContainer >
   );

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -460,10 +460,9 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         <LoadingOverlay message={t('admin.evalDashboard.loading')} />
       )}
 
-      <StatusMessage
-        variant={error ? 'error' : undefined}
-        message={error ? `${t('admin.evalDashboard.error')} ${String(error)}` : null}
-      />
+      <StatusMessage variant={error ? 'error' : undefined}>
+        {error && <>{t('admin.evalDashboard.error')} <code lang="en">{String(error)}</code></>}
+      </StatusMessage>
 
       {/* Distinct from the filters-driven empty state below - a zero-result
           global search means the search term didn't match anything, not

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -52,6 +52,10 @@ const RegisterPage = ({ lang = 'en' }) => {
         setSuccessMessage(true);
       }
     } catch {
+      // Never show err.message here — often just raw, always-English
+      // browser/fetch error text (e.g. "Failed to fetch"), and showing the
+      // specific reason (e.g. "email already exists") would double as an
+      // account-enumeration oracle. Always the generic translated message.
       setSystemError(t('signup.errorOccurred'));
     } finally {
       setIsLoading(false);

--- a/src/pages/ResetCompletePage.js
+++ b/src/pages/ResetCompletePage.js
@@ -7,6 +7,7 @@ import PasswordInput from '../components/auth/PasswordInput.js';
 import AnnouncedError from '../components/auth/AnnouncedError.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import { useAuthFormValidation } from '../hooks/auth/useAuthFormValidation.js';
+import { resolveErrorMessage } from '../utils/errorCodeMessage.js';
 import { useAuthOutcomeMessages } from '../hooks/auth/useAuthOutcomeMessages.js';
 import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
 
@@ -64,12 +65,10 @@ const ResetCompletePage = ({ lang = 'en' }) => {
       // Rate-limiting and an invalid/expired reset link aren't things the
       // user can fix by editing password/confirm — system-level outcomes,
       // not field errors, so they go through StatusMessage, not AnnouncedError.
-      const errorKeys = {
+      setSystemError(resolveErrorMessage(err.code, {
         RESET_LOCKED_OUT: 'reset.complete.lockedOut',
         RESET_INVALID_CODE: 'reset.complete.invalidCode',
-      };
-      const key = err.code && errorKeys[err.code];
-      setSystemError(key ? t(key) : t('reset.complete.error'));
+      }, 'reset.complete.error', t));
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/ScenarioOverridesPage.js
+++ b/src/pages/ScenarioOverridesPage.js
@@ -103,17 +103,22 @@ class PageErrorBoundary extends React.Component {
   }
   render() {
     if (this.state.hasError) {
-      // this.props.t?.(...), not this.props.t(...): a fallback render must
-      // never itself throw (there's no boundary above this one to catch a
-      // secondary error) — optional-chain the call rather than restoring
-      // main's old `t ? t(key, 'fallback text') : 'fallback text'` guard,
-      // which duplicated a literal fallback string alongside every locale
-      // key (against this repo's t()-takes-only-a-key convention).
+      // Hardcoded and bilingual on purpose, not t()-driven: this is the one
+      // screen in the app that must render even if something above it —
+      // including the translation system itself — is what broke. No prop,
+      // no function call, nothing here that can itself throw and leave the
+      // admin with a blank screen instead of a fallback. Both languages
+      // shown together since we can't safely assume which one the admin
+      // needs. role="alert" so a screen reader announces this immediately
+      // if the boundary trips without a full page navigation (e.g. a
+      // second render after some in-page action).
       return (
         <GcdsContainer layout="page" className="mb-600">
-          <h1 className="mb-400">{this.props.t?.('scenarioOverrides.title')}</h1>
-          <p style={{ color: '#d3080c' }}>{this.props.t?.('scenarioOverrides.error.fallback')}</p>
-          <p>{this.state.error?.toString?.() || ''}</p>
+          <h1 className="mb-400">Edit and test scenarios / Modifier et tester les scénarios</h1>
+          <p role="alert" style={{ color: '#d3080c' }}>
+            An error occurred while loading this page. / Une erreur est survenue lors du chargement de cette page.
+          </p>
+          <p><code lang="en">{this.state.error?.toString?.() || ''}</code></p>
         </GcdsContainer>
       );
     }
@@ -520,7 +525,7 @@ const ScenarioOverridesPage = ({ lang = 'en' }) => {
   const showTestLink = Boolean(enabled && updatedAt && !dirty);
 
   return (
-    <PageErrorBoundary t={t}>
+    <PageErrorBoundary>
       <GcdsContainer layout="page" className="mb-600">
         <h1 className="mb-400">{pageTitle}</h1>
         <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -3,6 +3,7 @@ import { GcdsButton, GcdsContainer } from '@gcds-core/components-react';
 import DataStoreService from '../services/DataStoreService.js';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
+import { useErrorStatus } from '../hooks/useErrorStatus.js';
 import { WORKFLOWS, AVAILABLE_MODELS, WORKFLOW_VALUES, DEFAULT_WORKFLOW } from '../config/workflows.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
 import { AUDIT_VALUE_PREVIEW_LENGTH } from '../components/settings/SettingsAuditValue.js';
@@ -40,7 +41,18 @@ const renderAuditValueHtml = (value, emptyLabel) => {
 // admin's UI language. This resolves either shape to display text in the
 // admin's actual language.
 const resolveFieldError = (error, t) => {
-  if (typeof error === 'string') return error;
+  // The plain-string branch is the rare case (a requireString/requireLiteralString
+  // validation failure, or a DB write throwing inside setMany's
+  // Promise.allSettled) — SettingsService.setMany has no translation for these,
+  // by its own comment, so `error` here is a raw driver/exception message.
+  // FeedbackInlineError renders `message` directly, so returning a fragment
+  // instead of a string works with no change to that component — same
+  // translated-prefix + <code lang="en"> wrap as buildErrorStatus uses for
+  // DatabasePage.js's raw details, just field-scoped instead of page-scoped.
+  if (typeof error === 'string') {
+    const [prefix, suffix] = t('settings.fieldError.unexpected').split('{error}');
+    return <>{prefix}<code lang="en">{error}</code>{suffix}</>;
+  }
   if (error && error.i18nKey) {
     let message = t(error.i18nKey);
     Object.entries(error.i18nValues || {}).forEach(([placeholder, value]) => {
@@ -197,6 +209,11 @@ const FIELD_META = {
 
 const SettingsPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
+  // Shared with DatabasePage.js's own ~13 uses of the same shape - see
+  // useErrorStatus.js. This page's only use (the settings-cache refresh
+  // below) renders success as 'info' (a neutral confirmation, not a
+  // completed mutation), not the 'success' default.
+  const { buildErrorStatus, renderStatusMessage } = useErrorStatus(t);
   const [status, setStatus] = useState('available');
   const [deploymentMode, setDeploymentMode] = useState('CDS');
   const [vectorServiceType, setVectorServiceType] = useState('imvectordb');
@@ -208,6 +225,12 @@ const SettingsPage = ({ lang = 'en' }) => {
   // without resetting whatever the admin had typed into the search box or
   // paged to, unlike forcing a full remount via a `tableKey` bump.
   const auditTableRef = useRef(null);
+  // Set from ServerDataTable's onError — a genuine fetch failure used to be
+  // silently indistinguishable from "no audit rows exist" (both rendered
+  // emptyTableText). buildErrorStatus/renderStatusMessage below is the same
+  // shape/rendering this page's settingsCacheStatus and DatabasePage.js's
+  // ~13 operations already use.
+  const [auditLoadStatus, setAuditLoadStatus] = useState(null);
   const [baseUrl, setBaseUrl] = useState('');
 
   // Global default workflow setting (Default | DefaultWithVector | DefaultWithVectorGraph)
@@ -556,10 +579,7 @@ const SettingsPage = ({ lang = 'en' }) => {
       setSettingsCacheStatus({ text: t('settings.refreshCache.success'), isError: false });
       auditTableRef.current?.reload();
     } catch (error) {
-      setSettingsCacheStatus({
-        text: t('settings.refreshCache.error').replace('{error}', () => error.message || String(error)),
-        isError: true,
-      });
+      setSettingsCacheStatus(buildErrorStatus('settings.refreshCache.error', error));
     } finally {
       setRefreshingSettingsCache(false);
     }
@@ -590,10 +610,7 @@ const SettingsPage = ({ lang = 'en' }) => {
         >
           {refreshingSettingsCache ? t('settings.refreshCache.loading') : t('settings.refreshCache.label')}
         </GcdsButton>
-        <StatusMessage
-          variant={settingsCacheStatus ? (settingsCacheStatus.isError ? 'error' : 'info') : undefined}
-          message={settingsCacheStatus?.text}
-        />
+        {renderStatusMessage(settingsCacheStatus, 'info')}
       </div>
       {/* Per-section "Unsaved changes" only shows while that section's
           <details> is open — a page-level one stays visible regardless of
@@ -1445,6 +1462,7 @@ const SettingsPage = ({ lang = 'en' }) => {
             belongs in its own tab on this page, or behind a details/summary
             disclosure — either would let a lighter "recent changes" view
             replace this full search/paginate table for the common case. */}
+        {renderStatusMessage(auditLoadStatus)}
         <ServerDataTable
           ref={auditTableRef}
           tableKey="settings-audit-history"
@@ -1458,6 +1476,7 @@ const SettingsPage = ({ lang = 'en' }) => {
           layout={{ topStart: 'search', topEnd: null }}
           containerClassName="table-scroll mt-200"
           emptyTableText={t('settings.auditHistory.empty')}
+          onError={(error) => setAuditLoadStatus(error ? buildErrorStatus('settings.auditHistory.loadError', error) : null)}
         />
       </section>
 

--- a/src/pages/VectorPage.js
+++ b/src/pages/VectorPage.js
@@ -9,6 +9,7 @@ import { formatDecimal, formatNumber } from '../utils/numberFormat.js';
 import StatusMessage, { useSrAnnouncer } from '../components/admin/StatusMessage.js';
 import FeedbackInlineError from '../components/chat/FeedbackInlineError.js';
 import { useInlineFormError } from '../hooks/useInlineFormError.js';
+import { useErrorStatus } from '../hooks/useErrorStatus.js';
 
 const ACTIVE_METADATA_JOB_STATUSES = new Set(['queued', 'running', 'stopping']);
 
@@ -60,10 +61,21 @@ const formatDocdb8ScoreRange = (scoreSummary, lang, t) => {
     .replace('{max}', formatDecimal(scoreSummary.maxScore, lang, 3));
 };
 
+// A probe's error is a genuine, unpredictable driver/DB message from a live
+// capability test (unlike VectorService.getStats/reinitialize's fixed
+// strings above) — always worth keeping, but wrapped behind a translated
+// prefix rather than shown alone, same as everywhere else in this file.
+const renderDocdb8Error = (detail, t) => {
+  if (!detail) return t('vector.docdb8Capability.noError');
+  const [prefix, suffix] = t('vector.docdb8Capability.errorDetail').split('{error}');
+  return <>{prefix}<code lang="en">{detail}</code>{suffix}</>;
+};
+
 const VectorPage = ({ lang = 'en' }) => {
   const { language } = usePageContext();
   const activeLang = lang || language;
   const { t } = useTranslations(activeLang);
+  const { buildErrorStatus, renderStatusMessage } = useErrorStatus(t);
   const fmtN = (n) => formatNumber(n, activeLang);
   const [vectorStats, setVectorStats] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -256,7 +268,12 @@ const VectorPage = ({ lang = 'en' }) => {
       setVectorStats(data);
       announceVectorStats(t('vector.statsLoaded'));
     } catch (err) {
-      setError(err.message);
+      // err.message is usually the one fixed string VectorService.getStats
+      // throws on a non-OK response — not truly unbounded — but a real
+      // network failure before any response (e.g. the browser's own
+      // "Failed to fetch") can still land here, so the detail is kept,
+      // just translated and wrapped rather than shown alone.
+      setError(buildErrorStatus('vector.statsLoadError', err));
     } finally {
       setLoading(false);
     }
@@ -335,9 +352,11 @@ const VectorPage = ({ lang = 'en' }) => {
     setError(null);
     try {
       await VectorService.reinitialize();
-      setIndexMessage({ type: 'success', text: t('vector.indexCreatedSuccess') });
+      setIndexMessage({ text: t('vector.indexCreatedSuccess'), isError: false });
     } catch (err) {
-      setIndexMessage({ type: 'error', text: err.message });
+      // Same reasoning as fetchVectorStats' catch above — usually one fixed
+      // string, occasionally a real network error, always kept but wrapped.
+      setIndexMessage(buildErrorStatus('vector.indexCreateError', err));
     } finally {
       setLoading(false);
     }
@@ -544,8 +563,8 @@ const VectorPage = ({ lang = 'en' }) => {
             {t('vector.reinitializeIndex')}
           </GcdsButton>
         </div>
-        <StatusMessage variant={error ? 'error' : undefined} message={error} />
-        <StatusMessage variant={indexMessage?.type} message={indexMessage?.text} />
+        {renderStatusMessage(error)}
+        {renderStatusMessage(indexMessage)}
         <StatusMessage persistent message={vectorStatsAnnouncement} nonce={vectorStatsAnnounceNonce} className="sr-only" />
         {vectorStats && (
           <div className="mb-200">
@@ -596,7 +615,7 @@ const VectorPage = ({ lang = 'en' }) => {
                     <td>{result?.test?.metadata?.candidateReductionBeforeVectorSearch ? t('vector.docdb8Capability.yes') : t('vector.docdb8Capability.no')}</td>
                     <td>{formatDocdb8ScoreRange(result?.test?.scoreSummary, activeLang, t)}</td>
                     <td>{t('vector.docdb8Capability.durationMs').replace('{ms}', fmtN(result?.test?.durationMs))}</td>
-                    <td>{probeError || result?.test?.error?.message || t('vector.docdb8Capability.noError')}</td>
+                    <td>{renderDocdb8Error(probeError || result?.test?.error?.message, t)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/pages/experimental/ExperimentalCreateDatasetPage.js
+++ b/src/pages/experimental/ExperimentalCreateDatasetPage.js
@@ -78,11 +78,21 @@ export default function ExperimentalCreateDatasetPage({ lang = 'en' }) {
                     : t('experimental.datasets.goldenAnswerSuccess')
             });
         } catch (err) {
+            // The server occasionally returns a specific, genuinely useful
+            // validation reason (data.error) — kept, but wrapped in
+            // <code lang="en"> behind a translated prefix rather than shown
+            // raw, same pattern as buildErrorStatus (useErrorStatus.js).
+            const detail = err.response?.data?.error;
+            let goldenAnswerText = t('experimental.datasets.goldenAnswerFailed');
+            if (detail) {
+                const [prefix, suffix] = t('experimental.datasets.goldenAnswerFailedDetail').split('{error}');
+                goldenAnswerText = <>{prefix}<code lang="en">{detail}</code>{suffix}</>;
+            }
             setMessage({
                 type: 'error',
                 text: method === 'instant-answer'
                     ? t('experimental.datasets.instantAnswerFailed')
-                    : err.response?.data?.error || t('experimental.datasets.goldenAnswerFailed')
+                    : goldenAnswerText
             });
         } finally {
             setCreating(false);

--- a/src/pages/experimental/ExperimentalDatasetsPage.js
+++ b/src/pages/experimental/ExperimentalDatasetsPage.js
@@ -112,9 +112,17 @@ export default function ExperimentalDatasetsPage({ lang = 'en' }) {
                     setSelectedFile(null);
                     setShowUpload(false);
                 } catch (err) {
+                    // Always the translated message here, not
+                    // err.response?.data?.error directly - same as the
+                    // sibling handleDelete below, never raw backend text.
+                    // `details` (below, rendered per-item) is kept raw on
+                    // purpose - specific per-field validation feedback from
+                    // the backend, genuinely useful for diagnosing a
+                    // rejected upload, wrapped in <code lang="en"> instead
+                    // of dropped.
                     setMessage({
                         type: 'error',
-                        text: err.response?.data?.error || t('experimental.datasets.uploadFailed'),
+                        text: t('experimental.datasets.uploadFailed'),
                         details: err.response?.data?.details
                     });
                 } finally {
@@ -136,10 +144,14 @@ export default function ExperimentalDatasetsPage({ lang = 'en' }) {
             await ExperimentalBatchClientService.deleteDataset(id);
             fetchDatasets();
         } catch (err) {
+            // Native alert() had no ARIA role and, worse, showed raw
+            // untranslated err.message text — routed through the page's
+            // existing setMessage/StatusMessage pattern instead, same as
+            // every other outcome on this page.
             if (err.response?.data?.code === 'IN_USE') {
-                alert(t('experimental.datasets.inUse'));
+                setMessage({ type: 'error', text: t('experimental.datasets.inUse') });
             } else {
-                alert(err.response?.data?.error || err.message);
+                setMessage({ type: 'error', text: t('experimental.datasets.deleteFailed') });
             }
         }
     };
@@ -187,7 +199,10 @@ export default function ExperimentalDatasetsPage({ lang = 'en' }) {
             const alreadyProcessing = err.code === 'stillProcessing' || err.status === 409;
             if (!alreadyProcessing) {
                 console.error('Process dataset error:', err);
-                if (showMessage) setMessage({ type: 'error', text: err.message || t('experimental.datasets.processFailed') });
+                // message.text renders as plain text (<GcdsText>{message.text}</GcdsText>),
+                // no room to wrap a raw err.message in <code lang="en"> here —
+                // always show the translated message rather than raw text.
+                if (showMessage) setMessage({ type: 'error', text: t('experimental.datasets.processFailed') });
             }
         } finally {
             processingDatasetRef.current = null;
@@ -378,7 +393,7 @@ export default function ExperimentalDatasetsPage({ lang = 'en' }) {
                                         {message.details && Array.isArray(message.details) && message.details.length > 0 && (
                                             <ul style={{ marginTop: '0.5rem', marginBottom: 0, paddingLeft: '1.5rem', fontSize: '0.9rem' }}>
                                                 {message.details.map((detail, i) => (
-                                                    <li key={i}>{detail}</li>
+                                                    <li key={i}><code lang="en">{detail}</code></li>
                                                 ))}
                                             </ul>
                                         )}

--- a/src/utils/errorCodeMessage.js
+++ b/src/utils/errorCodeMessage.js
@@ -1,0 +1,16 @@
+// Maps a backend-supplied error `code` (a small, stable enum — never free
+// text) to a translated message via a local code->locale-key table, with a
+// generic fallback for an unrecognized or missing code. This is the "map a
+// stable code through a local object to a t() key" half of the two safe
+// alternatives to showing a raw err.message — see
+// docs/coding-agent-docs/status-and-error-messaging.md.
+//
+// Extracted after ResetCompletePage.js and BatchUpload.js independently
+// hand-rolled the same shape (a code->key object literal, then t(key) with
+// a fallback) slightly differently each time — the same kind of drift this
+// codebase keeps hitting whenever a shared shape gets copy-pasted instead
+// of extracted the first time.
+export const resolveErrorMessage = (code, codeMap, fallbackKey, t) => {
+  const key = code && codeMap[code];
+  return key ? t(key) : t(fallbackKey);
+};


### PR DESCRIPTION
## Why this fix was needed

The app must serve English and French speakers equally (Official Languages Act) and work with screen readers (accessibility standards).

It helps to know there are two different layers of "error" here:

  - The browser's own UI (its native error pages, dialogs, menus) does follow the user's browser language setting — a French browser shows French browser chrome. The browser is a bilingual product.
  - JavaScript errors and driver/library messages — the ones this fix targets — are a different layer entirely. Things like a TypeError, a failed fetch() message, or a database driver's internal error string come from the code engine itself, not the browser's UI. They're hardcoded developer strings that were never meant for an end user to read, so no French version exists anywhere — the same way HTML tags or CSS properties aren't translated, because they're a fixed technical vocabulary, not content. No browser or OS language setting can make this layer speak French. 

## What the fix does

  - Everyday partners only ever see a proper, translated message in their own language — written by the app, not by the machine.
  - The cases where the raw technical detail is worth keeping (mainly admin/diagnostic pages, for admin troubleshooting) still shows it, but marked `<code lang="en"> `— so a screen reader pronounces it correctly instead of applying the wrong language's pronunciation rules, and sighted users can see it's the technical vocabulary, not content.
  
 ## Out of scope
 - Did not convert current popup dialog boxes used as these type of messages - confirmed they all have translations and exists on admin only. Will circle back when doing a11y work on admin specific tools. 