### PR TITLE
fix: session load error via useErrorStatus

### DIFF
--- a/src/hooks/useErrorStatus.js
+++ b/src/hooks/useErrorStatus.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import StatusMessage from '../components/admin/StatusMessage.js';
 
 // Shared { text } (success) | { prefix, suffix, detail, isError } (error)
@@ -22,7 +22,10 @@ import StatusMessage from '../components/admin/StatusMessage.js';
 // repeat useTranslations() plumbing through this - same shape as
 // useAuthOutcomeMessages taking its dependencies once at the top.
 export const useErrorStatus = (t) => {
-  const buildErrorStatus = (key, error, otherPlaceholders = {}) => {
+  // Stable across renders (as long as t is — see useTranslations.js) so
+  // callers can safely put buildErrorStatus/renderStatusMessage in their own
+  // useCallback/useEffect deps instead of having to omit them.
+  const buildErrorStatus = useCallback((key, error, otherPlaceholders = {}) => {
     let template = t(key);
     for (const [name, value] of Object.entries(otherPlaceholders)) {
       template = template.replace(`{${name}}`, () => value);
@@ -35,13 +38,13 @@ export const useErrorStatus = (t) => {
     const [prefix, suffix] = template.split('{error}');
     const detail = error?.message || String(error);
     return { prefix, suffix, detail, isError: true };
-  };
+  }, [t]);
 
   // successVariant: DatabasePage.js's operations are completed mutations
   // ('success', the default); SettingsPage.js's cache refresh is a neutral
   // confirmation, not a mutation ('info') - a real semantic difference
   // between the two existing callers, not just inconsistency to paper over.
-  const renderStatusMessage = (status, successVariant = 'success') => (
+  const renderStatusMessage = useCallback((status, successVariant = 'success') => (
     <StatusMessage variant={status ? (status.isError ? 'error' : successVariant) : undefined}>
       {status && (
         status.detail !== undefined
@@ -49,7 +52,7 @@ export const useErrorStatus = (t) => {
           : status.text
       )}
     </StatusMessage>
-  );
+  ), []);
 
   return { buildErrorStatus, renderStatusMessage };
 };

--- a/src/hooks/useErrorStatus.js
+++ b/src/hooks/useErrorStatus.js
@@ -21,6 +21,11 @@ import StatusMessage from '../components/admin/StatusMessage.js';
 // `t` is taken once here rather than passed to each call, so callers don't
 // repeat useTranslations() plumbing through this - same shape as
 // useAuthOutcomeMessages taking its dependencies once at the top.
+// TODO(follow-up PR): migrate these hand-rolled callers of the same
+// t(key).split('{placeholder}') + <code lang="en">detail pattern onto this
+// hook: DeleteExpertEval.js, SimilarChatsDashboard.js, DeleteChatSection.js,
+// ChatLogsDashboard.js, TechnicalMetricsDashboard.js, MetricsDashboard.js,
+// ExperimentalCreateDatasetPage.js, VectorPage.js.
 export const useErrorStatus = (t) => {
   // Stable across renders (as long as t is — see useTranslations.js) so
   // callers can safely put buildErrorStatus/renderStatusMessage in their own

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -817,8 +817,7 @@
       "lastLatency": "Last latency (ms)",
       "avgLatency": "Avg latency (ms)",
       "rpm": "Requests / minute",
-      "errorLoading": "Failed to load sessions: {status} {text}",
-      "errorGeneric": "Error: {message}"
+      "errorLoading": "Failed to load sessions: {error}"
     },
     "common": {
       "searchLabel": "Search:",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -817,8 +817,7 @@
       "lastLatency": "Dernière latence (ms)",
       "avgLatency": "Latence moyenne (ms)",
       "rpm": "Requêtes / minute",
-      "errorLoading": "Échec du chargement des sessions : {status} {text}",
-      "errorGeneric": "Erreur : {message}"
+      "errorLoading": "Échec du chargement des sessions : {error}"
     },
     "common": {
       "searchLabel": "Rechercher :",

--- a/src/pages/SessionPage.js
+++ b/src/pages/SessionPage.js
@@ -61,11 +61,7 @@ const SessionPage = ({ lang: propLang }) => {
     } finally {
       setLoading(false);
     }
-    // buildErrorStatus deliberately excluded: useErrorStatus() returns a new
-    // function identity every render, and usePausablePolling below re-fires
-    // its effect whenever this callback's identity changes — including it
-    // would poll in a tight loop instead of every 5s.
-  }, [t]);
+  }, [buildErrorStatus]);
 
   // WCAG 2.2.2 (Pause, Stop, Hide): the 5s poll below keeps refreshing the
   // table.

--- a/src/pages/SessionPage.js
+++ b/src/pages/SessionPage.js
@@ -11,6 +11,7 @@ import { escapeHtml } from '../utils/htmlEscape.js';
 import { usePageContext } from '../hooks/usePageParam.js';
 import SessionService from '../services/SessionService.js';
 import StatusMessage from '../components/admin/StatusMessage.js';
+import { useErrorStatus } from '../hooks/useErrorStatus.js';
 
 DataTable.use(DT);
 
