### PR TITLE
fix: remove redundant title attrs from auth form inputs

### DIFF
--- a/src/components/auth/PasswordInput.js
+++ b/src/components/auth/PasswordInput.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import { useTranslations } from '../../hooks/useTranslations.js';
 
-const PasswordInput = ({ id, name, label, value, onChange, title, required, disabled, autoComplete, ariaDescribedBy, ariaInvalid, lang = 'en' }) => {
+const PasswordInput = ({ id, name, label, value, onChange, required, disabled, autoComplete, ariaDescribedBy, ariaInvalid, lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -15,7 +15,6 @@ const PasswordInput = ({ id, name, label, value, onChange, title, required, disa
           id={id}
           name={name}
           value={value}
-          title={title}
           onChange={onChange}
           required={required}
           disabled={disabled}

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -215,7 +215,6 @@ const LoginPage = ({ lang = 'en' }) => {
                 type="email"
                 id="email"
                 value={email}
-                title={t('login.email')}
                 autoComplete="email"
                 onChange={(e) => setEmail(e.target.value)}
                 required
@@ -228,7 +227,6 @@ const LoginPage = ({ lang = 'en' }) => {
               id="password"
               label={t('login.password')}
               value={password}
-              title={t('login.password')}
               onChange={(e) => setPassword(e.target.value)}
               required
               disabled={isLoading}

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -85,7 +85,6 @@ const RegisterPage = ({ lang = 'en' }) => {
               type="email"
               id="email"
               value={email}
-              title={t('signup.email')}
               autoComplete="email"
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -99,7 +98,6 @@ const RegisterPage = ({ lang = 'en' }) => {
             name="password"
             label={t('signup.password')}
             value={password}
-            title={t('signup.password')}
             onChange={(e) => setPassword(e.target.value)}
             required
             disabled={isLoading}
@@ -113,7 +111,6 @@ const RegisterPage = ({ lang = 'en' }) => {
             name="confirmPassword"
             label={t('signup.confirmPassword')}
             value={confirmPassword}
-            title={t('signup.confirmPassword')}
             onChange={(e) => setConfirmPassword(e.target.value)}
             required
             disabled={isLoading}

--- a/src/pages/ResetRequestPage.js
+++ b/src/pages/ResetRequestPage.js
@@ -51,7 +51,6 @@ const ResetRequestPage = ({ lang = 'en' }) => {
               id="email"
               type="email"
               value={email}
-              title={t('login.email')}
               autoComplete="email"
               onChange={(e) => setEmail(e.target.value)}
               required


### PR DESCRIPTION
title duplicated the adjacent <label> text, so screen readers
  announced the name twice ("Email, edit text, Email"). Removed from
  LoginPage, RegisterPage, ResetRequestPage, and PasswordInput.

  Added in aeb576f8 as an attempted EN/FR fix, but title has no effect
  on that mechanism. The real bugs were fixed separately in 651f209f,
  dc4da515, and #1765 — this is just leftover cleanup.