### PR TITLE
fix: add scope="col" and caption to ChatViewer's log-entries table

### DIFF
--- a/src/hooks/chatviewer/useChatLogsTable.js
+++ b/src/hooks/chatviewer/useChatLogsTable.js
@@ -9,6 +9,7 @@ import Prism from 'prismjs';
 import { buildMetadataCellHtml, escapeHtml } from '../../utils/chatviewer/chatViewer.js';
 import { captureTableFocus, restoreTableFocus } from '../../utils/chatviewer/focusRestore.js';
 import { dataTableLanguage } from '../../utils/dataTableLanguage.js';
+import { setColumnHeaderScope } from '../../utils/admin/dataTableAccessibility.js';
 
 // DataTables' column search takes one string, not an array - '^(warn|error)$'
 // (regex mode) is how a multi-value "OR" match is expressed as that one
@@ -158,6 +159,11 @@ export function useChatLogsTable({
         // for those pages' department/program search and wouldn't fit
         // searching log messages/levels/metadata here.
         search: t('admin.common.searchLabel'),
+      },
+      // scope="col" is dynamic, not static JSX, so a future columns[] edit
+      // can't drift out of sync with it (WCAG 1.3.1).
+      initComplete: function () {
+        setColumnHeaderScope(this.api());
       },
       drawCallback: function () {
         // Scoped to this table - no <code> blocks exist outside it.

--- a/src/pages/ChatViewer.js
+++ b/src/pages/ChatViewer.js
@@ -13,6 +13,7 @@ import FeedbackInlineError from '../components/chat/FeedbackInlineError.js';
 import ChatIdMatchList, { buildChatIdMatchesLabels } from '../components/admin/ChatIdMatchList.js';
 import { formatNumber } from '../utils/numberFormat.js';
 import { dataTableLanguage } from '../utils/dataTableLanguage.js';
+import { setColumnHeaderScope } from '../utils/admin/dataTableAccessibility.js';
 import { buildChatReviewHref, chatLangFromPageLanguage } from '../utils/reviewLink.js';
 import 'prismjs/themes/prism.css';
 import 'prismjs/components/prism-json.js';
@@ -576,6 +577,13 @@ const ChatViewer = ({ lang = 'en' }) => {
                     ordering: false,
                     info: false,
                     language: dataTableLanguage(lang),
+                    // DataTables doesn't set scope="col" on header cells
+                    // itself (WCAG 1.3.1) - no search box on this table, so
+                    // just the scope half of wireTableAccessibility, not the
+                    // search-pill half that goes with it.
+                    initComplete: function () {
+                      setColumnHeaderScope(this.api());
+                    },
                   }}
                 >
                   <caption className="sr-only">{t('logging.timeline.title')}</caption>
@@ -669,6 +677,12 @@ const ChatViewer = ({ lang = 'en' }) => {
                     plain (non-grouped) table - no chat-group rowspanning
                     here, so dashboard-table--grouped isn't needed. */}
                 <table ref={tableRef} className="display dashboard-table zebra-stable-on-hover">
+                  {/* Ties this table to the h2 above it for a screen reader
+                      navigating by table rather than heading (Technique H39)
+                      - same reasoning as the step-timeline table's own
+                      caption above. */}
+                  <caption className="sr-only">{t('logging.entriesHeading')}</caption>
+                  {/* scope="col" set dynamically by useChatLogsTable's initComplete, not here. */}
                   <thead>
                     <tr>
                       <th>{t('logging.createdAt')}</th>

--- a/src/utils/admin/dataTableAccessibility.js
+++ b/src/utils/admin/dataTableAccessibility.js
@@ -1,18 +1,33 @@
-// Shared DOM-only accessibility wiring for a DataTable with a single global
-// search box (Chat/Eval/Metrics dashboards) — call once from that table's own
-// `initComplete`. No React state involved; everything here is imperative
-// DOM, mirroring DataTables' own imperative init style.
+// Shared DOM-only accessibility wiring for DataTables, called once from a
+// table's own `initComplete`. No React state involved; everything here is
+// imperative DOM, mirroring DataTables' own imperative init style.
 //
-//   - scope="col" on every header cell: DataTables doesn't set this itself
-//     (a real WCAG 1.3.1 gap in the library, not something a config option
-//     turns on).
-//   - A dismissible search-term pill next to the search box, same
-//     .filter-pill styling FilterPanel.js uses for its own active-filter
-//     pills, so the current term is visible and clearable without needing
-//     to select/delete the input text.
+//   - setColumnHeaderScope: scope="col" on every header cell. DataTables
+//     doesn't set this itself (a real WCAG 1.3.1 gap in the library, not
+//     something a config option turns on). Use alone for a table with no
+//     search box.
+//   - wireTableAccessibility: the above, plus a dismissible search-term
+//     pill next to the search box, same .filter-pill styling FilterPanel.js
+//     uses for its own active-filter pills. Use for a table with one.
 //
-// Previously hand-duplicated (near-identically) across ChatDashboardPage.js,
-// EvalDashboardPage.js, and MetricsDashboard.js.
+// wireTableAccessibility was previously hand-duplicated (near-identically)
+// across ChatDashboardPage.js, EvalDashboardPage.js, and MetricsDashboard.js.
+
+/**
+ * Scope-only half of wireTableAccessibility, for a table with no search box
+ * (ChatViewer.js's step-timeline and log-entries tables).
+ *
+ * @param {object} api - the DataTables API instance (`this.api()` inside initComplete)
+ */
+export function setColumnHeaderScope(api) {
+  try {
+    api.columns().header().each((header) => {
+      header.setAttribute('scope', 'col');
+    });
+  } catch (e) {
+    // Accessibility wiring must never break the table itself.
+  }
+}
 
 /**
  * @param {object} api - the DataTables API instance (`this.api()` inside initComplete)
@@ -20,11 +35,10 @@
  * @param {function} options.t - translation function
  */
 export function wireTableAccessibility(api, { t }) {
+  // Own try/catch, isolated from the pill logic below: a scope-setting
+  // failure shouldn't also skip the pill.
+  setColumnHeaderScope(api);
   try {
-    api.columns().header().each((header) => {
-      header.setAttribute('scope', 'col');
-    });
-
     const searchContainer = api.table().container().querySelector('.dt-search');
     if (!searchContainer) return; // searching disabled on this table
     const searchInput = searchContainer.querySelector('input');


### PR DESCRIPTION
  The log-entries table (createdAt/level/message/metadata) had neither
  scope="col" on its header cells nor a <caption> tying it to its own
  h2.
  Closes the last open WCAG 1.3.1 finding on this page.