@@ -18,8 +19,9 @@ const SessionPage = ({ lang: propLang }) => {
   const { language } = usePageContext();
   const lang = propLang || language || 'en';
   const { t } = useTranslations(lang);
+  const { buildErrorStatus, renderStatusMessage } = useErrorStatus(t);
   const [sessions, setSessions] = useState([]);
-  const [error, setError] = useState('');
+  const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const sessionTypeLabel = React.useCallback((value) => {
     const type = value || 'unknown';
@@ -38,7 +40,7 @@ const SessionPage = ({ lang: propLang }) => {
 
   const fetchSessions = React.useCallback(async () => {
     setLoading(true);
-    setError('');
+    setError(null);
     try {
       const sess = await SessionService.getSessionMetrics();
       // Ensure creditsLeft reflects the session-level value (shared across
@@ -54,16 +56,15 @@ const SessionPage = ({ lang: propLang }) => {
       const normalized = (sess || []).map(r => ({ ...r, creditsLeft: sessionCredits[r.sessionId] ?? r.creditsLeft }));
       setSessions(normalized);
     } catch (e) {
-      // prefer admin.session.errorLoading if status/text available
-      if (e && e.status) {
-        setError(t('admin.session.errorLoading', 'Failed to load sessions: {status} {text}', { status: e.status, text: e.text || '' }));
-      } else {
-        setError(t('admin.session.errorGeneric', 'Error: {message}', { message: e.message }));
-      }
+      setError(buildErrorStatus('admin.session.errorLoading', e));
       setSessions([]);
     } finally {
       setLoading(false);
     }
+    // buildErrorStatus deliberately excluded: useErrorStatus() returns a new
+    // function identity every render, and usePausablePolling below re-fires
+    // its effect whenever this callback's identity changes — including it
+    // would poll in a tight loop instead of every 5s.
   }, [t]);
 
   // WCAG 2.2.2 (Pause, Stop, Hide): the 5s poll below keeps refreshing the
@@ -79,7 +80,7 @@ const SessionPage = ({ lang: propLang }) => {
         </GcdsText>
       </nav>
 
-      <StatusMessage variant={error ? 'error' : undefined} message={error} />
+      {renderStatusMessage(error)}
       {loading && <StatusMessage loading message={t('admin.filters.loading')} />}
 
       <PauseToggleButton isPaused={isPaused} onToggle={togglePause} t={t} className="mb-200" />

--- a/src/pages/__tests__/SessionPage.test.js
+++ b/src/pages/__tests__/SessionPage.test.js
@@ -67,7 +67,7 @@ describe('SessionPage StatusMessage roles', () => {
 
     renderWithRouter(<SessionPage lang="en" />);
 
-    await waitForAnnouncement('admin.session.errorGeneric', 'assertive');
+    await waitForAnnouncement('admin.session.errorLoading', 'assertive');
   });
 
   it('announces the loading state as role="status" with the loading spinner box', async () => {

--- a/src/pages/__tests__/SessionPage.test.js
+++ b/src/pages/__tests__/SessionPage.test.js
@@ -19,10 +19,11 @@ vi.mock('../../services/SessionService.js', () => ({
 }));
 
 // A stable `t` reference matters here: SessionPage's fetchSessions is a
-// useCallback keyed on [t], and the mocked usePausablePolling below re-fires
-// its effect whenever that callback's identity changes — a fresh arrow
-// function per render would cause an infinite refetch loop instead of
-// settling on the error/loading state under test.
+// useCallback keyed on [buildErrorStatus] (from useErrorStatus, itself keyed
+// on [t]), and the mocked usePausablePolling below re-fires its effect
+// whenever that callback's identity changes — a fresh arrow function per
+// render would cause an infinite refetch loop instead of settling on the
+// error/loading state under test.
 const mockT = (key) => key;
 vi.mock('../../hooks/useTranslations.js', () => ({
   useTranslations: () => ({ t: mockT }),

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -35,10 +35,7 @@ const SessionService = {
       // "Failed to load sessions: {error}" template via useErrorStatus, so
       // .message is just the raw diagnostic detail (rendered as
       // <code lang="en">, never shown untranslated on its own).
-      const err = new Error(`${resp.status} ${txt}`);
-      err.status = resp.status;
-      err.text = txt;
-      throw err;
+      throw new Error(`${resp.status} ${txt}`);
     }
     const json = await resp.json();
     return json.sessions || [];

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -31,7 +31,11 @@ const SessionService = {
     });
     if (!resp.ok) {
       const txt = await resp.text();
-      const err = new Error(`Failed to load sessions: ${resp.status} ${txt}`);
+      // No page-facing prefix here: SessionPage wraps this in a translated
+      // "Failed to load sessions: {error}" template via useErrorStatus, so
+      // .message is just the raw diagnostic detail (rendered as
+      // <code lang="en">, never shown untranslated on its own).
+      const err = new Error(`${resp.status} ${txt}`);
       err.status = resp.status;
       err.text = txt;
       throw err;


### PR DESCRIPTION

  - src/pages/SessionPage.js: use buildErrorStatus/renderStatusMessage
  - src/services/SessionService.js: drop the redundant "Failed to load
    sessions" prefix from the thrown Error.message (now supplied by the
    translated template)
  - src/locales/en.json, fr.json: consolidate errorLoading/errorGeneric
    into one errorLoading: "Failed to load sessions: {error}" key
  - src/pages/__tests__/SessionPage.test.js: update expected key
