### PR TITLE
fix: route About/How-to load states through StatusMessage

### DIFF
--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -22,11 +22,18 @@ import ReactMarkdown from 'react-markdown';
 import { useMarkdownWithFrontmatter } from '../hooks/useMarkdownWithFrontmatter.js';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { DCTERMS } from '../config/metadata.js';
+import StatusMessage from '../components/admin/StatusMessage.js';
+import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
 
 const AboutPage = ({ lang = 'en' }) => {
   const { t } = useTranslations(lang);
   const filename = lang === 'fr' ? 'about-fr.md' : 'about-en.md';
   const { frontmatter, sections, loading, error } = useMarkdownWithFrontmatter(filename);
+  // Explicit focus-move on error - language toggle is a full page reload
+  // (GcdsHeader's langHref is a plain <a>), so error can only go
+  // false->true once per mount. Plain value is fine here (EvalPanel.js's
+  // justDeleted), no counter needed.
+  const errorRef = useFocusOnChange(error);
 
   // Update page metadata from frontmatter
   useEffect(() => {
@@ -115,7 +122,7 @@ const AboutPage = ({ lang = 'en' }) => {
   if (loading) {
     return (
       <div className="mb-600 container-custom">
-        <p>{t('aboutPage.loading')}</p>
+        <StatusMessage loading message={t('aboutPage.loading')} />
       </div>
     );
   }
@@ -125,7 +132,15 @@ const AboutPage = ({ lang = 'en' }) => {
     return (
       <div className="mb-600 container-custom">
         <h1>{t('aboutPage.title')}</h1>
-        <p>{t('aboutPage.loadError')}</p>
+        <StatusMessage
+          variant="error"
+          message={t('aboutPage.loadError')}
+          ref={errorRef}
+          tabIndex={-1}
+          announce={false}
+          announcedVia="focus"
+          className="focus-target"
+        />
       </div>
     );
   }

--- a/src/pages/HowToPage.js
+++ b/src/pages/HowToPage.js
@@ -15,16 +15,28 @@ import { GcdsContainer, GcdsText, GcdsLink } from '@gcds-core/components-react';
 import { useTranslations } from '../hooks/useTranslations.js';
 import { useMarkdownWithFrontmatter } from '../hooks/useMarkdownWithFrontmatter.js';
 import { getHowTo, HOW_TO_CONTENT_DIR } from '../config/howTos.js';
+import StatusMessage from '../components/admin/StatusMessage.js';
+import { useFocusOnChange } from '../hooks/useFocusOnChange.js';
 
 const HowToPage = ({ lang = 'en', howToId }) => {
   const { t } = useTranslations(lang);
   const howTo = getHowTo(howToId);
+  const notFound = !howTo;
   const filename = howTo ? howTo.files[lang] || howTo.files.en : null;
 
   const { frontmatter, content, loading, error } = useMarkdownWithFrontmatter(
     filename,
     HOW_TO_CONTENT_DIR
   );
+  // Explicit focus-move on notFound/error - no client-side route ever
+  // changes howToId under a mounted instance (every link is a plain <a>,
+  // full reload), so each can only go false->true once per mount. Plain
+  // value is fine here (EvalPanel.js's justDeleted), and per
+  // status-and-error-messaging.md, don't share one counter across two
+  // different outcomes - separate refs even though the two are mutually
+  // exclusive on screen.
+  const notFoundRef = useFocusOnChange(notFound);
+  const errorRef = useFocusOnChange(error);
 
   useEffect(() => {
     if (!loading && frontmatter.title) {
@@ -46,12 +58,20 @@ const HowToPage = ({ lang = 'en', howToId }) => {
     </nav>
   );
 
-  if (!howTo) {
+  if (notFound) {
     return (
       <GcdsContainer layout="page" className="mb-600">
         <h1 className="mb-400">{t('admin.howTo.notFoundTitle')}</h1>
         {backToAdminNav}
-        <p>{t('admin.howTo.notFound')}</p>
+        <StatusMessage
+          variant="error"
+          message={t('admin.howTo.notFound')}
+          ref={notFoundRef}
+          tabIndex={-1}
+          announce={false}
+          announcedVia="focus"
+          className="focus-target"
+        />
       </GcdsContainer>
     );
   }
@@ -59,7 +79,7 @@ const HowToPage = ({ lang = 'en', howToId }) => {
   if (loading) {
     return (
       <GcdsContainer layout="page" className="mb-600">
-        <p>{t('admin.howTo.loading')}</p>
+        <StatusMessage loading message={t('admin.howTo.loading')} />
       </GcdsContainer>
     );
   }
@@ -69,7 +89,15 @@ const HowToPage = ({ lang = 'en', howToId }) => {
       <GcdsContainer layout="page" className="mb-600">
         <h1 className="mb-400">{t(howTo.titleKey)}</h1>
         {backToAdminNav}
-        <p>{t('admin.howTo.loadError')}</p>
+        <StatusMessage
+          variant="error"
+          message={t('admin.howTo.loadError')}
+          ref={errorRef}
+          tabIndex={-1}
+          announce={false}
+          announcedVia="focus"
+          className="focus-target"
+        />
       </GcdsContainer>
     );
   }

--- a/src/pages/__tests__/AboutPage.test.js
+++ b/src/pages/__tests__/AboutPage.test.js
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import AboutPage from '../AboutPage.js';
+
+vi.mock('../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const ABOUT_MARKDOWN = `---
+title: "About AI Answers"
+description: "About page description"
+---
+
+# About AI Answers
+
+## Overview
+
+Some overview text.
+`;
+
+describe('AboutPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the overview section for a successful fetch', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(ABOUT_MARKDOWN) })
+    );
+
+    render(<AboutPage lang="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'About AI Answers' })).not.toBeNull();
+    });
+    expect(screen.getByText('Some overview text.')).not.toBeNull();
+  });
+
+  it('moves focus to the load-error message when the fetch fails', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') })
+    );
+
+    render(<AboutPage lang="en" />);
+
+    const notice = await screen.findByText('aboutPage.loadError');
+    const box = notice.closest('.status-message--error-box');
+    expect(box.getAttribute('tabindex')).toBe('-1');
+    await waitFor(() => expect(document.activeElement).toBe(box));
+  });
+});

--- a/src/pages/__tests__/HowToPage.test.js
+++ b/src/pages/__tests__/HowToPage.test.js
@@ -15,6 +15,7 @@ vi.mock('../../hooks/useTranslations.js', () => ({
 vi.mock('@gcds-core/components-react', () => ({
   GcdsContainer: ({ children }) => <div>{children}</div>,
   GcdsText: ({ children }) => <div>{children}</div>,
+  GcdsIcon: ({ name }) => <span data-icon={name} />,
   GcdsLink: ({ href, target, lang, children }) => (
     <a href={href} target={target} data-gcds-link lang={lang}>
       {children}
@@ -121,5 +122,24 @@ describe('HowToPage', () => {
 
     expect(screen.getByText('admin.howTo.notFound')).not.toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('moves focus to the not-found message, since there is no prior interaction to anchor to', () => {
+    render(<HowToPage lang="en" howToId="does-not-exist" />);
+
+    const notice = screen.getByText('admin.howTo.notFound').closest('.status-message--error-box');
+    expect(notice.getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(notice);
+  });
+
+  it('moves focus to the load-error message when the guide fetch fails', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') }));
+
+    render(<HowToPage lang="en" howToId="eval-informed-answers" />);
+
+    const notice = await screen.findByText('admin.howTo.loadError');
+    const box = notice.closest('.status-message--error-box');
+    expect(box.getAttribute('tabindex')).toBe('-1');
+    await waitFor(() => expect(document.activeElement).toBe(box));
   });
 });


### PR DESCRIPTION
- AboutPage.js — loading → StatusMessage loading; load-failure → StatusMessage variant="error" with
    focus-move (same pattern as ResetCompletePage.js).
- HowToPage.js — same for loading/load-failure, plus the !howTo "guide not found", with its own focus-move keyed on howToId.
- HowToPage.test.js — added missing GcdsIcon to the @gcds-core/components-react mock (StatusMessage's error
    variant renders it; without it the error/not-found paths would throw in tests).