### PR TITLE
refactor: retire .wb-inv in favour of .sr-only/.skip-link

### DIFF
--- a/src/components/chat/ExpertFeedbackComponent.js
+++ b/src/components/chat/ExpertFeedbackComponent.js
@@ -103,7 +103,7 @@ const ExpertFeedbackComponent = ({
   // With only one field in error, its own field name is visually redundant
   // (the message sits right beside the one field it can possibly refer to) —
   // shown only once there's more than one, to disambiguate between them.
-  // Screen reader users still get it either way, via .wb-inv when hidden.
+  // Screen reader users still get it either way, via .sr-only when hidden.
   const showFieldInMessage = visibleExplanationErrors.length > 1;
 
   // Shared label per field key, reused by the per-field error message and
@@ -118,7 +118,7 @@ const ExpertFeedbackComponent = ({
   // without ever hardcoding the surrounding punctuation ourselves (the
   // colon/spacing stays entirely inside the locale string, correct per
   // language either way). With exactly 1 error, the plain sentence is used
-  // and the field name still appended for screen readers only (.wb-inv) —
+  // and the field name still appended for screen readers only (.sr-only) —
   // never omitted, just not visibly duplicated next to its own field.
   const explanationErrorMessage = (key) => {
     const fieldLabel = explanationFieldLabel(key);
@@ -129,7 +129,7 @@ const ExpertFeedbackComponent = ({
     return (
       <>
         {t('homepage.expertRating.explanationRequired')}
-        <span className="wb-inv"> {fieldLabel}</span>
+        <span className="sr-only"> {fieldLabel}</span>
       </>
     );
   };

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -297,7 +297,7 @@ const FeedbackComponent = ({
         {showSkipButton && (
           <>
             <a
-              className="wb-inv"
+              className="sr-only skip-link"
               href={`#${skipToId}`}
               onClick={onSkip}
               aria-label={skipButtonLabel}
@@ -358,7 +358,7 @@ const FeedbackComponent = ({
         <>
           <span className="feedback-separator"></span>
           <a
-            className="wb-inv"
+            className="sr-only skip-link"
             href={`#${skipToId}`}
             onClick={onSkip}
             aria-label={skipButtonLabel}

--- a/src/components/chat/__tests__/ExpertFeedbackComponent.test.js
+++ b/src/components/chat/__tests__/ExpertFeedbackComponent.test.js
@@ -132,11 +132,11 @@ describe('ExpertFeedbackComponent — explanation required on non-good ratings',
     submit();
 
     // With 2 errors, the field name is shown plainly (not wrapped in the
-    // screen-reader-only .wb-inv span used for the single-error case).
+    // screen-reader-only .sr-only span used for the single-error case).
     const errorMessages = document.querySelectorAll('.form-error-message');
     expect(errorMessages).toHaveLength(2);
     errorMessages.forEach((el) => {
-      expect(el.querySelector('.wb-inv')).toBeNull();
+      expect(el.querySelector('.sr-only')).toBeNull();
       expect(el.textContent).toContain('homepage.expertRating.sentence');
     });
 
@@ -185,8 +185,8 @@ describe('ExpertFeedbackComponent — explanation required on non-good ratings',
     submit();
 
     const errorMessage = document.querySelector('.form-error-message');
-    expect(errorMessage.querySelector('.wb-inv')).toBeTruthy();
-    expect(errorMessage.querySelector('.wb-inv').textContent.trim()).toBe('homepage.expertRating.sentence1');
+    expect(errorMessage.querySelector('.sr-only')).toBeTruthy();
+    expect(errorMessage.querySelector('.sr-only').textContent.trim()).toBe('homepage.expertRating.sentence1');
     expect(document.querySelector('.explanation-error-summary')).toBeNull();
   });
 });

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -151,7 +151,7 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
             language: dataTableLanguage(lang)
           }}
         >
-          <caption className="wb-inv">{t('metrics.dashboard.userScored.title')}</caption>
+          <caption className="sr-only">{t('metrics.dashboard.userScored.title')}</caption>
         </DataTable>
         {/* One row per distinct feedback reason — a set that grows over
             time, same shape as MetricsDashboard.js's Institution breakdown
@@ -198,7 +198,7 @@ const EndUserFeedbackSection = ({ t, metrics, lang = 'en' }) => {
               language: dataTableLanguage(lang)
             }}
           >
-            <caption className="wb-inv">{t('metrics.dashboard.userScored.reasonTableTitle')}</caption>
+            <caption className="sr-only">{t('metrics.dashboard.userScored.reasonTableTitle')}</caption>
           </DataTable>
           </div>
         </div>

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -120,7 +120,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
   // reasoning as EvalDashboardPage.js's own icon cells: title's hover
   // delay is fixed by the browser and can't be shortened, this CSS
   // mechanism controls it. Accessible name for the icon+"AI text" pair
-  // comes from the sibling .wb-inv span carrying the fuller explanation,
+  // comes from the sibling .sr-only span carrying the fuller explanation,
   // not aria-label, matching that same established pattern - the icon and
   // the visible "AI text" label both stay aria-hidden so a screen
   // reader gets the one, fuller phrase instead of "AI text" followed
@@ -151,7 +151,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       `<span class="filter-pill eval-tooltip" data-tooltip="${fullLabel}" style="position: absolute; bottom: 0.5em; left: 0;">` +
       `<i class="fa-solid fa-language" style="font-size: 1.3em;" aria-hidden="true"></i>` +
       `<span aria-hidden="true">${shortLabel}</span>` +
-      `<span class="wb-inv">${fullLabel}</span>` +
+      `<span class="sr-only">${fullLabel}</span>` +
       `</span>`;
   }, [t]);
 

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -307,7 +307,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
       title: t('admin.evalDashboard.columns.feedback'), data: 'feedback', width: '60px', render: v => {
         // Icon + hidden text, same tight pattern as the Download column
         // below (FA icon since GC DS has no thumbs glyph, aria-hidden, real
-        // meaning carried in wb-inv text) instead of a spelled-out pill -
+        // meaning carried in sr-only text) instead of a spelled-out pill -
         // keeps this column narrow. Coloured with --gcds-border-default -
         // the same grey the row/cell dividers use (see .group-cell's
         // border-right and the other border rules above) - rather than
@@ -316,17 +316,17 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         // not a pass/fail outcome like Download's states.
         //
         // data-tooltip (+ .eval-tooltip's CSS, see admin.css) gives sighted
-        // mouse users a hover tooltip with the same text the wb-inv span
+        // mouse users a hover tooltip with the same text the sr-only span
         // already gives screen-reader users - a custom CSS tooltip rather
         // than the native title attribute so the appear delay is ours to
         // set (0.5s - native title's delay is fixed by the browser, not
         // controllable). Safe to add now specifically because the icon
         // stays aria-hidden: an arbitrary data-* attribute on an
         // aria-hidden element isn't exposed to the accessibility tree
-        // either, so it can't compete with/double up on the wb-inv
+        // either, so it can't compete with/double up on the sr-only
         // announcement. Two channels, one source of truth each.
-        if (v === 'yes') return `<i class="fa-solid fa-thumbs-up eval-tooltip" style="font-size: 1.2em; color: var(--gcds-border-default);" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.helpfulYes'))}"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.helpfulYes'))}</span>`;
-        if (v === 'no') return `<i class="fa-solid fa-thumbs-down eval-tooltip" style="font-size: 1.2em; color: var(--gcds-border-default);" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.helpfulNo'))}"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.helpfulNo'))}</span>`;
+        if (v === 'yes') return `<i class="fa-solid fa-thumbs-up eval-tooltip" style="font-size: 1.2em; color: var(--gcds-border-default);" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.helpfulYes'))}"></i><span class="sr-only">${escapeHtmlAttribute(t('reviewPanels.helpfulYes'))}</span>`;
+        if (v === 'no') return `<i class="fa-solid fa-thumbs-down eval-tooltip" style="font-size: 1.2em; color: var(--gcds-border-default);" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.helpfulNo'))}"></i><span class="sr-only">${escapeHtmlAttribute(t('reviewPanels.helpfulNo'))}</span>`;
         return '';
       }, searchable: false, orderable: true
     },
@@ -343,17 +343,17 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
         // data-tooltip (custom CSS tooltip, see the matching comment on the
         // Feedback column above for why not the native title attribute)
         // gives sighted mouse users a hover tooltip with the same text the
-        // wb-inv span gives screen-reader users.
+        // sr-only span gives screen-reader users.
         if (v === 'success') {
-          return `<span class="text-status--positive"><i class="fa-solid fa-check eval-tooltip" style="font-size: 1.4em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}</span></span>`;
+          return `<span class="text-status--positive"><i class="fa-solid fa-check eval-tooltip" style="font-size: 1.4em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}"></i><span class="sr-only">${escapeHtmlAttribute(t('reviewPanels.downloadSuccess'))}</span></span>`;
         }
         if (v === 'partial') {
           // Smaller than the other two icons - a filled circle shape reads
           // visually larger than the check/x glyphs at the same font-size.
-          return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke eval-tooltip" style="font-size: 1.2em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
+          return `<span class="text-status--warning"><i class="fa-solid fa-circle-half-stroke eval-tooltip" style="font-size: 1.2em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}"></i><span class="sr-only">${escapeHtmlAttribute(t('reviewPanels.downloadPartial'))}</span></span>`;
         }
         if (v === 'failed') {
-          return `<span class="text-status--negative"><i class="fa-solid fa-xmark eval-tooltip" style="font-size: 1.4em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.fail'))}"></i><span class="wb-inv">${escapeHtmlAttribute(t('reviewPanels.fail'))}</span></span>`;
+          return `<span class="text-status--negative"><i class="fa-solid fa-xmark eval-tooltip" style="font-size: 1.4em;" aria-hidden="true" data-tooltip="${escapeHtmlAttribute(t('reviewPanels.fail'))}"></i><span class="sr-only">${escapeHtmlAttribute(t('reviewPanels.fail'))}</span></span>`;
         }
         return '';
       },

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -483,6 +483,38 @@
   color: #555;
   margin: 0 0.2rem;
 }
+
+/* FeedbackComponent.js's skip-past-the-rating-buttons link - applied
+   alongside .sr-only (global.css) for the hidden baseline, since only the
+   focus-reveal state below is actually specific to this link. */
+/* No font-size of its own on purpose: inherits the ambient 20px body-text
+   size rather than matching .feedback-link's 18px beside it - tried
+   matching, reverted after confirming the larger size reads more legibly
+   once revealed. Don't "fix" this mismatch without checking again. */
+.skip-link:focus,
+.skip-link:active {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  background-color: var(--gcds-link-focus-background);
+  color: var(--gcds-link-focus-text);
+  border-radius: var(--gcds-link-focus-border-radius);
+  box-shadow: var(--gcds-link-focus-box-shadow);
+  outline: var(--gcds-link-focus-outline-width) solid
+    var(--gcds-link-focus-background);
+  outline-offset: var(--gcds-link-focus-outline-offset);
+  text-decoration: none;
+  padding: 10px;
+  display: inline-block;
+  z-index: 9999;
+  transition: none;
+  animation: none;
+}
+
 .button-as-link {
   background: none;
   border: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -132,44 +132,6 @@ code {
     monospace;
 }
 
-.wb-inv {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-  white-space: nowrap;
-  font-size: 1em;
-}
-
-/* When focused, make it visible for keyboard users */
-.wb-inv:focus,
-.wb-inv:active {
-  position: static;
-  width: auto;
-  height: auto;
-  margin: 0;
-  overflow: visible;
-  clip: auto;
-  white-space: normal;
-  background-color: var(--gcds-link-focus-background);
-  color: var(--gcds-link-focus-text);
-  border-radius: var(--gcds-link-focus-border-radius);
-  box-shadow: var(--gcds-link-focus-box-shadow);
-  outline: var(--gcds-link-focus-outline-width) solid
-    var(--gcds-link-focus-background);
-  outline-offset: var(--gcds-link-focus-outline-offset);
-  text-decoration: none;
-  padding: 10px;
-  display: inline-block;
-  z-index: 9999;
-  transition: none;
-  animation: none;
-}
-
 /* modifications of GCDS-tokens to Canada.ca design where appropriate */
 :root {
   --gcds-header-margin: 0 0 1.55rem !important;


### PR DESCRIPTION
Consolidates two visually-hidden-text utilities that did the same job.
  The plain-hidden uses (EndUserFeedbackSection, ExpertFeedbackComponent, EvalDashboardPage, ChatDashboardPage) move to the existing .sr-only. The one case that needs its own focus-reveal behaviour — FeedbackComponent's skip-past-the-rating-buttons link — is renamed to .skip-link, applied alongside .sr-only for the hidden baseline, and moved to chat.css since it's chat-only rather than a site-wide utility.