### PR TITLE
fix: resolve batch DefaultGraph alias to the shared default workflow

### DIFF
--- a/services/experimental/ExperimentalBatchService.js
+++ b/services/experimental/ExperimentalBatchService.js
@@ -11,6 +11,13 @@ import crypto from 'crypto';
 import PQueue from 'p-queue';
 import { getPersistedAppVersion } from '../AppVersionService.js';
 import { pickExplicitReferenceAnswer } from './datasetColumns.js';
+// Single source of truth for the fallback graph (also used by live chat via
+// api/chat/chat-graph-run.js and seeded as 'workflow.default'). The legacy
+// 'DefaultGraph' alias below must keep pointing at it — it previously named
+// 'GenericWorkflowGraph', which was removed from the graph registry in May
+// 2026, so every batch without an explicit config.workflow failed item by
+// item with 'Graph GenericWorkflowGraph not found' (issue #1792).
+import { DEFAULT_WORKFLOW } from '../../src/config/workflows.js';
 
 const QUEUE_NAME = 'experimental-batch-processing';
 const BATCH_CONCURRENCY = parseInt(process.env.BATCH_CONCURRENCY, 10) || 2;
@@ -18,7 +25,7 @@ const MAX_ITEM_RETRIES = parseInt(process.env.BATCH_ITEM_MAX_RETRIES, 10) || 3;
 const escapeRegex = (input = '') => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const ANSWER_ALIASES = ['answer', 'redactedAnswer', 'response'];
 const WORKFLOW_ALIASES = {
-    DefaultGraph: 'GenericWorkflowGraph'
+    DefaultGraph: DEFAULT_WORKFLOW
 };
 const CHAT_ID_ALIASES = ['chatid'];
 const SOURCE_CHAT_ID_ALIASES = ['chatid'];

--- a/services/experimental/__tests__/BatchDefaultWorkflow.test.js
+++ b/services/experimental/__tests__/BatchDefaultWorkflow.test.js
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ExperimentalBatchService from '../ExperimentalBatchService.js';
+import { ExperimentalBatch } from '../../../models/experimentalBatch.js';
+import { ExperimentalBatchItem } from '../../../models/experimentalBatchItem.js';
+import { getGraphApp, listGraphs } from '../../../agents/graphs/registry.js';
+import { DEFAULT_WORKFLOW } from '../../../src/config/workflows.js';
+
+vi.mock('../../../models/experimentalBatch.js', () => ({
+  ExperimentalBatch: { findById: vi.fn() },
+}));
+
+vi.mock('../../../models/experimentalBatchItem.js', () => ({
+  ExperimentalBatchItem: {
+    findById: vi.fn(),
+    findOne: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    updateOne: vi.fn(),
+  },
+}));
+
+vi.mock('../ExperimentalQueueService.js', () => ({
+  default: { enqueue: vi.fn(), registerProcessor: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock('../ExperimentalAnalyzerRegistry.js', () => ({
+  default: { get: vi.fn(), initialize: vi.fn().mockResolvedValue() },
+}));
+
+// Keep the real registry (listGraphs) so the test pins the resolved name
+// against graph names that actually exist; only the loader is stubbed.
+vi.mock('../../../agents/graphs/registry.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  getGraphApp: vi.fn(),
+}));
+
+vi.mock('../../../agents/graphs/requestContext.js', () => ({
+  graphRequestContext: { run: vi.fn((store, callback) => callback()) },
+}));
+
+const mockStream = {
+  async *[Symbol.asyncIterator]() {
+    yield { result: { answer: 'It is 4' } };
+  },
+};
+
+function mockBatchAndItem({ workflow } = {}) {
+  const batch = {
+    _id: 'batch-id',
+    status: 'queued',
+    type: 'batch',
+    createdBy: null,
+    config: { pageLanguage: 'en', aiProvider: 'azure', ...(workflow === undefined ? {} : { workflow }) },
+  };
+  const item = {
+    _id: 'item-id',
+    retryCount: 1,
+    rowIndex: 1,
+    question: 'What is 2+2?',
+    status: 'processing',
+    save: vi.fn().mockResolvedValue(undefined),
+    markModified: vi.fn(),
+  };
+  ExperimentalBatch.findById.mockResolvedValue(batch);
+  ExperimentalBatchItem.findOneAndUpdate.mockResolvedValue(item);
+  ExperimentalBatchItem.findOne.mockReturnValue({ sort: vi.fn().mockResolvedValue(null) });
+  return { batch, item };
+}
+
+describe('batch default workflow resolution (issue #1792)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getGraphApp.mockResolvedValue({ stream: vi.fn().mockResolvedValue(mockStream) });
+  });
+
+  it("resolves the legacy 'DefaultGraph' alias to a graph that exists in the registry", async () => {
+    mockBatchAndItem({ workflow: 'DefaultGraph' });
+
+    const result = await ExperimentalBatchService._processItem('batch-id', 'item-id');
+
+    expect(getGraphApp).toHaveBeenCalledWith(DEFAULT_WORKFLOW);
+    expect(listGraphs()).toContain(DEFAULT_WORKFLOW);
+    expect(result.status).toBe('completed');
+  });
+
+  it('falls back to a registered graph when config.workflow is missing', async () => {
+    mockBatchAndItem();
+
+    const result = await ExperimentalBatchService._processItem('batch-id', 'item-id');
+
+    expect(getGraphApp).toHaveBeenCalledWith(DEFAULT_WORKFLOW);
+    expect(listGraphs()).toContain(DEFAULT_WORKFLOW);
+    expect(result.status).toBe('completed');
+  });
+});

