### PR TITLE
fix: remove dead t() fallback strings

### DIFF
--- a/src/components/admin/AdminNotifications.js
+++ b/src/components/admin/AdminNotifications.js
@@ -54,7 +54,7 @@ const AdminNotifications = ({ lang = 'en' }) => {
         // docs/coding-agent-docs/status-and-error-messaging.md.
         <section
             className={`admin-notifications${hasNotifications ? ' mb-400' : ' admin-notifications--empty'}`}
-            aria-label={t('admin.notifications.ariaLabel', 'User notifications')}
+            aria-label={t('admin.notifications.ariaLabel')}
             role="status"
             aria-live="polite"
         >
@@ -63,7 +63,7 @@ const AdminNotifications = ({ lang = 'en' }) => {
                     <div className="admin-notifications-heading">
                         <span className="gcds-icon fa fa-solid fa-exclamation-circle admin-notifications-icon" aria-hidden="true"></span>
                         <h2 className="admin-notifications-title">
-                            {t('admin.notifications.title', 'User notifications')}
+                            {t('admin.notifications.title')}
                         </h2>
                     </div>
                     {/* role="list": Safari/VoiceOver computes the list/listitem
@@ -75,7 +75,7 @@ const AdminNotifications = ({ lang = 'en' }) => {
                             <li className="admin-notifications-item admin-notifications-item--warning">
                                 <span className="admin-notifications-count">{stats.newInactiveCount}</span>
                                 <span className="admin-notifications-label font-size-text-sm-nr">
-                                    {t('admin.notifications.newInactive', 'new user(s) awaiting activation (last 7 days)')}
+                                    {t('admin.notifications.newInactive')}
                                 </span>
                             </li>
                         )}
@@ -83,7 +83,7 @@ const AdminNotifications = ({ lang = 'en' }) => {
                             <li className="admin-notifications-item">
                                 <span className="admin-notifications-count">{stats.totalInactiveCount}</span>
                                 <span className="admin-notifications-label font-size-text-sm-nr">
-                                    {t('admin.notifications.totalInactive', 'total inactive user(s)')}
+                                    {t('admin.notifications.totalInactive')}
                                 </span>
                             </li>
                         )}
@@ -103,7 +103,7 @@ const AdminNotifications = ({ lang = 'en' }) => {
                           no filter type, no date-range/"last 7 days" concept.
                           Would need a new column filter built there first. */}
                     <GcdsLink href={getPath('users', lang)} className="admin-notifications-action font-size-text-sm-nr">
-                        {t('admin.notifications.viewUsers', 'View and manage users')}
+                        {t('admin.notifications.viewUsers')}
                     </GcdsLink>
                 </div>
             )}

