### PR TITLE
fix: restore focus to filter panel summary when Apply auto-closes it

### DIFF
--- a/src/components/admin/DashboardFilterBar.js
+++ b/src/components/admin/DashboardFilterBar.js
@@ -79,9 +79,20 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
   // The custom-date row (start/end inputs + Apply) unmounts whenever
   // showCustom flips back to false — whatever inside it had focus would
   // otherwise silently drop to <body>. Refocus this button (the one that
-  // opened the row) every time that happens, from all three closing paths:
-  // Escape, re-clicking "Custom", and clicking "Apply".
+  // opened the row) on the two closing paths that don't also start a fetch:
+  // Escape and re-clicking "Custom" to collapse it. The third path (Apply)
+  // used to land here too, but every preset button here - including this
+  // one - carries disabled={loading}, and onApply's fetch flips loading
+  // true in the very same tick: the browser blurs a focused element the
+  // instant it's disabled, so a fetch-triggering close would refocus this
+  // button just in time to have the disable yank focus right back off it.
+  // See dateRangeHeadingRef below for the fetch-triggering paths' fix.
   const customToggleRef = useRef(null);
+  // Fetch-triggering closes (fireApply, handleCustomApply, handleReset)
+  // land here instead of customToggleRef - this label is never disabled and
+  // never unmounts, so it can't be raced by the loading state its own click
+  // just triggered the way any of the preset buttons can.
+  const dateRangeHeadingRef = useRef(null);
   const [customStart, setCustomStart] = useState(DATA_START_DATE);
   const [customEnd, setCustomEnd] = useState(todayStr);
 
@@ -144,6 +155,21 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
     const { startDate, endDate } = getDateRange(preset, customStart, customEnd, allTimeStart);
     if (!startDate || !endDate) return;
     setAppliedPreset(preset);
+    // The clicked preset button doesn't unmount here (unlike the custom row),
+    // but disabled={loading} still blurs it to <body> the instant onApply's
+    // fetch flips loading true - see dateRangeHeadingRef's own comment above.
+    //
+    // Unconditional, unlike FilterPanel.js's sibling fix (which only
+    // redirects when focus was already inside the panel) - deliberately so,
+    // to match this file's own existing handleCustomApply/handleReset
+    // convention below, which was already unconditional before this diff.
+    // This file has two independent race sources to dodge (disable-blur
+    // here, custom-row unmount there) rather than FilterPanel's one, so a
+    // single uniform rule stays simpler than tracking prior focus state per
+    // handler. Tradeoff: a pure-mouse click (e.g. Safari's default, where
+    // clicking a <button> doesn't focus it) now plants a focus ring on this
+    // label it wouldn't have shown before.
+    dateRangeHeadingRef.current?.focus();
     onApplyRef.current({ startDate, endDate });
   };
 
@@ -186,7 +212,7 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
     setAppliedCustomStart(startDate);
     setAppliedCustomEnd(endDate);
     setShowCustom(false);
-    customToggleRef.current?.focus();
+    dateRangeHeadingRef.current?.focus();
     onApplyRef.current({ startDate, endDate });
   };
 
@@ -203,9 +229,10 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
     onApplyRef.current({ startDate: allTimeStart, endDate: todayStr() });
     // isDefault flips to true right after this, swapping the just-clicked
     // <button> pill for a plain non-interactive <span> - same "focused
-    // element disappears" gap handleCustomApply already avoids by landing
-    // here too.
-    customToggleRef.current?.focus();
+    // element disappears" gap handleCustomApply avoids, landing on the same
+    // stable target for the same reason (this button is also disabled by
+    // the loading state this fetch triggers).
+    dateRangeHeadingRef.current?.focus();
   };
 
   const isDefault = appliedPreset === 'allTime';
