### PR TITLE
Isolate bidi direction in chat transcript bubbles

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -876,7 +876,7 @@ const ChatAppContainer = ({ lang = 'en', chatId, readOnly = false, initialMessag
             (sentence) => typeof sentence === 'string' && sentence.trim()
           );
           return sentences.map((sentence, sentenceIndex) => (
-            <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence" lang={answerLang}>
+            <p key={`${messageId}-p${index}-s${sentenceIndex}`} className="ai-sentence" lang={answerLang} dir="auto">
               {decodeHTMLEntities(sentence)}
             </p>
           ));

--- a/src/components/chat/ChatInterface.js
+++ b/src/components/chat/ChatInterface.js
@@ -678,6 +678,12 @@ const ChatInterface = ({
                   // differs from the collapse-to-English rule used in the
                   // eval/dashboard tools.
                   lang={toLangAttr(message.questionLanguage)}
+                  // dir="auto" (WCAG bidi): the question is free-typed text
+                  // that can mix RTL scripts (an Arabic/Persian name or
+                  // phrase) into LTR text - the paragraph takes its base
+                  // direction from its own first strong character so trailing
+                  // punctuation and numbers stay on the right side.
+                  dir="auto"
                 >
                   {message.text}
                 </p>

--- a/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
+++ b/src/components/chat/__tests__/ChatAppContainer.formatAIResponse.test.js
@@ -99,3 +99,57 @@ describe('ChatAppContainer - formatAIResponse blank-sentence filtering', () => {
         expect(disclaimer.getAttribute('lang')).toBe('fr');
     });
 });
+
+describe('ChatAppContainer - formatAIResponse bidi isolation', () => {
+    afterEach(() => {
+        cleanup();
+        capturedFormatAIResponse = undefined;
+    });
+
+    it('marks each answer sentence dir="auto" so an RTL name or phrase keeps its own base direction', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        expect(capturedFormatAIResponse).toBeInstanceOf(Function);
+
+        const message = {
+            id: 'm-bidi-1',
+            interaction: {
+                answer: {
+                    paragraphs: ['<s-1>Hello أحمد, your file number is 12345.</s-1>'],
+                    questionLanguage: 'eng',
+                },
+            },
+        };
+
+        const { container } = render(<div>{capturedFormatAIResponse('openai', message)}</div>);
+
+        const sentence = container.querySelector('p.ai-sentence');
+        expect(sentence.textContent).toBe('Hello أحمد, your file number is 12345.');
+        expect(sentence.getAttribute('dir')).toBe('auto');
+        expect(sentence.getAttribute('lang')).toBe('en');
+    });
+
+    it('keeps dir="auto" on a fully RTL answer without changing the tagged answer language', async () => {
+        vi.mocked(usePageContext).mockReturnValue({ url: '', department: '' });
+        render(<ChatAppContainer lang="en" />);
+
+        expect(capturedFormatAIResponse).toBeInstanceOf(Function);
+
+        const message = {
+            id: 'm-bidi-2',
+            interaction: {
+                answer: {
+                    paragraphs: ['<s-1>نعم، يمكنك التجديد عبر الإنترنت.</s-1>'],
+                    questionLanguage: 'ara',
+                },
+            },
+        };
+
+        const { container } = render(<div>{capturedFormatAIResponse('openai', message)}</div>);
+
+        const sentence = container.querySelector('p.ai-sentence');
+        expect(sentence.getAttribute('dir')).toBe('auto');
+        expect(sentence.getAttribute('lang')).toBe('ar');
+    });
+});