--- a/services/experimental/__tests__/ExperimentalBatchService.test.js
+++ b/services/experimental/__tests__/ExperimentalBatchService.test.js
@@ -9,6 +9,7 @@ import ExperimentalQueueService from '../ExperimentalQueueService.js';
 import ExperimentalAnalyzerRegistry from '../ExperimentalAnalyzerRegistry.js';
 import { getGraphApp } from '../../../agents/graphs/registry.js';
 import { graphRequestContext } from '../../../agents/graphs/requestContext.js';
+import { DEFAULT_WORKFLOW, WORKFLOW_VALUES } from '../../../src/config/workflows.js';
 
 // Mock dependencies
 vi.mock('../ExperimentalQueueService.js', () => ({
@@ -734,7 +735,13 @@ describe('ExperimentalBatchService', () => {
 
             await ExperimentalBatchService._processItem(batch._id, item._id);
 
-            expect(getGraphApp).toHaveBeenCalledWith('GenericWorkflowGraph');
+            // The legacy 'DefaultGraph' alias must resolve to the shared
+            // default workflow — a name that actually exists in the graph
+            // registry (GenericWorkflowGraph was removed in May 2026, so
+            // pinning it here meant every default-workflow batch item failed
+            // with 'Graph GenericWorkflowGraph not found').
+            expect(getGraphApp).toHaveBeenCalledWith(DEFAULT_WORKFLOW);
+            expect(WORKFLOW_VALUES).toContain(DEFAULT_WORKFLOW);
             runSpy.mockRestore();
         });
 


### PR DESCRIPTION
Fixes #1792.

The DefaultGraph alias still pointed at GenericWorkflowGraph, which left the registry in May 2026. Any batch created without an explicit config.workflow failed item by item with 'Graph GenericWorkflowGraph not found'.

The alias now points at DEFAULT_WORKFLOW from src/config/workflows.js, the same single source of truth live chat uses. Batches that stored the legacy 'DefaultGraph' value keep resolving.

Tests: added services/experimental/__tests__/BatchDefaultWorkflow.test.js (alias and missing-workflow cases, asserting the resolved name against the real registry listing), and updated the pinning assertion in ExperimentalBatchService.test.js to the shared constant. New tests failed before the fix, pass after. Ran the neighboring experimental unit suites green.

Note: the DB-backed ExperimentalBatchService.test.js could not run in this sandbox (no MongoDB available), so that file got a syntax check plus review of the one-line assertion swap only.