@@ -228,7 +255,22 @@ const DashboardFilterBar = ({ lang = 'en', loading = false, onApply, onInitialLo
       {/* Row 1: date presets */}
       <div className="filter-bar__row">
         <div className="filter-bar__field filter-bar__field--grow">
-          <label className="filter-bar__label">{t('dashboardFilter.dateRange')}</label>
+          {/* <p>, not <label>: nothing below is a labelable form control (these
+              are all <button>s), so there was never a real label/control
+              relationship here - just a heading-style caption reusing
+              .filter-bar__label for its text styling. A <label> also picks
+              up its own WebKit/VoiceOver AXGroup mapping once it doubles as
+              a tabIndex={-1} focus target (confirmed: reads as "Date range,
+              empty group") - <p> carries no such implicit role. Matches the
+              same dedicated-focus-target convention as ChatIdMatchList.js's
+              <p ref={headingRef} tabIndex={-1}>. */}
+          <p
+            ref={dateRangeHeadingRef}
+            tabIndex={-1}
+            className="filter-bar__label focus-target"
+          >
+            {t('dashboardFilter.dateRange')}
+          </p>
           <div className="filter-bar__presets">
             {PRESETS.map(p => (
               <button

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -60,6 +60,19 @@ const FilterPanel = ({
   // does - see the appliedFilters effect below.
   const panelSummaryRef = useRef(null);
   const pendingClearFocusRef = useRef(false);
+  // Captured in handleApply itself, not re-derived later from
+  // document.activeElement: a caller like PartnerDashboard.js ties
+  // applyDisabled to the same loading state Apply triggers, so the Apply
+  // button gets disabled - and the browser blurs a disabled element to
+  // <body> immediately, well before any fetch resolves - before the
+  // auto-close effect below would otherwise get a chance to check who's
+  // focused. This is the last point guaranteed to still see the real
+  // target. Collapsing a native <details> hides everything except its
+  // <summary> - if focus was still on the Apply button (a keyboard/
+  // screen-reader user who just pressed it) that button vanishes from the
+  // accessibility tree, so this drives the same redirect-to-summary fix as
+  // pendingClearFocusRef above.
+  const focusWasInPanelOnApplyRef = useRef(false);
   // Removing a single pill (removeFilter, as opposed to Clear all above) -
   // buildPills() always pushes exactly one entry per category in the same
   // fixed order, so whatever's now at the same array index the clicked pill
@@ -95,16 +108,33 @@ const FilterPanel = ({
       // (hasAppliedFilters stays true throughout), this branch never runs, so
       // their existing skip-then-consume flow below is unaffected.
       skipNextAutoClose.current = false;
+      focusWasInPanelOnApplyRef.current = false;
       return;
     }
     if (filterLoading) return;
     if (skipNextAutoClose.current) {
       skipNextAutoClose.current = false;
+      // Same staleness concern as skipNextAutoClose above: a Clear fired
+      // while an earlier Apply's loading was still in flight shouldn't let
+      // that Apply's armed flag silently redirect focus on some later,
+      // unrelated close.
+      focusWasInPanelOnApplyRef.current = false;
       return;
     }
     if (filterError || filterResultCount === 0) {
+      focusWasInPanelOnApplyRef.current = false;
       setIsOpen(true);
     } else if (filterResultCount > 0) {
+      // panelSummaryRef.current is always mounted (a native <summary> stays
+      // visible whether its <details> is open or closed), so there's no
+      // need to wait for the collapse to actually commit before focusing it
+      // - unlike pendingClearFocusRef's case (Clear reopens the panel, so
+      // the target isn't rendered yet when Clear fires), the redirect
+      // target here already exists at arm time.
+      if (focusWasInPanelOnApplyRef.current) {
+        panelSummaryRef.current?.focus();
+      }
+      focusWasInPanelOnApplyRef.current = false;
       setIsOpen(false);
     }
   }, [hasAppliedFilters, filterLoading, filterError, filterResultCount]);
@@ -729,6 +759,16 @@ const FilterPanel = ({
   ];
 
   const handleApply = () => {
+    // Captured here, synchronously, before anything else runs - see
+    // focusWasInPanelOnApplyRef's own comment above for why this can't be
+    // deferred to the auto-close effect below. .closest('details') rather
+    // than .parentElement: names the actual ancestor relationship this
+    // depends on instead of a one-hop DOM fact that happens to hold today.
+    const activeEl = document.activeElement;
+    const panelEl = panelSummaryRef.current?.closest('details');
+    focusWasInPanelOnApplyRef.current =
+      !!panelEl && !!activeEl && activeEl !== panelSummaryRef.current && panelEl.contains(activeEl);
+
     // Prefer the picker's live state over React state: the picker tracks the
     // user's calendar selection in real-time, so dates are correct even when
     // the user chose a custom range without clicking Apply inside the calendar.

--- a/src/components/admin/__tests__/DashboardFilterBar.test.js
+++ b/src/components/admin/__tests__/DashboardFilterBar.test.js
@@ -9,6 +9,8 @@ const TRANSLATIONS = {
   'dashboardFilter.last30': 'Last 30 days',
   'dashboardFilter.custom': 'Custom',
   'dashboardFilter.removeFilter': 'Remove filter',
+  'dashboardFilter.dateRange': 'Date range',
+  'dashboardFilter.apply': 'Apply',
 };
 const mockT = (key) => TRANSLATIONS[key] || key;
 vi.mock('../../../hooks/useTranslations.js', () => ({
@@ -20,11 +22,13 @@ import DashboardFilterBar from '../DashboardFilterBar.js';
 describe('DashboardFilterBar', () => {
   afterEach(() => cleanup());
 
-  it('moves focus to the Custom preset toggle when the date pill is reset, instead of dropping it to <body>', () => {
+  it('moves focus to the Date range heading when the date pill is reset, instead of dropping it to <body>', () => {
     // Regression test: resetting the date pill (its own × button, handleReset)
     // flips isDefault back to true, swapping the just-clicked <button> for a
-    // plain non-interactive <span> - handleCustomApply already redirects focus
-    // to customToggleRef in the equivalent apply case; handleReset didn't.
+    // plain non-interactive <span>. Lands on the "Date range" label
+    // (dateRangeHeadingRef), not the "Custom" preset toggle - see the second
+    // test below for why the toggle button isn't a safe target for any
+    // fetch-triggering close.
     render(<DashboardFilterBar lang="en" onApply={vi.fn()} />);
 
     // Apply a non-default preset first so the pill renders as a real,
@@ -37,8 +41,57 @@ describe('DashboardFilterBar', () => {
 
     fireEvent.click(removeButton);
 
-    const customToggle = screen.getByText('Custom').closest('button');
-    expect(document.activeElement).toBe(customToggle);
+    expect(document.activeElement).toBe(screen.getByText('Date range'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('moves focus to the Date range heading synchronously on Apply, before the loading state that would otherwise disable and blur the clicked button', () => {
+    // Regression test: fireApply previously had no focus handling at all -
+    // a keyboard/screen-reader user who clicked a preset button relied on
+    // that button staying focused. But every preset button here, including
+    // the one just clicked, carries disabled={loading}, and onApply's fetch
+    // flips loading true in the very same tick the click fires. A real
+    // browser blurs a focused element the instant it's disabled, dropping
+    // focus to <body> with no signal of what happened. The fix redirects
+    // focus synchronously, before onApply is even called - landing on a
+    // target ("Date range") that's never subject to loading at all, not on
+    // a deferred check that would just lose the same race a tick later.
+    const { rerender } = render(<DashboardFilterBar lang="en" loading={false} onApply={vi.fn()} />);
+
+    const last30Button = screen.getByText('Last 30 days').closest('button');
+    last30Button.focus();
+    expect(document.activeElement).toBe(last30Button);
+
+    fireEvent.click(last30Button);
+    expect(document.activeElement).toBe(screen.getByText('Date range'));
+
+    // Confirm the redirect actually holds once loading catches up and
+    // disables the (no-longer-focused) button - not just that it fired.
+    rerender(<DashboardFilterBar lang="en" loading={true} onApply={vi.fn()} />);
+    expect(last30Button.disabled).toBe(true);
+    expect(document.activeElement).toBe(screen.getByText('Date range'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('moves focus to the Date range heading when Apply is clicked inside the expanded custom-date row', () => {
+    // Regression test for handleCustomApply's retarget (customToggleRef ->
+    // dateRangeHeadingRef): the custom row (inputs + this Apply button)
+    // unmounts the instant showCustom flips false, so whatever's clicked
+    // disappears from the DOM - landing on a target outside that row is the
+    // whole point, and nothing asserted which target before this test.
+    const { container } = render(<DashboardFilterBar lang="en" onApply={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Custom'));
+    fireEvent.change(container.querySelector('#dashboard-custom-start'), { target: { value: '2026-01-01' } });
+    fireEvent.change(container.querySelector('#dashboard-custom-end'), { target: { value: '2026-01-31' } });
+
+    const customApplyButton = container.querySelector('.filter-bar__apply');
+    customApplyButton.focus();
+    expect(document.activeElement).toBe(customApplyButton);
+
+    fireEvent.click(customApplyButton);
+
+    expect(document.activeElement).toBe(screen.getByText('Date range'));
     expect(document.activeElement).not.toBe(document.body);
   });
 });

--- a/src/components/admin/__tests__/FilterPanel.test.js
+++ b/src/components/admin/__tests__/FilterPanel.test.js
@@ -438,4 +438,85 @@ describe('FilterPanel', () => {
     expect(document.activeElement).not.toBe(document.body);
     expect(container.querySelector('.filter-bar__pills-row').contains(document.activeElement)).toBe(true);
   });
+
+  it('moves focus to the panel summary when the panel auto-closes after a successful Apply, instead of dropping it to <body>', async () => {
+    // Regression test: a successful Apply flips hasAppliedFilters/filterResultCount
+    // (owned by the parent dashboard), which the auto-close effect consumes to
+    // collapse the panel. Collapsing a native <details> hides everything except
+    // its <summary> - before the fix, a keyboard/screen-reader user who had just
+    // pressed the (now-hidden) Apply button lost focus to <body> with no
+    // indication where it went.
+    //
+    // Mirrors PartnerDashboard.js's real wiring (applyDisabled={loading},
+    // filterLoading={loading} - the same state) rather than jumping straight
+    // to the resolved state: PartnerDashboard's Apply button disables the
+    // instant loading flips true, and a disabled focused button is blurred
+    // to <body> by the browser well before the fetch resolves. A test that
+    // skips this intermediate render never re-creates that blur, so it can't
+    // catch a regression here - see the two rerenders below.
+    const { container, rerender, onApplyFilters, onClearFilters } = renderPanel({
+      hasAppliedFilters: false,
+      filterLoading: false,
+      applyDisabled: false,
+      filterResultCount: null,
+    });
+    await waitFor(() => getDateRangeInput(container));
+
+    const applyButton = container.querySelector('#filter-apply-button');
+    applyButton.focus();
+    expect(document.activeElement).toBe(applyButton);
+
+    fireEvent.click(applyButton);
+    expect(onApplyFilters).toHaveBeenCalled();
+
+    // Real browsers blur a focused element the instant it becomes disabled -
+    // that's the actual mechanism this test exists to guard against, and
+    // exactly what PartnerDashboard's applyDisabled={loading} triggers here.
+    // jsdom doesn't implement that side effect (confirmed: calling .blur()
+    // on an already-disabled element is a no-op in jsdom, unlike real
+    // browsers), so it has to be forced explicitly, while the button is
+    // still enabled, to land on the same end state a real browser would.
+    applyButton.blur();
+    expect(document.activeElement).toBe(document.body);
+
+    // Simulate the loading render frame: PartnerDashboard disables Apply the
+    // instant its fetch starts. The blur above already modelled its effect;
+    // this is the render that must not depend on re-reading
+    // document.activeElement live to decide whether to restore focus later.
+    // hasAppliedFilters flips true in the same batch as filterLoading here -
+    // PartnerDashboard.js's handleApplyFilters calls setHasUserApplied(true)
+    // and fetchMetrics (which sets loading true) together, synchronously -
+    // not after the fetch resolves.
+    rerender(
+      <FilterPanel
+        lang="en"
+        onApplyFilters={onApplyFilters}
+        onClearFilters={onClearFilters}
+        isVisible={true}
+        hasAppliedFilters={true}
+        filterLoading={true}
+        applyDisabled={true}
+        filterResultCount={null}
+      />
+    );
+    expect(applyButton.disabled).toBe(true);
+    expect(document.activeElement).toBe(document.body);
+
+    // Simulate the parent's fetch resolving with results.
+    rerender(
+      <FilterPanel
+        lang="en"
+        onApplyFilters={onApplyFilters}
+        onClearFilters={onClearFilters}
+        isVisible={true}
+        hasAppliedFilters={true}
+        filterLoading={false}
+        applyDisabled={false}
+        filterResultCount={5}
+      />
+    );
+
+    expect(document.activeElement).toBe(container.querySelector('.filter-panel-summary'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
 });


### PR DESCRIPTION
 A successful Apply collapses the filter `<details>` panel. Collapsing a
  native `<details>` hides everything but its `<summary>`, so a keyboard/
  screen-reader user who had focus on the (now-hidden) Apply button was
  silently dropped to `<body>.` Redirect focus to the summary instead,
  matching the existing Clear-all fix's pattern.
  
 DashboardFilterBar.js — (focus the stable "Date range" label instead of chasing a target that keeps getting disabled).
  Applied to all three fetch-triggering handlers (fireApply — previously had no focus handling at all, handleCustomApply, handleReset); the two
  non-fetching closes (Escape, re-click-to-collapse) correctly kept customToggleRef. Added .focus-target so the visible ring shows. One existing
  test updated for the new target, one new test added.