### PR TITLE
fix: replace text-glyph disclosure chevron with a CSS mask

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -402,15 +402,24 @@ summary::-webkit-details-marker {
 }
 
 details > summary::before {
-  content: '►';
+  content: '';
   display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
   margin-right: 0.5rem;
-  font-size: 0.75em;
-  line-height: 1;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='1,0 9,5 1,10' fill='white'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='1,0 9,5 1,10' fill='white'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 details[open] > summary::before {
-  content: '▼';
+  transform: rotate(90deg);
 }
 
 /* A focused, open summary's outline (outline-offset 0.125rem + outline

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -422,6 +422,17 @@ details[open] > summary::before {
   transform: rotate(90deg);
 }
 
+/* The chevron's fill comes from background-color (masked to a triangle).
+   Forced-colors mode (Windows High Contrast Mode) maps background-color to
+   Canvas (the page background), not CanvasText like it does for color/text —
+   so the mask would be forced to match the page background and disappear.
+   Repaint it explicitly with the CanvasText system color so it stays visible. */
+@media (forced-colors: active) {
+  details > summary::before {
+    background-color: CanvasText;
+  }
+}
+
 /* A focused, open summary's outline (outline-offset 0.125rem + outline
    0.25rem, see summary:focus below) bleeds ~0.375rem past its own box —
    without breathing room after it, that blue ring touches the revealed


### PR DESCRIPTION
details > summary::before drew the expand/collapse chevron as real text content ('►'/'▼'). Modern AT/browser pairings (Chrome+NVDA/JAWS, Safari+VoiceOver) expose ::before/::after text to the accessibility tree, so every `<summary> `on the site announced a stray glyph alongside its label on top of `<summary>`'s own native disclosure semantics.

Replaces the text content with a CSS mask (an inline SVG triangle) plus background-color: currentColor, so nothing textual is exposed while the per-context colour (e.g. FilterPanel's white-on-blue closed state) still comes through correctly. One shape rotated 90deg for the open state instead of a second glyph. Verified pixel-identical rendering via a headless-Chrome screenshot comparison against the current site.