--- a/src/components/chat/__tests__/ChatInterface.bidi.test.js
+++ b/src/components/chat/__tests__/ChatInterface.bidi.test.js
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import ChatInterface from '../ChatInterface';
+
+vi.mock('../../../hooks/useTranslations.js', () => ({
+  useTranslations: () => ({
+    t: (key) => key,
+  }),
+}));
+
+const mockUseHasAnyRole = vi.fn(() => false);
+vi.mock('../../RoleBasedUI.js', () => ({
+  useHasAnyRole: (...args) => mockUseHasAnyRole(...args),
+  RoleBasedContent: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseProps = {
+  inputText: '',
+  isLoading: false,
+  textareaKey: 'test',
+  handleInputChange: vi.fn(),
+  handleSendMessage: vi.fn(),
+  handleReload: vi.fn(),
+  handleAIToggle: vi.fn(),
+  workflowSelection: '',
+  handleWorkflowChange: vi.fn(),
+  handleReferringUrlChange: vi.fn(),
+  formatAIResponse: () => null,
+  modelSelection: '',
+  selectedSearch: '',
+  referringUrl: '',
+  chatCreatedAt: null,
+  turnCount: 1,
+  showFeedback: false,
+  displayStatus: '',
+  currentDepartment: '',
+  currentTopic: '',
+  MAX_CONVERSATION_TURNS: 10,
+  t: (key) => key,
+  lang: 'en',
+  extractSentences: (text) => [text],
+  chatId: 'chat-1',
+  readOnly: false,
+  userLeftChatRef: { current: true },
+};
+
+describe('ChatInterface - user question bidi isolation', () => {
+  it('marks the user question paragraph dir="auto" so an RTL name or phrase keeps its own base direction', () => {
+    const messages = [
+      {
+        id: 'u1',
+        sender: 'user',
+        text: 'Hello أحمد, your total is 45$.',
+        questionLanguage: 'eng',
+      },
+    ];
+
+    const { container } = render(<ChatInterface {...baseProps} messages={messages} />);
+
+    const question = container.querySelector('.user-message-box p');
+    expect(question).not.toBeNull();
+    expect(question.textContent).toBe('Hello أحمد, your total is 45$.');
+    expect(question.getAttribute('dir')).toBe('auto');
+    expect(question.getAttribute('lang')).toBe('en');
+  });
+
+  it('keeps dir="auto" on a fully RTL question without changing the tagged question language', () => {
+    const messages = [
+      {
+        id: 'u2',
+        sender: 'user',
+        text: 'هل يمكنني التجديد عبر الإنترنت؟',
+        questionLanguage: 'ara',
+      },
+    ];
+
+    const { container } = render(<ChatInterface {...baseProps} messages={messages} />);
+
+    const question = container.querySelector('.user-message-box p');
+    expect(question).not.toBeNull();
+    expect(question.getAttribute('dir')).toBe('auto');
+    expect(question.getAttribute('lang')).toBe('ar');
+  });
+});

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -137,6 +137,17 @@
   line-height: 1.6em;
 }
 
+/* Bidi isolation for user-typed chat content (WCAG 2.2 success criterion
+   1.3.2, language of parts direction): each bubble paragraph carries
+   dir="auto" so it takes its base direction from its own first strong
+   character - an Arabic/Persian name or phrase inside LTR text (or vice
+   versa) keeps its punctuation and numbers on the right side. isolate
+   keeps that direction from leaking into the surrounding LTR chrome. */
+.user-message-box p,
+.ai-sentence {
+  unicode-bidi: isolate;
+}
+
 .citation-divider {
   border: none;
   border-top: 3px solid #d9d9d9;
@@ -170,7 +181,9 @@
 
 .new-tab-link-icon {
   display: inline-block;
-  margin-left: 4px;
+  /* Logical property so the icon gap flips with the bubble's own base
+     direction (dir="auto") instead of staying glued to the left. */
+  margin-inline-start: 4px;
 }
 
 /* Only apply mobile ellipsis styles to long URLs */


### PR DESCRIPTION
Chat questions and answers can mix RTL scripts (an Arabic or Persian name or phrase) into LTR text. Without a base direction of their own, trailing punctuation and numbers next to the RTL segment render on the wrong side.

This change gives each transcript paragraph its own base direction:

- User question and AI answer paragraphs carry dir="auto", so each one follows its own first strong character. The existing lang attributes are untouched.
- A small CSS rule adds bidi isolation to those paragraphs so the direction does not leak into the surrounding LTR layout.
- The citation new-tab icon gap uses a logical property so it follows the bubble direction. Renders identically in LTR.

No new locale keys. Tests cover mixed-direction and fully RTL content on both bubbles, plus the existing chat suite (14 files, 82 tests) passes.