### PR TITLE
fix: mark interrupted eval-analysis run as a warning, not info

### DIFF
--- a/src/components/admin/__tests__/EvalAnalysisSection.test.js
+++ b/src/components/admin/__tests__/EvalAnalysisSection.test.js
@@ -31,6 +31,29 @@ vi.mock('../../../services/EvalAnalysisService.js', () => ({
   }
 }));
 
+// Real useEvalAnalysis() drives a whole precheck→create→advance state
+// machine off the mocked service above — overkill for a test that only
+// needs one specific `analysis` shape rendered. Mocked here; individual
+// tests override just the field(s) they care about by spreading this base.
+const defaultHookResult = {
+  precheck: null,
+  precheckLoading: false,
+  runPrecheck: vi.fn(),
+  running: false,
+  analysis: null,
+  runError: null,
+  runAnalysis: vi.fn(),
+  pastRuns: [],
+  refreshList: vi.fn(),
+  loadAnalysis: vi.fn(),
+  clearAnalysis: vi.fn(),
+  loadingAnalysisId: null
+};
+const mockUseEvalAnalysis = vi.fn(() => defaultHookResult);
+vi.mock('../../../hooks/admin/useEvalAnalysis.js', () => ({
+  useEvalAnalysis: (...args) => mockUseEvalAnalysis(...args)
+}));
+
 import EvalAnalysisSection from '../dashboard/EvalAnalysisSection.js';
 import EvalAnalysisReport from '../dashboard/EvalAnalysisReport.js';
 
@@ -44,6 +67,20 @@ describe('EvalAnalysisSection', () => {
     expect(screen.getByText('Select an institution in the filters above to enable analysis.')).toBeTruthy();
     const button = document.querySelector('gcds-button, button');
     expect(button).toBeTruthy();
+  });
+
+  it('shows the interrupted-run message as a warning, not info', () => {
+    // A past run loaded in a non-terminal status (neither 'complete' nor
+    // 'error') — the tab was closed mid-run, nothing left to display but
+    // the fact that it needs re-running. That's warning-shaped (a broken
+    // state with one way forward), not neutral info, even though role/
+    // aria-live don't change between the two variants.
+    mockUseEvalAnalysis.mockReturnValueOnce({ ...defaultHookResult, analysis: { _id: 'a1', status: 'running' } });
+    render(<EvalAnalysisSection lang="en" appliedDepartment="TBS-SCT" appliedFilters={{}} />);
+
+    const message = screen.getByText('This analysis was interrupted before it finished and has no report to display. Run a new analysis.');
+    expect(message.closest('.status-message--warning-box')).toBeTruthy();
+    expect(message.closest('.status-message--info-box')).toBeNull();
   });
 });
 

--- a/src/components/admin/dashboard/EvalAnalysisSection.js
+++ b/src/components/admin/dashboard/EvalAnalysisSection.js
@@ -276,10 +276,13 @@ const EvalAnalysisSection = ({ lang = 'en', appliedDepartment = '', appliedFilte
 
       {/* A past run loaded in a non-terminal state (interrupted mid-run —
           e.g. the tab was closed) has no report to show; say so instead of
-          rendering nothing. */}
+          rendering nothing. variant="warning", not "info" — unlike the
+          precheck messages above (an objective fact about the dataset the
+          user can't act on), this represents a genuinely broken/failed run
+          with only one way forward (re-run it), which is warning-shaped. */}
       {analysis && !running && analysis.status !== 'complete' && analysis.status !== 'error' && (
         <div className="dashboard-section">
-          <StatusMessage variant="info" message={t('partnerDashboard.evalAnalysis.report.incomplete')} />
+          <StatusMessage variant="warning" message={t('partnerDashboard.evalAnalysis.report.incomplete')} />
         </div>
       )}
     </div>


### PR DESCRIPTION
 The "analysis was interrupted before it finished" message
  (EvalAnalysisSection.js, partnerDashboard.evalAnalysis.report.incomplete)
  used variant="info", the same as the precheck too-few/too-many messages
  above it — but unlike those (an objective fact about the dataset the
  user can't act on), this represents a genuinely broken run with no
  completed report and only one way forward: re-run it. That's
  warning-shaped, not neutral information.

  Switches to variant="warning". role/aria-live don't change (both info
  and warning render role="status" aria-live="polite"), so this is a
  visual/semantic correction, not a live-region fix.

  Adds regression coverage for this render path (a non-terminal-status
  analysis loaded), which had none before.