--- a/src/components/admin/FilterPanel.js
+++ b/src/components/admin/FilterPanel.js
@@ -703,16 +703,16 @@ const FilterPanel = ({
 
   // Department options — partner list is shared across the app
   const departmentOptions = [
-    { value: '', label: t('admin.filters.allDepartments') || 'All Departments' },
+    { value: '', label: t('admin.filters.allDepartments') },
     ...PARTNER_DEPARTMENTS.map(d => ({ value: d, label: d })),
   ];
 
   // User type options
   const userTypeOptions = [
-    { value: 'all', label: t('admin.filters.allUsers') || 'All Users' },
-    { value: 'public', label: t('admin.filters.publicUsers') || 'Public Users' },
-    { value: 'referredPublic', label: t('admin.filters.referredPublicUsers') || 'Public Referred' },
-    { value: 'admin', label: t('admin.filters.adminUsers') || 'Admin Users' }
+    { value: 'all', label: t('admin.filters.allUsers') },
+    { value: 'public', label: t('admin.filters.publicUsers') },
+    { value: 'referredPublic', label: t('admin.filters.referredPublicUsers') },
+    { value: 'admin', label: t('admin.filters.adminUsers') }
   ];
 
   // Answer type options
@@ -1078,7 +1078,7 @@ const FilterPanel = ({
         <div className="filter-main-row">
           <div className="filter-row">
             <label htmlFor="dateRangePicker" className="filter-label">
-              {t('admin.filters.dateRange') || 'Date Range'}
+              {t('admin.filters.dateRange')}
             </label>
             <input
               ref={dateRangePickerRef}
@@ -1094,7 +1094,7 @@ const FilterPanel = ({
 
           <div className="filter-row">
             <label htmlFor="department" className="filter-label">
-              {t('admin.filters.department') || 'Department'}
+              {t('admin.filters.department')}
             </label>
             <select
               id="department"
@@ -1112,7 +1112,7 @@ const FilterPanel = ({
 
           <div className="filter-row">
             <label htmlFor="user-type" className="filter-label">
-              {t('admin.filters.users') || 'User Type'}
+              {t('admin.filters.users')}
             </label>
             <select
               id="user-type"
@@ -1146,27 +1146,27 @@ const FilterPanel = ({
             <div className="filter-column">
               <div className="filter-row">
                 <label htmlFor="url-en" className="filter-label">
-                  {t('admin.filters.urlEn') || 'URL (EN)'}
+                  {t('admin.filters.urlEn')}
                 </label>
                 <input
                   type="text"
                   id="url-en"
                   value={urlEn}
                   onChange={(e) => setUrlEn(e.target.value)}
-                  placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
+                  placeholder={t('admin.filters.urlPlaceholder')}
                   className="filter-input"
                 />
               </div>
               <div className="filter-row">
                 <label htmlFor="url-fr" className="filter-label">
-                  {t('admin.filters.urlFr') || 'URL (FR)'}
+                  {t('admin.filters.urlFr')}
                 </label>
                 <input
                   type="text"
                   id="url-fr"
                   value={urlFr}
                   onChange={(e) => setUrlFr(e.target.value)}
-                  placeholder={t('admin.filters.urlPlaceholder') || 'Filter by partial URL'}
+                  placeholder={t('admin.filters.urlPlaceholder')}
                   className="filter-input"
                 />
               </div>
@@ -1195,7 +1195,7 @@ const FilterPanel = ({
             <>
             <details className="filter-checkbox-details details-form" open onToggle={(e) => e.stopPropagation()}>
               <summary className="filter-label">
-                {t('admin.filters.answerType') || 'Answer Type'}
+                {t('admin.filters.answerType')}
                 {answerType.length > 0 && (
                   <>
                     <span className="filter-count" aria-hidden="true"> ({answerType.length})</span>
@@ -1206,7 +1206,7 @@ const FilterPanel = ({
               <fieldset className="gc-chckbxrdio sm filter-checkbox-group" aria-label={t('admin.filters.answerType')}>
                 <div className="checkbox">
                   <input type="checkbox" id="answerType-all" checked={answerType.length === 0} onChange={(e) => handleAnswerTypeAll(e.target.checked)} />
-                  <label htmlFor="answerType-all">{t('admin.filters.allAnswerTypes') || 'All'}</label>
+                  <label htmlFor="answerType-all">{t('admin.filters.allAnswerTypes')}</label>
                 </div>
                 {answerTypeOptions.filter(o => o.value !== 'all').map(option => (
                   <div className="checkbox" key={option.value}>
@@ -1224,7 +1224,7 @@ const FilterPanel = ({
               <div className="filter-eval-pair">
                 <details className="filter-checkbox-details details-form filter-eval-box" open onToggle={(e) => e.stopPropagation()}>
                   <summary className="filter-label">
-                    {t('admin.filters.partnerEval') || 'Partner Evaluation'}
+                    {t('admin.filters.partnerEval')}
                     {partnerEval.length > 0 && (
                   <>
                     <span className="filter-count" aria-hidden="true"> ({partnerEval.length})</span>
@@ -1235,7 +1235,7 @@ const FilterPanel = ({
                   <fieldset className="gc-chckbxrdio sm filter-checkbox-group" aria-label={t('admin.filters.partnerEval')}>
                     <div className="checkbox">
                       <input type="checkbox" id="partnerEval-all" checked={partnerEval.length === 0} onChange={(e) => handlePartnerEvalAll(e.target.checked)} />
-                      <label htmlFor="partnerEval-all">{t('admin.filters.allPartnerEvals') || 'All'}</label>
+                      <label htmlFor="partnerEval-all">{t('admin.filters.allPartnerEvals')}</label>
                     </div>
                     {partnerEvalOptions.filter(o => o.value !== 'all').map(option => (
                       <div className="checkbox" key={option.value}>
@@ -1248,7 +1248,7 @@ const FilterPanel = ({
 
                 <details className="filter-checkbox-details details-form filter-eval-box" open onToggle={(e) => e.stopPropagation()}>
                   <summary className="filter-label">
-                    {t('admin.filters.aiEval') || 'AI Evaluation'}
+                    {t('admin.filters.aiEval')}
                     {aiEval.length > 0 && (
                   <>
                     <span className="filter-count" aria-hidden="true"> ({aiEval.length})</span>
@@ -1259,7 +1259,7 @@ const FilterPanel = ({
                   <fieldset className="gc-chckbxrdio sm filter-checkbox-group" aria-label={t('admin.filters.aiEval')}>
                     <div className="checkbox">
                       <input type="checkbox" id="aiEval-all" checked={aiEval.length === 0} onChange={(e) => handleAiEvalAll(e.target.checked)} />
-                      <label htmlFor="aiEval-all">{t('admin.filters.allAiEvals') || 'All'}</label>
+                      <label htmlFor="aiEval-all">{t('admin.filters.allAiEvals')}</label>
                     </div>
                     {aiEvalOptions.filter(o => o.value !== 'all').map(option => (
                       <div className="checkbox" key={option.value}>

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -279,9 +279,9 @@ const FeedbackComponent = ({
             className="feedback-link button-as-link link-default hover:link-hover feedback-icon-up"
             onClick={() => handleFeedback(true)}
             tabIndex="0"
-            aria-label={`${t("homepage.publicFeedback.question")} ${t("common.yes", "Yes")}`}
+            aria-label={`${t("homepage.publicFeedback.question")} ${t("common.yes")}`}
           >
-            {t("common.yes", "Yes")}
+            {t("common.yes")}
           </button>
           <span className="feedback-separator">·</span>
           <button
@@ -289,9 +289,9 @@ const FeedbackComponent = ({
             className="feedback-link button-as-link link-default hover:link-hover feedback-icon-down"
             onClick={() => handleFeedback(false)}
             tabIndex="0"
-            aria-label={`${t("homepage.publicFeedback.question")} ${t("common.no", "No")}`}
+            aria-label={`${t("homepage.publicFeedback.question")} ${t("common.no")}`}
           >
-            {t("common.no", "No")}
+            {t("common.no")}
           </button>
         </span>
         {showSkipButton && (

--- a/src/components/chat/review/DownloadPanel.js
+++ b/src/components/chat/review/DownloadPanel.js
@@ -43,7 +43,7 @@ const DownloadPanel = ({ message, t, lang = 'en', answerNumber }) => {
         partial: t('reviewPanels.downloadPartial'),
         failed: t('reviewPanels.fail')
     }[downloadStatus];
-    const title = withAnswerNumber(t('reviewPanels.downloadedPagesTitle') || 'Downloaded pages');
+    const title = withAnswerNumber(t('reviewPanels.downloadedPagesTitle'));
 
     return (
         <details className="review-details">

--- a/src/components/metrics/EndUserFeedbackSection.js
+++ b/src/components/metrics/EndUserFeedbackSection.js
@@ -33,8 +33,8 @@ const getReasonLabel = (scoreKey, t, isPositive) => {
   if (!id) return scoreKey;
   if (id === 'other') {
     return isPositive
-      ? t('metrics.dashboard.userScored.otherYes', 'Other (yes)')
-      : t('metrics.dashboard.userScored.otherNo', 'Other (no)');
+      ? t('metrics.dashboard.userScored.otherYes')
+      : t('metrics.dashboard.userScored.otherNo');
   }
   const translationKey = isPositive
     ? `homepage.publicFeedback.yes.options.${id}`

--- a/src/pages/AdminPage.js
+++ b/src/pages/AdminPage.js
@@ -41,7 +41,7 @@ const AdminPage = ({ lang = 'en' }) => {
         <AdminNotifications lang={lang} />
       </RoleBasedContent>
 
-      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', isPartner ? 'Partner Navigation' : 'Admin Navigation')}>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
 
         {/* Partner Menu - Visible to everyone (Partner & Admin) */}
         <section className="mb-400">

--- a/src/pages/AutoEvalDashboardPage.js
+++ b/src/pages/AutoEvalDashboardPage.js
@@ -106,7 +106,7 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
   // Columns: Chat ID, #, Department, AI eval, Partner eval, Processed, Matches, Fallback, No-match reason, Date
   const columns = useMemo(() => ([
     {
-      title: t('admin.autoEvalDashboard.columns.chatId', 'Chat ID'),
+      title: t('admin.autoEvalDashboard.columns.chatId'),
       data: 'chatId',
       // Fixed width; the UUID wraps onto two lines (see .col-chat-id in admin.css).
       width: '150px',
@@ -149,21 +149,21 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
         { active: row && row.partnerHasContentIssue, className: 'hasContentIssue', labelKey: 'admin.chatDashboard.labels.contentIssue' }
       ]), searchable: true, orderable: true
     },
-    { title: t('admin.autoEvalDashboard.columns.processed', 'Processed'), data: 'processed', render: v => v ? t('common.yes', 'Yes') : t('common.no', 'No'), searchable: true, orderable: false },
-    { title: t('admin.autoEvalDashboard.columns.matches', 'Has matches'), data: 'hasMatches', render: v => v ? t('common.yes', 'Yes') : t('common.no', 'No'), searchable: true, orderable: false },
+    { title: t('admin.autoEvalDashboard.columns.processed'), data: 'processed', render: v => v ? t('common.yes') : t('common.no'), searchable: true, orderable: false },
+    { title: t('admin.autoEvalDashboard.columns.matches'), data: 'hasMatches', render: v => v ? t('common.yes') : t('common.no'), searchable: true, orderable: false },
     // TODO: fallbackType is a raw internal code shown untranslated (only value
     // today: 'qa-high-score' - the evaluation was inherited from a similar
     // past expert-scored Q&A, see services/evaluation.worker.js). Map it
     // through t() like noMatchReasonType does with eval.noMatchReasonTypes.*,
     // and switch its filter to the Yes/No/Any select since there is one value.
-    { title: t('admin.autoEvalDashboard.columns.fallback', 'Fallback'), data: 'fallbackType', className: 'col-nowrap', searchable: true, orderable: true },
-    { title: t('admin.autoEvalDashboard.columns.reason', 'No-match reason'), data: 'noMatchReasonType', render: (v) => v ? t(`eval.noMatchReasonTypes.${v}`, v) : '', searchable: true, orderable: true },
-    { title: t('admin.autoEvalDashboard.columns.date', 'Date'), data: 'date', render: (v) => renderDateTimeCell(v, lang), searchable: true, orderable: true }
+    { title: t('admin.autoEvalDashboard.columns.fallback'), data: 'fallbackType', className: 'col-nowrap', searchable: true, orderable: true },
+    { title: t('admin.autoEvalDashboard.columns.reason'), data: 'noMatchReasonType', render: (v) => v ? t(`eval.noMatchReasonTypes.${v}`, v) : '', searchable: true, orderable: true },
+    { title: t('admin.autoEvalDashboard.columns.date'), data: 'date', render: (v) => renderDateTimeCell(v, lang), searchable: true, orderable: true }
   ]), [t, lang]);
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('admin.autoEvalDashboard.title', 'Auto-Evaluation dashboard')}</h1>
+      <h1 className="mb-400">{t('admin.autoEvalDashboard.title')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
@@ -230,7 +230,7 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
                 },
                 infoCallback: function (_settings, start, end, _max, _total, _pre) {
                   const pageNumber = Math.floor(Math.max(Number(start) - 1, 0) / Math.max(end - start, 1)) + 1;
-                  return `${t('common.page', 'Page')} ${pageNumber}`;
+                  return `${t('common.page')} ${pageNumber}`;
                 },
                 language: dataTableLanguage(lang),
                 // Striping and keep-chat-together cells - see
@@ -294,9 +294,9 @@ const AutoEvalDashboardPage = ({ lang = 'en' }) => {
                         const sel = document.createElement('select');
                         sel.className = 'dt-col-search';
                         sel.setAttribute('aria-label', `${t('admin.common.filterPlaceholder')} — ${colTitle}`);
-                        const optAny = document.createElement('option'); optAny.value = ''; optAny.textContent = t('admin.autoEvalDashboard.columns.any', 'Any'); sel.appendChild(optAny);
-                        const optYes = document.createElement('option'); optYes.value = 'true'; optYes.textContent = t('common.yes', 'Yes'); sel.appendChild(optYes);
-                        const optNo = document.createElement('option'); optNo.value = 'false'; optNo.textContent = t('common.no', 'No'); sel.appendChild(optNo);
+                        const optAny = document.createElement('option'); optAny.value = ''; optAny.textContent = t('admin.autoEvalDashboard.columns.any'); sel.appendChild(optAny);
+                        const optYes = document.createElement('option'); optYes.value = 'true'; optYes.textContent = t('common.yes'); sel.appendChild(optYes);
+                        const optNo = document.createElement('option'); optNo.value = 'false'; optNo.textContent = t('common.no'); sel.appendChild(optNo);
                         sel.addEventListener('change', function () {
                           markActive(sel);
                           column.search(this.value);

--- a/src/pages/ChatDashboardPage.js
+++ b/src/pages/ChatDashboardPage.js
@@ -259,7 +259,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       }
     },
     {
-      title: t('admin.chatDashboard.columns.question', 'Question'),
+      title: t('admin.chatDashboard.columns.question'),
       data: 'redactedQuestion',
       searchable: false,
       orderable: false,
@@ -273,7 +273,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       createdCell: (td) => { td.style.position = 'relative'; }
     },
     {
-      title: t('admin.chatDashboard.columns.answer', 'Answer'),
+      title: t('admin.chatDashboard.columns.answer'),
       data: 'answerContent',
       searchable: false,
       orderable: false,
@@ -281,7 +281,7 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
       createdCell: (td) => { td.style.position = 'relative'; }
     },
     {
-      title: t('admin.chatDashboard.columns.citationUrl', 'Citation link'),
+      title: t('admin.chatDashboard.columns.citationUrl'),
       data: 'citationUrl',
       // Capped so Question/Answer (no fixed width - they auto-fill
       // remaining space) don't get squeezed by this column growing to fit
@@ -331,9 +331,9 @@ const ChatDashboardPage = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('admin.chatDashboard.title', 'Chat dashboard')}</h1>
+      <h1 className="mb-400">{t('admin.chatDashboard.title')}</h1>
 
-      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
           <GcdsLink href={`/${lang}/admin`}>
             {t('common.backToAdmin')}

--- a/src/pages/ConnectivityPage.js
+++ b/src/pages/ConnectivityPage.js
@@ -165,7 +165,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
     return (
         <GcdsContainer layout="page" className="mb-600">
             <h1 className="mb-400">
-                {t('connectivity.title', 'Service Connectivity Dashboard')}
+                {t('connectivity.title')}
             </h1>
 
             <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
@@ -175,8 +175,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
             </nav>
 
             <GcdsText className="mb-400">
-                {t('connectivity.description',
-                    'Test connectivity to all external services and AI providers used by AI Answers.')}
+                {t('connectivity.description')}
             </GcdsText>
 
             <div className="mb-400">
@@ -185,8 +184,8 @@ const ConnectivityPage = ({ lang = 'en' }) => {
                     disabled={loading}
                 >
                     {loading
-                        ? t('connectivity.testing', 'Testing connections...')
-                        : t('connectivity.runTests', 'Run Connectivity Tests')}
+                        ? t('connectivity.testing')
+                        : t('connectivity.runTests')}
                 </GcdsButton>
             </div>
 
@@ -244,7 +243,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
                                 {results.summary.connected}
                             </div>
                             <div style={{ color: '#666' }}>
-                                {t('connectivity.connected', 'Connected')}
+                                {t('connectivity.connected')}
                             </div>
                         </div>
                         <div style={{ textAlign: 'center' }}>
@@ -252,7 +251,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
                                 {results.summary.errors}
                             </div>
                             <div style={{ color: '#666' }}>
-                                {t('connectivity.errors', 'Errors')}
+                                {t('connectivity.errors')}
                             </div>
                         </div>
                         <div style={{ textAlign: 'center' }}>
@@ -260,7 +259,7 @@ const ConnectivityPage = ({ lang = 'en' }) => {
                                 {results.summary.warnings}
                             </div>
                             <div style={{ color: '#666' }}>
-                                {t('connectivity.warnings', 'Warnings')}
+                                {t('connectivity.warnings')}
                             </div>
                         </div>
                         <div style={{ textAlign: 'center' }}>
@@ -268,16 +267,16 @@ const ConnectivityPage = ({ lang = 'en' }) => {
                                 {results.summary.notConfigured}
                             </div>
                             <div style={{ color: '#666' }}>
-                                {t('connectivity.notConfigured', 'Not Configured')}
+                                {t('connectivity.notConfigured')}
                             </div>
                         </div>
                     </div>
 
                     <p style={{ color: '#888', fontSize: '0.875rem', marginBottom: '16px' }}>
-                        {t('connectivity.lastRun', 'Last run')}: {new Date(results.timestamp).toLocaleString()}
+                        {t('connectivity.lastRun')}: {new Date(results.timestamp).toLocaleString()}
                     </p>
 
-                    <h2 className="mb-300">{t('connectivity.serviceDetails', 'Service Details')}</h2>
+                    <h2 className="mb-300">{t('connectivity.serviceDetails')}</h2>
 
                     {results.services.map((service, index) => (
                         <ServiceCard key={index} service={service} t={t} />

--- a/src/pages/EvalDashboardPage.js
+++ b/src/pages/EvalDashboardPage.js
@@ -380,7 +380,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('admin.evalDashboard.title', 'Evaluation dashboard')}</h1>
+      <h1 className="mb-400">{t('admin.evalDashboard.title')}</h1>
 
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
@@ -539,7 +539,7 @@ const EvalDashboardPage = ({ lang = 'en' }) => {
                 },
                 infoCallback: function (_settings, start, end, _max, _total, _pre) {
                   const pageNumber = Math.floor(Math.max(Number(start) - 1, 0) / Math.max(end - start, 1)) + 1;
-                  return `${t('common.page', 'Page')} ${pageNumber}`;
+                  return `${t('common.page')} ${pageNumber}`;
                 },
                 language: {
                   ...dataTableLanguage(lang),

--- a/src/pages/EvalPage.js
+++ b/src/pages/EvalPage.js
@@ -119,7 +119,7 @@ const EvalPage = ({ lang = 'en' }) => {
 
   return (
     <GcdsContainer layout="page">
-      <h1 className="mb-400">{t('admin.navigation.eval', 'Evaluation Administration')}</h1>
+      <h1 className="mb-400">{t('admin.navigation.eval')}</h1>
       
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
@@ -128,96 +128,96 @@ const EvalPage = ({ lang = 'en' }) => {
       </nav>
 
       <div className="mb-400">
-        <h2>{t('admin.evalPage.similarityTitle', 'Similarity-Based Expert Feedback Transfer')}</h2>
+        <h2>{t('admin.evalPage.similarityTitle')}</h2>
         <GcdsText>
-          {t('admin.evalPage.similarityDescription', 'This approach automatically evaluates new interactions by finding similar expert-evaluated interactions and transferring feedback scores and explanations. If sentence-level matching fails, the system will fall back to using a highly similar question+answer match with a high expert score.')}
+          {t('admin.evalPage.similarityDescription')}
         </GcdsText>
         {expertFeedbackCount !== null && (
           <GcdsText>
-            <strong>{t('admin.evalPage.label.expertEvaluations', 'Expert Evaluations in System:')}</strong> {expertFeedbackCount}
+            <strong>{t('admin.evalPage.label.expertEvaluations')}</strong> {expertFeedbackCount}
           </GcdsText>
         )}
         {nonEmptyEvalCount !== null && (
           <GcdsText>
-            <strong>{t('admin.evalPage.label.nonEmptyEvaluations', 'Non-Empty Evaluations in System:')}</strong> {nonEmptyEvalCount}
+            <strong>{t('admin.evalPage.label.nonEmptyEvaluations')}</strong> {nonEmptyEvalCount}
           </GcdsText>
         )}
-        <GcdsDetails detailsTitle={t('admin.evalPage.detailsTitle', 'Detailed Evaluation Process')} className="mt-400">
+        <GcdsDetails detailsTitle={t('admin.evalPage.detailsTitle')} className="mt-400">
           <ol className="mb-200">
             <li>
-              <strong>{t('admin.evalPage.step.initialValidation.title', 'Initial Validation')}:</strong>
+              <strong>{t('admin.evalPage.step.initialValidation.title')}:</strong>
               {' '}
-              {t('admin.evalPage.step.initialValidation.description', 'The system first validates that the interaction has question and answer content, then checks if an evaluation already exists.')}
+              {t('admin.evalPage.step.initialValidation.description')}
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.embeddingRetrieval.title', 'Embedding Retrieval')}:</strong>
+              <strong>{t('admin.evalPage.step.embeddingRetrieval.title')}:</strong>
               {' '}
-              {t('admin.evalPage.step.embeddingRetrieval.description', 'Finds vector embeddings for the interaction (question+answer combined, answer-only, and sentence-level).')}
+              {t('admin.evalPage.step.embeddingRetrieval.description')}
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.findingSimilar.title', 'Finding Similar Content')}:</strong>
+              <strong>{t('admin.evalPage.step.findingSimilar.title')}:</strong>
               {' '}
-              {t('admin.evalPage.step.findingSimilar.description', 'Searches for interactions with existing expert feedback and strong QA similarity; returns up to 20 closest matches. Filters out results from the same chat and ensures sentence embeddings exist for candidates.')}
+              {t('admin.evalPage.step.findingSimilar.description')}
               <ul>
-                <li>{t('admin.evalPage.step.findingSimilar.item.expertFeedback', 'Existing expert feedback')}</li>
-                <li>{t('admin.evalPage.step.findingSimilar.item.qaSimilarity', 'Question(s)+answer similarity above threshold (e.g., 0.85)')}</li>
-                <li>{t('admin.evalPage.step.findingSimilar.item.maxMatches', 'Returns up to 20 closest matches (candidates are re-sorted by similarity)')}</li>
+                <li>{t('admin.evalPage.step.findingSimilar.item.expertFeedback')}</li>
+                <li>{t('admin.evalPage.step.findingSimilar.item.qaSimilarity')}</li>
+                <li>{t('admin.evalPage.step.findingSimilar.item.maxMatches')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.sentenceMatching.title', 'Sentence-Level Matching')}:</strong>
+              <strong>{t('admin.evalPage.step.sentenceMatching.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.sentenceMatching.item.findMostSimilar', 'For each sentence in the new interaction, find the most similar sentence in each potential match (vector search with per-sentence threshold)')}</li>
-                <li>{t('admin.evalPage.step.sentenceMatching.item.threshold', 'Keep matches above the sentence similarity threshold and prefer highest-similarity neighbors')}</li>
-                <li>{t('admin.evalPage.step.sentenceMatching.item.transfer', 'If all or a sufficient number of sentences are matched, transfer sentence-level feedback and create a detailed evaluation')}</li>
-                <li>{t('admin.evalPage.step.sentenceMatching.item.telemetry', 'Optionally run a sentence-compare agent for extra verification and capture telemetry (provider/model/latency/tokens)')}</li>
+                <li>{t('admin.evalPage.step.sentenceMatching.item.findMostSimilar')}</li>
+                <li>{t('admin.evalPage.step.sentenceMatching.item.threshold')}</li>
+                <li>{t('admin.evalPage.step.sentenceMatching.item.transfer')}</li>
+                <li>{t('admin.evalPage.step.sentenceMatching.item.telemetry')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.citationMatch.title', 'Citation Matching')}:</strong>
+              <strong>{t('admin.evalPage.step.citationMatch.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.citationMatch.item.compare', 'Compare the source citation URL with candidate interactions to find an exact or high-confidence citation match')}</li>
-                <li>{t('admin.evalPage.step.citationMatch.item.score', 'Score and record a citation match (score, explanation, matched interaction/chat ids)')}</li>
-                <li>{t('admin.evalPage.step.citationMatch.item.searchPage', 'Search page citations may be handled specially and scored zero')}</li>
+                <li>{t('admin.evalPage.step.citationMatch.item.compare')}</li>
+                <li>{t('admin.evalPage.step.citationMatch.item.score')}</li>
+                <li>{t('admin.evalPage.step.citationMatch.item.searchPage')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.qaFallback.title', 'QA High Score Fallback')}:</strong>
+              <strong>{t('admin.evalPage.step.qaFallback.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.qaFallback.item.checkTop', 'If sentence-level matching fails, check the top QA matches (configurable top-N) for those with high expert feedback scores')}</li>
-                <li>{t('admin.evalPage.step.qaFallback.item.citationCheck', 'For candidates, perform a citation match and optionally run a fallback compare agent to ensure the candidate answer sufficiently covers the source')}</li>
-                <li>{t('admin.evalPage.step.qaFallback.item.useQaOnly', 'If a candidate passes checks, create an evaluation using the QA match (QA-high-score fallback) and record fallback metadata and candidate traces')}</li>
+                <li>{t('admin.evalPage.step.qaFallback.item.checkTop')}</li>
+                <li>{t('admin.evalPage.step.qaFallback.item.citationCheck')}</li>
+                <li>{t('admin.evalPage.step.qaFallback.item.useQaOnly')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.fallbackCompare.title', 'Fallback Compare Checks')}:</strong>
+              <strong>{t('admin.evalPage.step.fallbackCompare.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.fallbackCompare.item.agent', 'A small compare agent can be invoked to verify that a fallback candidate sufficiently matches the source answer; results, raw output and parsed checks are recorded')}</li>
-                <li>{t('admin.evalPage.step.fallbackCompare.item.record', 'Whether compare was used and its meta (provider/model/latency/tokens) are stored on the evaluation for traceability')}</li>
+                <li>{t('admin.evalPage.step.fallbackCompare.item.agent')}</li>
+                <li>{t('admin.evalPage.step.fallbackCompare.item.record')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.creation.title', 'Evaluation Creation & Scoring')}:</strong>
+              <strong>{t('admin.evalPage.step.creation.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.creation.item.createFeedback', "Create a new expert feedback object based on the matched interaction's feedback or generated fallback feedback (type 'ai')")}</li>
-                <li>{t('admin.evalPage.step.creation.item.computeScore', 'Compute total score from per-sentence scores and citation score (default weights applied). If no ratings exist, totalScore may be null.')}</li>
-                <li>{t('admin.evalPage.step.creation.item.mapFeedback', 'Map feedback to the new interaction (sentence-level or QA-only) and save sentence match trace and similarity scores')}</li>
-                <li>{t('admin.evalPage.step.creation.item.recordSimilarities', 'Record similarity scores, matched citation interaction/chat ids, fallback metadata, and a detailed stage timeline for auditing')}</li>
-                <li>{t('admin.evalPage.step.creation.item.updateInteraction', 'Update the interaction with the new evaluation reference (autoEval)')}</li>
+                <li>{t('admin.evalPage.step.creation.item.createFeedback')}</li>
+                <li>{t('admin.evalPage.step.creation.item.computeScore')}</li>
+                <li>{t('admin.evalPage.step.creation.item.mapFeedback')}</li>
+                <li>{t('admin.evalPage.step.creation.item.recordSimilarities')}</li>
+                <li>{t('admin.evalPage.step.creation.item.updateInteraction')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.noMatch.title', 'No Match / Rejection Cases')}:</strong>
+              <strong>{t('admin.evalPage.step.noMatch.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.noMatch.item.recordNoMatch', 'If neither sentence-level nor QA fallback matches are accepted, create a no-match evaluation recording reason types and per-sentence rejection causes')}</li>
-                <li>{t('admin.evalPage.step.noMatch.item.trace', 'No-match evaluations include a sentence-trace and timeline so operators can inspect why candidates were rejected')}</li>
+                <li>{t('admin.evalPage.step.noMatch.item.recordNoMatch')}</li>
+                <li>{t('admin.evalPage.step.noMatch.item.trace')}</li>
               </ul>
             </li>
             <li>
-              <strong>{t('admin.evalPage.step.timeline.title', 'Stage Timeline & Telemetry')}:</strong>
+              <strong>{t('admin.evalPage.step.timeline.title')}:</strong>
               <ul>
-                <li>{t('admin.evalPage.step.timeline.item.record', 'The worker records a stage-by-stage timeline (stage, status, code, message, timestamp) to the evaluation for diagnostics')}</li>
-                <li>{t('admin.evalPage.step.timeline.item.telemetry', 'Agent and VectorService telemetry (latency, tokens, model) are captured where applicable')}</li>
+                <li>{t('admin.evalPage.step.timeline.item.record')}</li>
+                <li>{t('admin.evalPage.step.timeline.item.telemetry')}</li>
               </ul>
             </li>
           </ol>
@@ -225,7 +225,7 @@ const EvalPage = ({ lang = 'en' }) => {
         <br/>
         {/* Evaluation metrics summary */}
         <div className="mt-400">
-          <h3>{t('admin.evalPage.metrics.title', 'Evaluation metrics')}</h3>
+          <h3>{t('admin.evalPage.metrics.title')}</h3>
           {evalMetrics ? (
             <div>
               <table className="table" style={{ borderCollapse: 'collapse', width: '100%' }}>
@@ -237,22 +237,22 @@ const EvalPage = ({ lang = 'en' }) => {
                 </thead>
                 <tbody>
                   <tr>
-                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.total', 'Total evaluations')}</td>
+                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.total')}</td>
                     <td style={{ border: '1px solid #ddd', padding: '8px' }}>{evalMetrics.total}</td>
                   </tr>
                   <tr>
-                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.processed', 'Processed evaluations')}</td>
+                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.processed')}</td>
                     <td style={{ border: '1px solid #ddd', padding: '8px' }}>{evalMetrics.processed}</td>
                   </tr>
                   <tr>
-                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.hasMatches', 'Evaluations with matches')}</td>
+                    <td style={{ border: '1px solid #ddd', padding: '8px' }}>{t('admin.evalPage.metrics.hasMatches')}</td>
                     <td style={{ border: '1px solid #ddd', padding: '8px' }}>{evalMetrics.hasMatches}</td>
                   </tr>
                 </tbody>
               </table>
 
               <div className="mt-200">
-                <h4>{t('admin.evalPage.metrics.noMatchReasons', 'No-match reasons')}</h4>
+                <h4>{t('admin.evalPage.metrics.noMatchReasons')}</h4>
                   {evalMetrics.noMatchByReason && Object.keys(evalMetrics.noMatchByReason).length > 0 ? (
                   <table className="table" style={{ borderCollapse: 'collapse', width: '100%' }}>
                     <thead>
@@ -264,19 +264,19 @@ const EvalPage = ({ lang = 'en' }) => {
                     <tbody>
                       {Object.entries(evalMetrics.noMatchByReason).map(([k, v]) => (
                         <tr key={`nm-${k}`}>
-                          <td style={{ border: '1px solid #ddd', padding: '8px' }}>{k ? t(`eval.noMatchReasonTypes.${k}`, k) : t('admin.evalPage.metrics.unknown', 'unknown')}</td>
+                          <td style={{ border: '1px solid #ddd', padding: '8px' }}>{k ? t(`eval.noMatchReasonTypes.${k}`, k) : t('admin.evalPage.metrics.unknown')}</td>
                           <td style={{ border: '1px solid #ddd', padding: '8px' }}>{v}</td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
                 ) : (
-                  <div>{t('admin.evalPage.metrics.noMatchNone', 'No no-match reason data available.')}</div>
+                  <div>{t('admin.evalPage.metrics.noMatchNone')}</div>
                 )}
               </div>
 
               <div className="mt-200">
-                <h4>{t('admin.evalPage.metrics.fallbackTypes', 'Fallback types')}</h4>
+                <h4>{t('admin.evalPage.metrics.fallbackTypes')}</h4>
                 {evalMetrics.fallbackByType && Object.keys(evalMetrics.fallbackByType).length > 0 ? (
                   <table className="table" style={{ borderCollapse: 'collapse', width: '100%' }}>
                     <thead>
@@ -288,21 +288,21 @@ const EvalPage = ({ lang = 'en' }) => {
                     <tbody>
                       {Object.entries(evalMetrics.fallbackByType).map(([k, v]) => (
                         <tr key={`fb-${k}`}>
-                          <td style={{ border: '1px solid #ddd', padding: '8px' }}>{k || t('admin.evalPage.metrics.unknown', 'unknown')}</td>
+                          <td style={{ border: '1px solid #ddd', padding: '8px' }}>{k || t('admin.evalPage.metrics.unknown')}</td>
                           <td style={{ border: '1px solid #ddd', padding: '8px' }}>{v}</td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
                 ) : (
-                  <div>{t('admin.evalPage.metrics.fallbackNone', 'No fallback usage data available.')}</div>
+                  <div>{t('admin.evalPage.metrics.fallbackNone')}</div>
                 )}
               </div>
 
               <div className="mt-200">
                 <button onClick={() => {
                   EvaluationService.getEvalMetrics().then(setEvalMetrics).catch(() => {});
-                }}>{t('admin.evalPage.metrics.refresh', 'Refresh metrics')}</button>
+                }}>{t('admin.evalPage.metrics.refresh')}</button>
               </div>
             </div>
           ) : (
@@ -311,7 +311,7 @@ const EvalPage = ({ lang = 'en' }) => {
         </div>
         <div style={{ display: "flex", gap: "1rem", margin: "1rem 0" }}>
           <label>
-            {t('admin.evalPage.date.startLabel', 'Start Date')}:
+            {t('admin.evalPage.date.startLabel')}:
             <input
               type="date"
               value={startTime}
@@ -320,7 +320,7 @@ const EvalPage = ({ lang = 'en' }) => {
             />
           </label>
           <label>
-            {t('admin.evalPage.date.endLabel', 'End Date')}:
+            {t('admin.evalPage.date.endLabel')}:
             <input
               type="date"
               value={endTime}
@@ -335,7 +335,7 @@ const EvalPage = ({ lang = 'en' }) => {
             disabled={evalProgress?.loading || isAutoProcessingEvals || isRegeneratingAll}
             className="mb-200 mr-200"
           >
-            {evalProgress?.loading && !isAutoProcessingEvals && !isRegeneratingAll ? t('admin.evalPage.button.processing', 'Processing...') : t('admin.evalPage.button.generate', 'Generate Evaluations')}
+            {evalProgress?.loading && !isAutoProcessingEvals && !isRegeneratingAll ? t('admin.evalPage.button.processing') : t('admin.evalPage.button.generate')}
           </GcdsButton>
           <GcdsButton 
             onClick={handleDeleteEvals}
@@ -343,7 +343,7 @@ const EvalPage = ({ lang = 'en' }) => {
             buttonRole="danger"
             className="mb-200 mr-200"
           >
-            {t('admin.evalPage.button.deleteAll', 'Delete Evaluations')}
+            {t('admin.evalPage.button.deleteAll')}
           </GcdsButton>
           <GcdsButton 
             onClick={handleDeleteEmptyEvals}
@@ -351,29 +351,29 @@ const EvalPage = ({ lang = 'en' }) => {
             buttonRole="danger"
             className="mb-200"
           >
-            {t('admin.evalPage.button.deleteEmpty', 'Delete Empty Evaluations')}
+            {t('admin.evalPage.button.deleteEmpty')}
           </GcdsButton>
         </div>
           {evalProgress && (
           <StatusMessage tag="div" className="mb-200">
             <p>
               {evalProgress.processed !== undefined && (
-                <span> • {t('admin.evalPage.progress.processed', 'Processed')}: {evalProgress.processed}</span>
+                <span> • {t('admin.evalPage.progress.processed')}: {evalProgress.processed}</span>
               )}
               {evalProgress.failed !== undefined && (
-                <span> • {t('admin.evalPage.progress.failed', 'Failed')}: {evalProgress.failed}</span>
+                <span> • {t('admin.evalPage.progress.failed')}: {evalProgress.failed}</span>
               )}
               {evalProgress.remaining !== undefined && (
-                <span> • {t('admin.evalPage.progress.remaining', 'Remaining')}: {evalProgress.remaining}</span>
+                <span> • {t('admin.evalPage.progress.remaining')}: {evalProgress.remaining}</span>
               )}
               {evalProgress.duration !== undefined && (
-                <span> • {t('admin.evalPage.progress.duration', 'Duration')}: {evalProgress.duration}s</span>
+                <span> • {t('admin.evalPage.progress.duration')}: {evalProgress.duration}s</span>
               )}
               {isAutoProcessingEvals && !isRegeneratingAll && (
-                <span> • <strong>{t('admin.evalPage.progress.autoProcessing', 'Auto-processing active')}</strong></span>
+                <span> • <strong>{t('admin.evalPage.progress.autoProcessing')}</strong></span>
               )}
               {isRegeneratingAll && (
-                <span> • <strong>{t('admin.evalPage.progress.regeneratingAll', 'Regenerating all evaluations')}</strong></span>
+                <span> • <strong>{t('admin.evalPage.progress.regeneratingAll')}</strong></span>
               )}
             </p>
           </StatusMessage>

--- a/src/pages/MetricsPage.js
+++ b/src/pages/MetricsPage.js
@@ -13,7 +13,7 @@ const MetricsPage = ({ lang = 'en' }) => {
     <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('metrics.title')}</h1>
       
-      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
           <GcdsLink href={`/${lang}/admin`}>{t('common.backToAdmin')}</GcdsLink>
         </GcdsText>

--- a/src/pages/PublicEvalPage.js
+++ b/src/pages/PublicEvalPage.js
@@ -48,7 +48,7 @@ const PublicEvalPage = ({ lang: propLang }) => {
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('admin.publicEval.title', 'Public Evaluation')}</h1>
+      <h1 className="mb-400">{t('admin.publicEval.title')}</h1>
       <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
           <GcdsLink href={`/${lang}/admin`}>{t('common.backToAdmin')}</GcdsLink>
@@ -60,13 +60,13 @@ const PublicEvalPage = ({ lang: propLang }) => {
         data={rows}
         columns={[
           {
-            title: t('admin.publicEval.chatId', 'Chat ID'),
+            title: t('admin.publicEval.chatId'),
             data: 'chatId',
             render: (data) => `<a href="/${lang}?chat=${data}&review=1">${data}</a>`
           },
-          { title: t('admin.publicEval.department', 'Department'), data: 'department' },
+          { title: t('admin.publicEval.department'), data: 'department' },
           {
-            title: t('admin.publicEval.date', 'Date'),
+            title: t('admin.publicEval.date'),
             data: 'date',
             render: (data) => formatDate(data)
           }

--- a/src/pages/SessionPage.js
+++ b/src/pages/SessionPage.js
@@ -33,7 +33,7 @@ const SessionPage = ({ lang: propLang }) => {
     return labels[type] || labels.unknown;
   }, [t]);
   const creditsLeftLabel = React.useCallback((value) => (
-    value === null ? t('admin.session.unlimited', 'Unlimited') : (value !== undefined ? value : 0)
+    value === null ? t('admin.session.unlimited') : (value !== undefined ? value : 0)
   ), [t]);
 
   const fetchSessions = React.useCallback(async () => {
@@ -72,8 +72,8 @@ const SessionPage = ({ lang: propLang }) => {
 
   return (
     <GcdsContainer layout="page" className="mb-600">
-      <h1 className="mb-400">{t('admin.session.title', 'Sessions')}</h1>
-      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
+      <h1 className="mb-400">{t('admin.session.title')}</h1>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
           <GcdsLink href={`/${lang}/admin`}>{t('common.backToAdmin')}</GcdsLink>
         </GcdsText>
@@ -89,26 +89,26 @@ const SessionPage = ({ lang: propLang }) => {
         data={sessions}
         className="display dashboard-table zebra-stable-on-hover"
         columns={[
-          { title: t('admin.session.sessionId', 'Session ID'), data: 'sessionId', render: (data) => data || '' },
-          { title: t('admin.session.sessionType', 'Session type'), data: 'sessionType', render: (data) => sessionTypeLabel(data) },
+          { title: t('admin.session.sessionId'), data: 'sessionId', render: (data) => data || '' },
+          { title: t('admin.session.sessionType'), data: 'sessionType', render: (data) => sessionTypeLabel(data) },
           {
-            title: t('admin.session.chatId', 'Chat ID'), data: 'chatId', render: (data, type, row) => {
+            title: t('admin.session.chatId'), data: 'chatId', render: (data, type, row) => {
               const cid = data || row.chatId || '';
               return cid ? `<a href="/${lang}?chat=${cid}&review=1">${cid}</a>` : '';
             }
           },
-          { title: t('admin.session.creditsLeft', 'Credits left'), data: 'creditsLeft', render: (data) => creditsLeftLabel(data) },
-          { title: t('admin.session.lastSeen', 'Last seen'), data: 'lastSeen', render: (data) => new Date(data).toLocaleString() },
-          { title: t('admin.session.requests', 'Requests'), data: 'requestCount' },
-          { title: t('admin.session.errors', 'Errors'), data: 'errorCount' },
+          { title: t('admin.session.creditsLeft'), data: 'creditsLeft', render: (data) => creditsLeftLabel(data) },
+          { title: t('admin.session.lastSeen'), data: 'lastSeen', render: (data) => new Date(data).toLocaleString() },
+          { title: t('admin.session.requests'), data: 'requestCount' },
+          { title: t('admin.session.errors'), data: 'errorCount' },
           // specific error type columns
-          { title: t('admin.session.errorTypes.redaction', 'Redactions'), data: 'errorTypes', render: (data) => (data && data.redaction) ? data.redaction : 0 },
-          { title: t('admin.session.errorTypes.shortQuery', 'Short queries'), data: 'errorTypes', render: (data) => (data && data.shortQuery) ? data.shortQuery : 0 },
+          { title: t('admin.session.errorTypes.redaction'), data: 'errorTypes', render: (data) => (data && data.redaction) ? data.redaction : 0 },
+          { title: t('admin.session.errorTypes.shortQuery'), data: 'errorTypes', render: (data) => (data && data.shortQuery) ? data.shortQuery : 0 },
           // aggregated "other" errors column
-          { title: t('admin.session.errorTypes.other', 'Other errors'), data: 'errorTypesOther' },
-          { title: t('admin.session.lastLatency', 'Last latency (ms)'), data: 'lastLatencyMs' },
-          { title: t('admin.session.avgLatency', 'Avg latency (ms)'), data: 'avgLatencyMs' },
-          { title: t('admin.session.rpm', 'Requests / minute'), data: 'rpm' }
+          { title: t('admin.session.errorTypes.other'), data: 'errorTypesOther' },
+          { title: t('admin.session.lastLatency'), data: 'lastLatencyMs' },
+          { title: t('admin.session.avgLatency'), data: 'avgLatencyMs' },
+          { title: t('admin.session.rpm'), data: 'rpm' }
         ]}
         options={{
           paging: true,

--- a/src/pages/TechnicalMetricsPage.js
+++ b/src/pages/TechnicalMetricsPage.js
@@ -11,7 +11,7 @@ const TechnicalMetricsPage = ({ lang = 'en' }) => {
     <GcdsContainer layout="page" className="mb-600">
       <h1 className="mb-400">{t('technicalMetrics.title')}</h1>
 
-      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel', 'Admin Navigation')}>
+      <nav className="mb-400" aria-label={t('admin.navigation.ariaLabel')}>
         <GcdsText>
           <GcdsLink href={`/${lang}/admin`}>{t('common.backToAdmin')}</GcdsLink>
         </GcdsText>

--- a/src/pages/__tests__/ChatDashboardPage.test.js
+++ b/src/pages/__tests__/ChatDashboardPage.test.js
@@ -10,7 +10,7 @@ import DashboardService from '../../services/DashboardService.js';
 // Mock dependencies
 vi.mock('../../hooks/useTranslations.js', () => ({
   useTranslations: () => ({
-    t: (key, defaultValue) => defaultValue || key
+    t: (key) => key
   })
 }));
 
@@ -95,7 +95,7 @@ describe('ChatDashboardPage rendering', () => {
     const { getByText } = render(<ChatDashboardPage lang="en" />);
 
     await waitFor(() => {
-      expect(getByText(/Chat dashboard/i)).toBeTruthy();
+      expect(getByText('admin.chatDashboard.title')).toBeTruthy();
     });
   });
 

--- a/src/pages/__tests__/EvalDashboardPages.test.js
+++ b/src/pages/__tests__/EvalDashboardPages.test.js
@@ -9,7 +9,7 @@ let lastDataTableProps = null;
 
 vi.mock('../../hooks/useTranslations.js', () => ({
   useTranslations: () => ({
-    t: (key, defaultValue) => defaultValue || key
+    t: (key) => key
   })
 }));
 
@@ -59,7 +59,7 @@ describe('eval dashboard pages', () => {
     const { container } = render(<EvalDashboardPage lang="en" />);
 
     await waitFor(() => {
-      expect(within(container).getByRole('heading', { name: 'Evaluation dashboard' })).toBeTruthy();
+      expect(within(container).getByRole('heading', { name: 'admin.evalDashboard.title' })).toBeTruthy();
     });
 
     await waitFor(() => {
@@ -77,7 +77,7 @@ describe('eval dashboard pages', () => {
     const { container } = render(<AutoEvalDashboardPage lang="en" />);
 
     await waitFor(() => {
-      expect(within(container).getByRole('heading', { name: 'Auto-Evaluation dashboard' })).toBeTruthy();
+      expect(within(container).getByRole('heading', { name: 'admin.autoEvalDashboard.title' })).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
t() takes only a key here — the fallbacks never fired. On a missing/renamed key the raw key rendered, unmasked; removing the fallback just lets that fail loudly instead of quietly.