### PR TITLE
fix: compare conversation history HMACs in constant time

### DIFF
--- a/services/ConversationIntegrityService.js
+++ b/services/ConversationIntegrityService.js
@@ -159,7 +159,15 @@ class ConversationIntegrityService {
             // eslint-disable-next-line no-console
             console.log('[ConversationIntegrityService] verifyHistory:', { signature, expected, match: signature === expected });
         }
-        return signature === expected;
+        // Constant-time comparison: a plain === leaks how many leading
+        // characters matched through timing, letting an attacker forge the
+        // HMAC byte by byte. timingSafeEqual throws on length mismatch, so
+        // unequal lengths are rejected first (a client-supplied signature can
+        // be any length).
+        const provided = Buffer.from(String(signature), 'utf8');
+        const wanted = Buffer.from(expected, 'utf8');
+        if (provided.length !== wanted.length) return false;
+        return crypto.timingSafeEqual(provided, wanted);
     }
 
     /**

--- a/services/__tests__/ConversationIntegrityService.test.js
+++ b/services/__tests__/ConversationIntegrityService.test.js
@@ -1,5 +1,6 @@
 import ConversationIntegrityService from '../ConversationIntegrityService.js';
 import { describe, it, expect, vi } from 'vitest';
+import crypto from 'crypto';
 
 describe('ConversationIntegrityService', () => {
     const mockHistory = [
@@ -96,6 +97,23 @@ describe('ConversationIntegrityService', () => {
             ];
             const isValid = ConversationIntegrityService.verifyHistory(tamperedHistory, signature);
             expect(isValid).toBe(false);
+        });
+
+        it('should compare signatures in constant time', () => {
+            const signature = ConversationIntegrityService.calculateSignature(mockHistory);
+            const spy = vi.spyOn(crypto, 'timingSafeEqual');
+            try {
+                expect(ConversationIntegrityService.verifyHistory(mockHistory, signature)).toBe(true);
+                expect(spy).toHaveBeenCalled();
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it('should return false (not throw) for a different-length signature', () => {
+            const signature = ConversationIntegrityService.calculateSignature(mockHistory);
+            expect(ConversationIntegrityService.verifyHistory(mockHistory, `${signature}00`)).toBe(false);
+            expect(ConversationIntegrityService.verifyHistory(mockHistory, 'short')).toBe(false);
         });
 
         // End-to-end regression for the same bug as above, at the signature


### PR DESCRIPTION
verifyHistory compared the computed and supplied hex digests with ===, which leaks how many leading characters matched through timing. It now uses crypto.timingSafeEqual, with a length check first since that throws on mismatched lengths (a client-supplied signature can be any length).

Return contract is unchanged (boolean), and the only caller (verifySignedPrefix via middleware/chat-session.js) passes strings through as before.

Tests: added a constant-time assertion (spies on timingSafeEqual) plus a different-length-signature case to ConversationIntegrityService.test.js. The new assertion failed before the fix; all 13 tests pass after.